### PR TITLE
Changed confusing age verification message.

### DIFF
--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -214,7 +214,7 @@
 
 // NYPLWelcomeScreen
 "WelcomeScreenAgeVerifyTitle" = "Age Verification";
-"WelcomeScreenAgeVerifyMessage" = "You must be 13 years of age or older to download a book from the collection. How old are you?";
+"WelcomeScreenAgeVerifyMessage" = "You must be 13 years of age or older to download some of the books from this collection. How old are you?";
 "WelcomeScreenTitle1" = "Read Books From Your Library";
 "WelcomeScreenSubtitle1" = "Check out books and sync across devices";
 "WelcomeScreenButtonTitle1" = "PICK YOUR LIBRARY";


### PR DESCRIPTION
Changed age verification message to "You must be 13 years of age or older to download some of the books in this collection. How old are you?"  This change is only in the English message.

fixes #541