### PR TITLE
Use OAuth for Desk Support

### DIFF
--- a/Simplified/NYPLConfiguration.h
+++ b/Simplified/NYPLConfiguration.h
@@ -8,17 +8,11 @@
 + (id)new NS_UNAVAILABLE;
 - (id)init NS_UNAVAILABLE;
 
-+ (BOOL) heapEnabled;
-
 + (BOOL) bugsnagEnabled;
-
-+ (NSString *)heapID;
 
 + (NSString *)bugsnagID;
 
 + (BOOL)cardCreationEnabled;
-
-//+ (NSURL *)circulationURL;
 
 // This can be overriden by setting |customMainFeedURL| in NYPLSettings.
 + (NSURL *)mainFeedURL;

--- a/Simplified/NYPLConfiguration.m
+++ b/Simplified/NYPLConfiguration.m
@@ -13,27 +13,19 @@
 #import "SimplyE-Swift.h"
 #import "NYPLAppDelegate.h"
 
-
-//static NSString *const NYPLCirculationBaseURLProduction = @"https://circulation.librarysimplified.org";
-//static NSString *const NYPLCirculationBaseURLTesting = @"http://qa.circulation.librarysimplified.org/";
-
-static NSString *const heapIDProduction = @"3245728259";
-static NSString *const heapIDDevelopment = @"1848989408";
-
 @implementation NYPLConfiguration
 
 + (void)initialize
 {
   [[HSHelpStack instance] setThemeFrompList:@"HelpStackTheme"];
+    
   HSDeskGear *deskGear = [[HSDeskGear alloc]
                           initWithInstanceBaseUrl:@"https://nypl.desk.com/"
-                          toHelpEmail:@"jamesenglish@nypl.org"
-                          staffLoginEmail:@"jamesenglish@nypl.org"
-                          AndStaffLoginPassword:@"Marin1010!"
-                          andBrand:@"12060"];
+                          token:@""
+                          andBrand:@""];
+    
   HSHelpStack *helpStack = [HSHelpStack instance];
   helpStack.gear = deskGear;
-  
   
   if([NYPLConfiguration bugsnagEnabled]) {
     [Bugsnag startBugsnagWithApiKey:[NYPLConfiguration bugsnagID]];
@@ -49,31 +41,18 @@ static NSString *const heapIDDevelopment = @"1848989408";
 #endif
 }
 
-+ (BOOL) heapEnabled
-{
-  return !TARGET_OS_SIMULATOR;
-}
 
 + (BOOL) bugsnagEnabled
 {
   return !TARGET_OS_SIMULATOR;
 }
 
-+ (NSString *)heapID
-{
-//  return heapIDProduction;
-  return heapIDDevelopment;
-}
 
 + (NSString *) bugsnagID
 {
   return @"76cb0080ae8cc30d903663e10b138381";
 }
 
-//+ (NSURL *)circulationURL
-//{
-//  return [NSURL URLWithString:NYPLCirculationBaseURLProduction];
-//}
 
 + (NSURL *)mainFeedURL
 {
@@ -86,7 +65,6 @@ static NSString *const heapIDDevelopment = @"1848989408";
   if(accountURL) return accountURL;
 
   return nil;
-//  return [self circulationURL];
 }
 
 + (NSURL *)loanURL


### PR DESCRIPTION
Use OAuth for Desk Support. Call the function that uses OAuth to access Desk Support and remove the function call that uses username and password to access Desk.

Part of the fix for PR https://github.com/NYPL-Simplified/helpstack-ios/issues/1 SSO Refactor (for helpstack-ios repo)