### PR TITLE
Fix leaking of NYPLReaderReadiumView

### DIFF
--- a/Simplified/NYPLReaderReadiumView.m
+++ b/Simplified/NYPLReaderReadiumView.m
@@ -893,8 +893,14 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
   dispatch_time_t const dispatchTime =
     dispatch_time(DISPATCH_TIME_NOW, (int64_t)(readyStateCheckIntervalInSeconds * NSEC_PER_SEC));
   
+  // A weak reference is needed here so that the main queue does not retain
+  // `NYPLReaderReadiumView` indefinitely. After the reference to `weakSelf`
+  // becomes nil, the block passed to `dispatch_after` will be called one
+  // final time and will not be rescheduled (because `pollReadyState` will
+  // be sent to nil).
+  __weak NYPLReaderReadiumView *const weakSelf = self;
   dispatch_after(dispatchTime, dispatch_get_main_queue(), ^{
-    [self pollReadyState];
+    [weakSelf pollReadyState];
   });
 }
 

--- a/Simplified/NYPLReaderSettings.h
+++ b/Simplified/NYPLReaderSettings.h
@@ -63,7 +63,7 @@ BOOL NYPLReaderSettingsIncreasedFontSize(NYPLReaderSettingsFontSize input,
 @property (nonatomic) NYPLReaderSettingsFontSize fontSize;
 @property (nonatomic) NYPLReaderSettingsMediaOverlaysEnableClick mediaOverlaysEnableClick;
 @property (nonatomic, readonly) UIColor *foregroundColor;
-@property (nonatomic) id currentReaderReadiumView;
+@property (nonatomic, weak) id currentReaderReadiumView;
 
 - (void) toggleMediaOverlayPlayback;
 


### PR DESCRIPTION
This fixes a MAJOR memory leak and a major hog of CPU. The app was never releasing `NYPLReaderReadiumView` instances thus causing WebKit processes to pile up. We should get this into a release ASAP.