### PR TITLE
Allow barcode fields to take letters

### DIFF
--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -171,7 +171,7 @@ static CellKind CellKindFromIndexPath(NSIndexPath *const indexPath)
                                         UIViewAutoresizingFlexibleHeight);
   self.PINTextField.font = [UIFont systemFontOfSize:17];
   self.PINTextField.placeholder = NSLocalizedString(@"PIN", nil);
-  self.PINTextField.keyboardType = UIKeyboardTypeNumberPad;
+  self.PINTextField.keyboardType = UIKeyboardTypeDefault;
   self.PINTextField.secureTextEntry = YES;
   self.PINTextField.delegate = self;
   [self.PINTextField
@@ -532,9 +532,6 @@ replacementString:(NSString *)string
   }
   
   if(textField == self.PINTextField) {
-    if([string stringByTrimmingCharactersInSet:[NSCharacterSet decimalDigitCharacterSet]].length > 0) {
-      return NO;
-    }
     
     if([textField.text stringByReplacingCharactersInRange:range withString:string].length > 4) {
       return NO;

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -183,7 +183,7 @@ NSString *const NYPLSettingsAccountsSignInFinishedNotification = @"NYPLSettingsA
                                         UIViewAutoresizingFlexibleHeight);
   self.PINTextField.font = [UIFont systemFontOfSize:17];
   self.PINTextField.placeholder = NSLocalizedString(@"PIN", nil);
-  self.PINTextField.keyboardType = UIKeyboardTypeNumberPad;
+  self.PINTextField.keyboardType = UIKeyboardTypeDefault;
   self.PINTextField.secureTextEntry = YES;
   self.PINTextField.delegate = self;
   [self.PINTextField
@@ -1166,9 +1166,6 @@ replacementString:(NSString *)string
   }
   
   if(textField == self.PINTextField) {
-    if([string stringByTrimmingCharactersInSet:[NSCharacterSet decimalDigitCharacterSet]].length > 0) {
-      return NO;
-    }
     
     if([textField.text stringByReplacingCharactersInRange:range withString:string].length > 4) {
       return NO;


### PR DESCRIPTION
Not all pins are strictly numeric and we need to allow the pin fields to accommodate that. This is already supported in Android.