### PR TITLE
Improve layout of metadata in detail views

### DIFF
--- a/Simplified/NYPLBookDetailView.m
+++ b/Simplified/NYPLBookDetailView.m
@@ -262,7 +262,12 @@ static NSString *detailTemplate = nil;
     CGFloat const x = CGRectGetMinX(self.titleLabel.frame);
     CGFloat const w = CGRectGetWidth(self.subtitleLabel.frame);
     CGFloat const h = [self.categoriesLabel sizeThatFits:CGSizeMake(w, CGFLOAT_MAX)].height;
-    CGFloat const y = CGRectGetMaxY(self.coverImageView.frame) - h;
+    // FIXME: This detail view is getting way too crowded with metadata information,
+    // and the awkward layout here is a symptom of that. We should rethink the whole
+    // design of the top portion of detail views at some point.
+    //
+    // '3' is a magic value that provides mostly consistent baseline spacing.
+    CGFloat const y = CGRectGetMaxY(self.coverImageView.frame) - h + 3;
     self.categoriesLabel.frame = CGRectMake(x, y, w, h);
   }
   {


### PR DESCRIPTION
Fixes #370.

@aferditamuriqi 

See #370 first for the main purpose of this pull request.

The additional baseline spacing adjustment just ensures that there is equal spacing between subtitle, authors, and publication labels. This is a bit of a hack because the first three labels (title, subtitle, and authors) are laid out from the top going down and the other three are laid out from the bottom going up. The three pixel adjustment just ensures they meet in the correct place.

Really though, the layout is just way too crowded. The non-essential metadata like publisher and publication date should be moved somewhere else entirely. As such, I am not investing much time into cleaning this up properly right now: We'll redo it at some point in the future.
