### PR TITLE
Non-DRM Building

### DIFF
--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -226,6 +226,7 @@ static NYPLOPDSFeedType TypeImpliedByEntry(NYPLOPDSEntry *const entry)
             NYPLLOG(last);
             NYPLLOG(@"#### feed reload ####");
 
+#if defined(FEATURE_DRM_CONNECTOR)
             [[NYPLADEPT sharedInstance]
              authorizeWithVendorID:[[NYPLAccount sharedAccount:currentAccount.id] licensor][@"vendor"]
              username:first
@@ -247,6 +248,7 @@ static NYPLOPDSFeedType TypeImpliedByEntry(NYPLOPDSEntry *const entry)
                }
                
              }];
+#endif
           }
 //        }
       }


### PR DESCRIPTION
Added an extra ```defined(FEATURE_DRM_CONNECTOR)``` check to allow the app to build for users without DRM.

Verified in testing to still allow downloads of DRM-free books in SimplyE and NYPL accounts.

This does not effect any development machine with DRM installed.

Fixes #634 