### PR TITLE
Make adobe-rmsdk-build.sh no longer build book2png

### DIFF
--- a/adobe-rmsdk-build.sh
+++ b/adobe-rmsdk-build.sh
@@ -27,15 +27,5 @@ for SDK in ${SDKS[@]}; do
     cp \
       dp/build/xc5/Build/${CONFIGURATION}-${SDK}/libdp-iOS.a \
       lib/ios/${CONFIGURATION}-${SDK}
-    cd "$ADOBE_RMSDK/samples/book2png/build/xc5"
-    xcodebuild \
-      -project book2png.xcodeproj \
-      -configuration ${CONFIGURATION} \
-      -target book2png-iOS \
-      ONLY_ACTIVE_ARCH=NO \
-      ENABLE_BITCODE=NO \
-      ARCHS="${ARCHS}" \
-      -sdk ${SDK} \
-      build
   done
 done


### PR DESCRIPTION
It seems like building book2png was entirely unnecessary. Doing so also occasionally caused problems because it would fail if the right provisioning profile magic was not in place. I tested this fix with @vuinguyen and it allowed her to get her environment set up properly.