### PR TITLE
added old keys to text size in reader settings to prevent crash

### DIFF
--- a/Simplified/NYPLReaderSettings.m
+++ b/Simplified/NYPLReaderSettings.m
@@ -162,11 +162,15 @@ NSString * mediaOverlaysEnableClickToString(BOOL mediaClickOverlayAlwaysEnable)
 
 NYPLReaderSettingsFontSize fontSizeFromString(NSString *const string)
 {
+  // Had to re-add older keys 'larger' and 'largest' to save from a
+  // crash for versions before 2.0.0 (1087)
   NSNumber *const fontSizeNumber = @{@"smallest": @(NYPLReaderSettingsFontSizeSmallest),
                                      @"smaller": @(NYPLReaderSettingsFontSizeSmaller),
                                      @"small": @(NYPLReaderSettingsFontSizeSmall),
                                      @"normal": @(NYPLReaderSettingsFontSizeNormal),
                                      @"large": @(NYPLReaderSettingsFontSizeLarge),
+                                     @"larger": @(NYPLReaderSettingsFontSizeXLarge),
+                                     @"largest": @(NYPLReaderSettingsFontSizeXXLarge),
                                      @"xlarge": @(NYPLReaderSettingsFontSizeXLarge),
                                      @"xxlarge": @(NYPLReaderSettingsFontSizeXXLarge),
                                      @"xxxlarge": @(NYPLReaderSettingsFontSizeXXXLarge)}[string];


### PR DESCRIPTION
fixes crash by re-adding old keys from text-size in reader settings