### PR TITLE
Fix xcodeproj -> project warning in Podfile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-xcodeproj 'Simplified.xcodeproj'
+project 'Simplified.xcodeproj'
 
 # Uncomment this line to define a global platform for your project
 platform :ios, '8.0'


### PR DESCRIPTION
Cocoapods issued the following warning on `pod install`:

    [!] `xcodeproj` was renamed to `project`. Please update your
    Podfile accordingly.

This fix simply implements the above suggestion.

---

If everything looks good, please feel free to merge!