### PR TITLE
Improved accuracy of time reporting for days left

### DIFF
--- a/Simplified/NSDate+NYPLDateAdditions.m
+++ b/Simplified/NSDate+NYPLDateAdditions.m
@@ -40,12 +40,14 @@
                                           } appendPlural:@""];
 }
 
+// FIXME: These strings need to be localized and pluralization needs to be handled properly.
 - (NSString *)longTimeUntilString
 {
   return [self timeUntilStringWithNames:@{@"year": @" year",
                                           @"month": @" month",
                                           @"week": @" week",
-                                          @"day": @" day"
+                                          @"day": @" day",
+                                          @"hour": @" hour"
                                           } appendPlural:@"s"];
 }
 
@@ -55,19 +57,26 @@
   seconds = seconds > 0 ? seconds : 0;
   long minutes = seconds / 60;
   long hours = minutes / 60;
-  long days = ceil((float)hours / 24.f);
+  long days = hours / 24;
   long weeks = days / 7;
   long months = days / 30;
   long years = days / 365;
   
-  if(years > 0) {
-    return [NSString stringWithFormat:@"%ld%@%@", years, names[@"year"], years > 1 ? appendPlural : @""];
-  } else if(months > 1) {
-    return [NSString stringWithFormat:@"%ld%@%@", months, names[@"month"], months > 1 ? appendPlural : @""];
-  } else if(weeks > 0) {
-    return [NSString stringWithFormat:@"%ld%@%@", weeks, names[@"week"], weeks > 1 ? appendPlural : @""];
+  if(years >= 4) {
+    // Switch to years after ~48 months.
+    return [NSString stringWithFormat:@"%ld%@%@", years, names[@"year"], years != 1 ? appendPlural : @""];
+  } else if(months >= 4) {
+    // Switch to months after ~16 weeks.
+    return [NSString stringWithFormat:@"%ld%@%@", months, names[@"month"], months != 1 ? appendPlural : @""];
+  } else if(weeks >= 4) {
+    // Switch to weeks after 28 days.
+    return [NSString stringWithFormat:@"%ld%@%@", weeks, names[@"week"], weeks != 1 ? appendPlural : @""];
+  } else if(days >= 2) {
+    // Switch to days after 48 hours.
+    return [NSString stringWithFormat:@"%ld%@%@", days, names[@"day"], days != 1 ? appendPlural : @""];
   } else {
-    return [NSString stringWithFormat:@"%ld%@%@", days, names[@"day"], days > 1 ? appendPlural : @""];
+    // Use hours.
+    return [NSString stringWithFormat:@"%ld%@%@", hours, names[@"hour"], hours != 1 ? appendPlural : @""];
   }
 }
 


### PR DESCRIPTION
Fixes #384.

@aferditamuriqi 
- The time left will now be shown in hours if fewer than two days remain.
- Less than one hour remaining will be shown as "0h" and "0 hours".
- Coarser levels of granularity are used more sparingly than before. See the code comments.
- A FIXME was added because localization is needed. This issue has been captured in #386.
