### PR TITLE
Cut CHRTextFieldFormatter

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,6 @@ target 'SimplyE' do
 
   pod 'HelpStack', :git => 'https://github.com/NYPL-Simplified/helpstack-ios'
   pod 'Bugsnag', :git => 'https://github.com/bugsnag/bugsnag-cocoa.git'
-  pod 'CHRTextFieldFormatter'
   pod 'NYPLCardCreator', :git => 'https://github.com/NYPL-Simplified/CardCreator-iOS.git'
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,6 @@ PODS:
     - AFNetworking/NSURLSession
   - Bugsnag (5.7.0):
     - KSCrash/RecordingAdvanced (= 1.11.2)
-  - CHRTextFieldFormatter (1.0.1)
   - HelpStack (1.1.2):
     - AFNetworking (~> 2.0)
     - HelpStack/Core (= 1.1.2)
@@ -52,7 +51,6 @@ PODS:
 
 DEPENDENCIES:
   - Bugsnag (from `https://github.com/bugsnag/bugsnag-cocoa.git`)
-  - CHRTextFieldFormatter
   - HelpStack (from `https://github.com/NYPL-Simplified/helpstack-ios`)
   - NYPLCardCreator (from `https://github.com/NYPL-Simplified/CardCreator-iOS.git`)
 
@@ -78,12 +76,11 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
   Bugsnag: d86488d670f91acbce0186e6570e500039676ef0
-  CHRTextFieldFormatter: 13b6449dbd421d97b6e179e50d817165f9feebec
   HelpStack: a9067738597ef81835d84ac8bb75ee346e34f000
   KSCrash: 8acc46aca72b2772d5d1e3cba1da9173db4d705e
   NYPLCardCreator: e0f5034902008b4c8cdfb5edbffa2a51ec0b261d
   PureLayout: 4d550abe49a94f24c2808b9b95db9131685fe4cd
 
-PODFILE CHECKSUM: a016c07d61e4ee09df494a98203049adf735204e
+PODFILE CHECKSUM: c600d7e4dd5c705f6e1ff847a9502a4b50d7202b
 
 COCOAPODS: 1.2.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,89 @@
+PODS:
+  - AFNetworking (2.6.3):
+    - AFNetworking/NSURLConnection (= 2.6.3)
+    - AFNetworking/NSURLSession (= 2.6.3)
+    - AFNetworking/Reachability (= 2.6.3)
+    - AFNetworking/Security (= 2.6.3)
+    - AFNetworking/Serialization (= 2.6.3)
+    - AFNetworking/UIKit (= 2.6.3)
+  - AFNetworking/NSURLConnection (2.6.3):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.6.3):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/Reachability (2.6.3)
+  - AFNetworking/Security (2.6.3)
+  - AFNetworking/Serialization (2.6.3)
+  - AFNetworking/UIKit (2.6.3):
+    - AFNetworking/NSURLConnection
+    - AFNetworking/NSURLSession
+  - Bugsnag (5.7.0):
+    - KSCrash/RecordingAdvanced (= 1.11.2)
+  - CHRTextFieldFormatter (1.0.1)
+  - HelpStack (1.1.2):
+    - AFNetworking (~> 2.0)
+    - HelpStack/Core (= 1.1.2)
+    - HelpStack/Stacks (= 1.1.2)
+    - HelpStack/UI (= 1.1.2)
+    - HelpStack/Util (= 1.1.2)
+  - HelpStack/Core (1.1.2):
+    - AFNetworking (~> 2.0)
+    - HelpStack/Util
+  - HelpStack/Stacks (1.1.2):
+    - AFNetworking (~> 2.0)
+    - HelpStack/Core
+    - HelpStack/Util
+  - HelpStack/UI (1.1.2):
+    - AFNetworking (~> 2.0)
+    - HelpStack/Core
+    - HelpStack/Stacks
+    - HelpStack/Util
+  - HelpStack/Util (1.1.2):
+    - AFNetworking (~> 2.0)
+  - KSCrash/Recording (1.11.2)
+  - KSCrash/RecordingAdvanced (1.11.2):
+    - KSCrash/Recording
+  - NYPLCardCreator (1.0.0):
+    - PureLayout (~> 3.0)
+  - PureLayout (3.0.2)
+
+DEPENDENCIES:
+  - Bugsnag (from `https://github.com/bugsnag/bugsnag-cocoa.git`)
+  - CHRTextFieldFormatter
+  - HelpStack (from `https://github.com/NYPL-Simplified/helpstack-ios`)
+  - NYPLCardCreator (from `https://github.com/NYPL-Simplified/CardCreator-iOS.git`)
+
+EXTERNAL SOURCES:
+  Bugsnag:
+    :git: https://github.com/bugsnag/bugsnag-cocoa.git
+  HelpStack:
+    :git: https://github.com/NYPL-Simplified/helpstack-ios
+  NYPLCardCreator:
+    :git: https://github.com/NYPL-Simplified/CardCreator-iOS.git
+
+CHECKOUT OPTIONS:
+  Bugsnag:
+    :commit: eb5fe14f80fe247b3014e56a8cf8f08f1c873369
+    :git: https://github.com/bugsnag/bugsnag-cocoa.git
+  HelpStack:
+    :commit: 8cdacdd06fb9804e0431cf6a0008835b401314fc
+    :git: https://github.com/NYPL-Simplified/helpstack-ios
+  NYPLCardCreator:
+    :commit: 4f88f487b991ed1a3d20e42ad3d9def71d7b2fd1
+    :git: https://github.com/NYPL-Simplified/CardCreator-iOS.git
+
+SPEC CHECKSUMS:
+  AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
+  Bugsnag: d86488d670f91acbce0186e6570e500039676ef0
+  CHRTextFieldFormatter: 13b6449dbd421d97b6e179e50d817165f9feebec
+  HelpStack: a9067738597ef81835d84ac8bb75ee346e34f000
+  KSCrash: 8acc46aca72b2772d5d1e3cba1da9173db4d705e
+  NYPLCardCreator: e0f5034902008b4c8cdfb5edbffa2a51ec0b261d
+  PureLayout: 4d550abe49a94f24c2808b9b95db9131685fe4cd
+
+PODFILE CHECKSUM: a016c07d61e4ee09df494a98203049adf735204e
+
+COCOAPODS: 1.2.0

--- a/Simplified/software-licenses.html
+++ b/Simplified/software-licenses.html
@@ -73,23 +73,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.</p>
-<h2 id="chrtextfieldformatter">CHRTextFieldFormatter</h2>
-<p>Copyright (c) 2015 Nesterenko Dmitry</p>
-<p>Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:</p>
-<p>The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.</p>
-<p>THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</p>
 <h2 id="helpstack">HelpStack</h2>
 <p>Copyright (c) 2014 HelpStack (<a href="http://helpstack.io">http://helpstack.io</a>)</p>
 <p>Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
## Pull Request Dependency

This patch makes changes to "Podfile.lock" which is not currently in `master`.

 **You must merge #573 (which adds "Podfile.lock") before merging this pull request**.

---

This was used for a version of card creator that no longer exists. I removed it as a dependency and removed the license text.