### PR TITLE
Creator bug #595

### DIFF
--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -715,6 +715,8 @@ replacementString:(NSString *)string
                          NSURLResponse *const response,
                          NSError *const error) {
        
+       [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+       
        self.isCurrentlySigningIn = NO;
        // This cast is always valid according to Apple's documentation for NSHTTPURLResponse.
        NSInteger const statusCode = ((NSHTTPURLResponse *) response).statusCode;
@@ -722,7 +724,6 @@ replacementString:(NSString *)string
        // Success.
        if(statusCode == 200) {
          [self authorizationAttemptDidFinish:YES error:nil];
-         self.isLoggingInAfterSignUp = NO;
          return;
        }
        
@@ -747,6 +748,7 @@ replacementString:(NSString *)string
      }];
   
   [task resume];
+  [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
 }
 
 - (void)showLoginAlertWithError:(NSError *)error

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -493,7 +493,6 @@ NSString *const NYPLSettingsAccountsSignInFinishedNotification = @"NYPLSettingsA
      // Success.
      if(statusCode == 200) {
        [self authorizationAttemptDidFinish:YES error:nil];
-       self.isLoggingInAfterSignUp = NO;
        return;
      }
      

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -482,10 +482,7 @@ NSString *const NYPLSettingsAccountsSignInFinishedNotification = @"NYPLSettingsA
                        NSURLResponse *const response,
                        NSError *const error) {
      
-     if (self.isLoggingInAfterSignUp) {
-       [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSettingsAccountsSignInFinishedNotification
-                                                           object:self];
-     }
+     [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
      
      // This cast is always valid according to Apple's documentation for NSHTTPURLResponse.
      NSInteger const statusCode = ((NSHTTPURLResponse *) response).statusCode;
@@ -517,6 +514,7 @@ NSString *const NYPLSettingsAccountsSignInFinishedNotification = @"NYPLSettingsA
    }];
   
   [task resume];
+  [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
 }
 
 - (void)showLoginAlertWithError:(NSError *)error
@@ -655,38 +653,36 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       [self.tableView deselectRowAtIndexPath:indexPath animated:YES];
       
       if (self.account.supportsCardCreator) {
-
-      __weak NYPLSettingsAccountDetailViewController *const weakSelf = self;
-      CardCreatorConfiguration *const configuration =
-      [[CardCreatorConfiguration alloc]
-       initWithEndpointURL:[APIKeys cardCreatorEndpointURL]
-       endpointVersion:[APIKeys cardCreatorVersion]
-       endpointUsername:[APIKeys cardCreatorUsername]
-       endpointPassword:[APIKeys cardCreatorPassword]
-       requestTimeoutInterval:20.0
-       completionHandler:^(NSString *const username, NSString *const PIN, BOOL const userInitiated) {
-         if (userInitiated) {
-           // Dismiss CardCreator when user finishes Credential Review
-           [weakSelf dismissViewControllerAnimated:YES completion:nil];
-         } else {
-           weakSelf.barcodeTextField.text = username;
-           weakSelf.PINTextField.text = PIN;
-           [weakSelf updateLoginLogoutCellAppearance];
-           self.isLoggingInAfterSignUp = YES;
-           [weakSelf logIn];
-         }
-       }];
-      
-      UINavigationController *const navigationController =
-      [CardCreator initialNavigationControllerWithConfiguration:configuration];
-      navigationController.navigationBar.topItem.leftBarButtonItem =
-      [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Cancel", nil)
-                                       style:UIBarButtonItemStylePlain
-                                      target:self
-                                      action:@selector(didSelectCancelForSignUp)];
-      navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
-      [self presentViewController:navigationController animated:YES completion:nil];
-      
+        __weak NYPLSettingsAccountDetailViewController *const weakSelf = self;
+        CardCreatorConfiguration *const configuration =
+        [[CardCreatorConfiguration alloc]
+         initWithEndpointURL:[APIKeys cardCreatorEndpointURL]
+         endpointVersion:[APIKeys cardCreatorVersion]
+         endpointUsername:[APIKeys cardCreatorUsername]
+         endpointPassword:[APIKeys cardCreatorPassword]
+         requestTimeoutInterval:20.0
+         completionHandler:^(NSString *const username, NSString *const PIN, BOOL const userInitiated) {
+           if (userInitiated) {
+             // Dismiss CardCreator when user finishes Credential Review
+             [weakSelf dismissViewControllerAnimated:YES completion:nil];
+           } else {
+             weakSelf.barcodeTextField.text = username;
+             weakSelf.PINTextField.text = PIN;
+             [weakSelf updateLoginLogoutCellAppearance];
+             self.isLoggingInAfterSignUp = YES;
+             [weakSelf logIn];
+           }
+         }];
+        
+        UINavigationController *const navigationController =
+        [CardCreator initialNavigationControllerWithConfiguration:configuration];
+        navigationController.navigationBar.topItem.leftBarButtonItem =
+        [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Cancel", nil)
+                                         style:UIBarButtonItemStylePlain
+                                        target:self
+                                        action:@selector(didSelectCancelForSignUp)];
+        navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
+        [self presentViewController:navigationController animated:YES completion:nil];
       }
       else
       {
@@ -702,10 +698,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
                                         action:@selector(didSelectCancelForSignUp)];
         navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
         [self presentViewController:navigationController animated:YES completion:nil];
-        
-        
       }
-      
       break;
     }
     case CellKindSetCurrentAccount: {


### PR DESCRIPTION
Related to bug 14 in Card Creator.
https://github.com/NYPL-Simplified/CardCreator-iOS/issues/14

Fixes #595 

Allows the final confirmation screen to remain until the user chooses to dismiss it. This allows them to view and copy their newly-created credentials.
