### PR TITLE
Reworked approach to tracking and displaying reader progress information

### DIFF
--- a/Simplified/Localizable.strings
+++ b/Simplified/Localizable.strings
@@ -99,6 +99,7 @@
 
 "ReaderViewControllerCorruptTitle" = "Could Not Display Book";
 "ReaderViewControllerCorruptMessage" = "This book is corrupt and cannot be read.";
+"ReaderViewControllerCurrentChapter" = "Current Chapter";
 "Book" = "Book";
 "leftin" = "left in";
 "ReaderSettings" = "Reader settings";

--- a/Simplified/NYPLReaderRenderer.h
+++ b/Simplified/NYPLReaderRenderer.h
@@ -13,20 +13,25 @@ typedef NS_ENUM(NSInteger, NYPLReaderRendererGesture) {
 
 @property (nonatomic, readonly) BOOL bookIsCorrupt;
 @property (nonatomic, readonly) BOOL loaded;
-@property (nonatomic, readonly) NSArray *TOCElements;
+@property (nonatomic, readonly, nonnull) NSArray *TOCElements;
 
 // This must be called with a reader-appropriate underlying value. Readers implementing this should
 // throw |NSInvalidArgumentException| in the event it is not.
-- (void)openOpaqueLocation:(NYPLReaderRendererOpaqueLocation *)opaqueLocation;
+- (void)openOpaqueLocation:(nonnull NYPLReaderRendererOpaqueLocation *)opaqueLocation;
 
 @end
 
 @protocol NYPLReaderRendererDelegate
 
-- (void)renderer:(id<NYPLReaderRenderer>)renderer
-didEncounterCorruptionForBook:(NYPLBook *)book;
+- (void)renderer:(nonnull id<NYPLReaderRenderer>)renderer
+didEncounterCorruptionForBook:(nonnull NYPLBook *)book;
 
-- (void)rendererDidFinishLoading:(id<NYPLReaderRenderer>)renderer;
+- (void)rendererDidFinishLoading:(nonnull id<NYPLReaderRenderer>)renderer;
 
--(void) didUpdateProgressSpineItemPercentage: (NSNumber *)spineItemPercentage bookPercentage: (NSNumber *) bookPercentage pageIndex:(NSNumber *)pageIndex pageCount:(NSNumber *)pageCount withCurrentSpineItemDetails: (NSDictionary *) currentSpineItemDetails completed:(BOOL)completed;
+- (void)renderer:(nonnull id<NYPLReaderRenderer>)renderer
+didUpdateProgressWithinBook:(float)progressWithinBook
+       pageIndex:(NSUInteger)pageIndex
+       pageCount:(NSUInteger)pageCount
+  spineItemTitle:(nullable NSString *)spineItemTitle;
+
 @end

--- a/Simplified/NYPLReaderViewController.m
+++ b/Simplified/NYPLReaderViewController.m
@@ -366,21 +366,6 @@ didEncounterCorruptionForBook:(__attribute__((unused)) NYPLBook *)book
   [self.bottomView addConstraint:constraintPL4];
 }
 
--(void) didUpdateProgressSpineItemPercentage: (NSNumber *)spineItemPercentage bookPercentage: (NSNumber *) bookPercentage pageIndex:(NSNumber *)pageIndex pageCount:(NSNumber *)pageCount withCurrentSpineItemDetails: (NSDictionary *) currentSpineItemDetails completed:(BOOL)completed {
-  
-  if (UIAccessibilityIsVoiceOverRunning()) {
-    UIAccessibilityPostNotification(UIAccessibilityPageScrolledNotification, [NSString stringWithFormat:NSLocalizedString(@"Page %d of %d", nil), pageIndex.integerValue+1, pageCount.integerValue]);
-  }
-  
-  [self.bottomViewProgressView setProgress:bookPercentage.floatValue / 100 animated:YES];  
-  NSString *title = [currentSpineItemDetails objectForKey:@"tocElementTitle"];
-  
-//  NSString *bookLocalized = NSLocalizedString(@"Book", nil);
-  
-  self.bottomViewProgressLabel.text = [NSString stringWithFormat:@"Page %ld of %ld (%@)", pageIndex.integerValue + 1, pageCount.integerValue, title];
-  [self.bottomViewProgressLabel needsUpdateConstraints];
-}
-
 - (BOOL)prefersStatusBarHidden
 {
   return self.isStatusBarHidden;
@@ -492,6 +477,33 @@ didEncounterCorruptionForBook:(__attribute__((unused)) NYPLBook *)book
   }
   [self.navigationController popViewControllerAnimated:YES];
   return YES;
+}
+
+#pragma mark NYPLReaderReadiumDelegate
+
+- (void)
+renderer:(__unused id<NYPLReaderRenderer>)renderer
+didUpdateProgressWithinBook:(float)progressWithinBook
+pageIndex:(NSUInteger const)pageIndex
+pageCount:(NSUInteger const)pageCount
+spineItemTitle:(NSString *const)title
+{
+  if (UIAccessibilityIsVoiceOverRunning()) {
+    UIAccessibilityPostNotification(UIAccessibilityPageScrolledNotification,
+                                    [NSString stringWithFormat:NSLocalizedString(@"Page %d of %d", nil),
+                                     pageIndex + 1,
+                                     pageCount]);
+  }
+  
+  [self.bottomViewProgressView setProgress:progressWithinBook animated:NO];
+  
+  self.bottomViewProgressLabel.text =
+    [NSString stringWithFormat:@"Page %ld of %ld (%@)",
+     pageIndex + 1,
+     pageCount,
+     title ? title : NSLocalizedString(@"ReaderViewControllerCurrentChapter", nil)];
+  
+  [self.bottomViewProgressLabel needsUpdateConstraints];
 }
 
 #pragma mark UIPopoverControllerDelegate


### PR DESCRIPTION
Fixes #346.

@aferditamuriqi 

This fixes an issue where the math that calculated the current progress in the book would occasionally crash. In addition, I stripped out all of the silly overuse of `NSNumber*` classes, simplified the interface for `NYPLReaderRendererDelegate`, and added a fallback chapter title in case one was not provided by the EPUB.
