### PR TITLE
Account switching #527

### DIFF
--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -193,7 +193,9 @@
        {
          [[NYPLAccount sharedAccount:account.id] setUserID:userID];
          [[NYPLAccount sharedAccount:account.id] setDeviceID:deviceID];
-         [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:nil];
+         [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL __unused success) {
+           [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
+         }];
        }
        
      }];

--- a/Simplified/NYPLHoldsNavigationController.m
+++ b/Simplified/NYPLHoldsNavigationController.m
@@ -76,7 +76,7 @@
 #if defined(FEATURE_DRM_CONNECTOR)
       if([NYPLADEPT sharedInstance].workflowsInProgress) {
         [self presentViewController:[NYPLAlertController
-                                     alertWithTitle:@"SettingsAccountViewControllerCannotLogOutTitle"
+                                     alertWithTitle:@"PleaseWait"
                                      message:@"SettingsAccountViewControllerCannotLogOutMessage"]
                            animated:YES
                          completion:nil];
@@ -119,15 +119,10 @@
   [[NYPLSettings sharedSettings] setAccountMainFeedURL:[NSURL URLWithString:account.catalogUrl]];
   [UIApplication sharedApplication].delegate.window.tintColor = [NYPLConfiguration mainColor];
   
-  [[NYPLBookRegistry sharedRegistry] justLoad];
-
   NYPLCatalogNavigationController * catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
-  
   [catalog reloadSelectedLibraryAccount];
   
-  
   NYPLHoldsViewController *viewController = (NYPLHoldsViewController *)self.visibleViewController;
-  
   viewController.navigationItem.title = [[NYPLSettings sharedSettings] currentAccount].name;
   viewController.navigationItem.leftBarButtonItem.enabled = NO;
 

--- a/Simplified/NYPLHoldsNavigationController.m
+++ b/Simplified/NYPLHoldsNavigationController.m
@@ -77,7 +77,7 @@
       if([NYPLADEPT sharedInstance].workflowsInProgress) {
         [self presentViewController:[NYPLAlertController
                                      alertWithTitle:@"PleaseWait"
-                                     message:@"SettingsAccountViewControllerCannotLogOutMessage"]
+                                     message:@"PleaseWaitMessage"]
                            animated:YES
                          completion:nil];
       } else {
@@ -119,6 +119,8 @@
   [[NYPLSettings sharedSettings] setAccountMainFeedURL:[NSURL URLWithString:account.catalogUrl]];
   [UIApplication sharedApplication].delegate.window.tintColor = [NYPLConfiguration mainColor];
   
+  [[NYPLBookRegistry sharedRegistry] justLoad];
+
   NYPLCatalogNavigationController * catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
   [catalog reloadSelectedLibraryAccount];
   

--- a/Simplified/NYPLMyBooksNavigationController.m
+++ b/Simplified/NYPLMyBooksNavigationController.m
@@ -79,7 +79,7 @@
 #if defined(FEATURE_DRM_CONNECTOR)
       if([NYPLADEPT sharedInstance].workflowsInProgress) {
         [self presentViewController:[NYPLAlertController
-                                     alertWithTitle:@"SettingsAccountViewControllerCannotLogOutTitle"
+                                     alertWithTitle:@"PleaseWait"
                                      message:@"SettingsAccountViewControllerCannotLogOutMessage"]
                            animated:YES
                          completion:nil];
@@ -124,17 +124,11 @@
   
   [[NYPLSettings sharedSettings] setAccountMainFeedURL:[NSURL URLWithString:account.catalogUrl]];
   [UIApplication sharedApplication].delegate.window.tintColor = [NYPLConfiguration mainColor];
-  
-  [[NYPLBookRegistry sharedRegistry] justLoad];
-
-  
+   
   NYPLCatalogNavigationController * catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
-  
   [catalog reloadSelectedLibraryAccount];
   
-  
   NYPLMyBooksViewController *viewController = (NYPLMyBooksViewController *)self.visibleViewController;
-  
   viewController.navigationItem.title =  [[NYPLSettings sharedSettings] currentAccount].name;
   viewController.navigationItem.leftBarButtonItem.enabled = NO;
   

--- a/Simplified/NYPLMyBooksNavigationController.m
+++ b/Simplified/NYPLMyBooksNavigationController.m
@@ -80,7 +80,7 @@
       if([NYPLADEPT sharedInstance].workflowsInProgress) {
         [self presentViewController:[NYPLAlertController
                                      alertWithTitle:@"PleaseWait"
-                                     message:@"SettingsAccountViewControllerCannotLogOutMessage"]
+                                     message:@"PleaseWaitMessage"]
                            animated:YES
                          completion:nil];
       } else {
@@ -124,7 +124,9 @@
   
   [[NYPLSettings sharedSettings] setAccountMainFeedURL:[NSURL URLWithString:account.catalogUrl]];
   [UIApplication sharedApplication].delegate.window.tintColor = [NYPLConfiguration mainColor];
-   
+  
+  [[NYPLBookRegistry sharedRegistry] justLoad];
+  
   NYPLCatalogNavigationController * catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
   [catalog reloadSelectedLibraryAccount];
   

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -50,6 +50,7 @@
 "PDFNotSupportedDescriptionFormat" = "%@ is an Adobe PDF, which is not supported.";
 "PickYourLibrary" = "Pick Your Library";
 "PIN" = "PIN";
+"PleaseWait" = "Please Wait";
 "PrivacyPolicy" = "Privacy Policy";
 "Published" = "Published";
 "Publisher" = "Publisher";

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -51,6 +51,7 @@
 "PickYourLibrary" = "Pick Your Library";
 "PIN" = "PIN";
 "PleaseWait" = "Please Wait";
+"PleaseWaitMessage" = "Please wait a moment before switching library accounts.";
 "PrivacyPolicy" = "Privacy Policy";
 "Published" = "Published";
 "Publisher" = "Publisher";


### PR DESCRIPTION
disable/enable of Library Switcher Icon improved in My Books and Holds:

- Added completion block to "sync" in catalog nav controller
- No longer relying on bookRegistryDidChange notification. that would fire multiple times and was re--enabling the icon too soon