### PR TITLE
Make CocoaPods not warn about OTHER_LDFLAGS

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1628,10 +1628,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
-					"-all_load",
-					"-ObjC",
-				);
 				PRODUCT_NAME = SimplyE;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 2.3;
@@ -1673,10 +1669,6 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				OTHER_LDFLAGS = (
-					"-all_load",
-					"-ObjC",
-				);
 				PRODUCT_NAME = SimplyE;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -1707,7 +1699,6 @@
 					"$(PROJECT_DIR)/heap-ios-latest",
 					"$(PROJECT_DIR)/readium-sdk/Platform/Apple/build/Debug-iphoneos",
 				);
-				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -1749,7 +1740,6 @@
 					"$(PROJECT_DIR)/heap-ios-latest",
 					"$(PROJECT_DIR)/readium-sdk/Platform/Apple/build/Debug-iphoneos",
 				);
-				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "9ba5bad4-c0e9-4d22-aae9-4d2e2e60ca6d";


### PR DESCRIPTION
The SimplyE target was explicitly setting `OTHER_LDFLAGS` to `-ObjC` without use of `$(inherited)`. The lack of `$(inherited)` caused CocoaPods to issue the following warnings:

    [!] The `SimplyE [Debug]` target overrides the `OTHER_LDFLAGS` build
    setting defined in `Pods/Target Support
    Files/Pods-SimplyE/Pods-SimplyE.debug.xcconfig'. This can lead to
    problems with the CocoaPods installation
        - Use the `$(inherited)` flag, or
        - Remove the build settings from the target.

    [!] The `SimplyE [Release]` target overrides the `OTHER_LDFLAGS`
    build setting defined in `Pods/Target Support
    Files/Pods-SimplyE/Pods-SimplyE.release.xcconfig'. This can lead to
    problems with the CocoaPods installation
        - Use the `$(inherited)` flag, or
        - Remove the build settings from the target.

Adding `$(inherited)`, however, would break the build because it implied `-all_load` (as that was set project-wide) which in turn would cause problems with the fat binaries supplied by Adobe as part of RMSDK.

I edited "Simplified.xcodeproj/project.pbxproj" and removed the project-wide use of `-all_load`. The use of `-all_load` is no longer necessary: It was only included by old versions of Xcode to work around a bug in `ld` related to static libraries that _only_ contained Objective-C categories (of which we have none anyway). New projects created with Xcode 8 no longer include `-all_load`.

After I removed `-all_load`, I was able to remove the `-ObjC` override for the target and thus silence the warnings. Everything is now building correctly using only the linker flags set by CocoaPods.