### PR TITLE
Drm bug #645 (activation workflow changes)

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,91 @@
+PODS:
+  - AFNetworking (2.6.3):
+    - AFNetworking/NSURLConnection (= 2.6.3)
+    - AFNetworking/NSURLSession (= 2.6.3)
+    - AFNetworking/Reachability (= 2.6.3)
+    - AFNetworking/Security (= 2.6.3)
+    - AFNetworking/Serialization (= 2.6.3)
+    - AFNetworking/UIKit (= 2.6.3)
+  - AFNetworking/NSURLConnection (2.6.3):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.6.3):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/Reachability (2.6.3)
+  - AFNetworking/Security (2.6.3)
+  - AFNetworking/Serialization (2.6.3)
+  - AFNetworking/UIKit (2.6.3):
+    - AFNetworking/NSURLConnection
+    - AFNetworking/NSURLSession
+  - Bugsnag (5.10.1):
+    - KSCrash/RecordingAdvanced (= 1.8.13)
+  - HelpStack (1.1.2):
+    - AFNetworking (~> 2.0)
+    - HelpStack/Core (= 1.1.2)
+    - HelpStack/Stacks (= 1.1.2)
+    - HelpStack/UI (= 1.1.2)
+    - HelpStack/Util (= 1.1.2)
+  - HelpStack/Core (1.1.2):
+    - AFNetworking (~> 2.0)
+    - HelpStack/Util
+  - HelpStack/Stacks (1.1.2):
+    - AFNetworking (~> 2.0)
+    - HelpStack/Core
+    - HelpStack/Util
+  - HelpStack/UI (1.1.2):
+    - AFNetworking (~> 2.0)
+    - HelpStack/Core
+    - HelpStack/Stacks
+    - HelpStack/Util
+  - HelpStack/Util (1.1.2):
+    - AFNetworking (~> 2.0)
+  - KSCrash/Recording (1.8.13)
+  - KSCrash/RecordingAdvanced (1.8.13):
+    - KSCrash/Recording
+  - NYPLCardCreator (1.0.0):
+    - PureLayout (~> 3.0)
+  - PureLayout (3.0.2)
+  - SQLite.swift (0.11.2):
+    - SQLite.swift/standard (= 0.11.2)
+  - SQLite.swift/standard (0.11.2)
+
+DEPENDENCIES:
+  - Bugsnag (from `https://github.com/bugsnag/bugsnag-cocoa.git`)
+  - HelpStack (from `https://github.com/NYPL-Simplified/helpstack-ios`)
+  - NYPLCardCreator (from `https://github.com/NYPL-Simplified/CardCreator-iOS.git`)
+  - SQLite.swift (~> 0.11.2)
+
+EXTERNAL SOURCES:
+  Bugsnag:
+    :git: https://github.com/bugsnag/bugsnag-cocoa.git
+  HelpStack:
+    :git: https://github.com/NYPL-Simplified/helpstack-ios
+  NYPLCardCreator:
+    :git: https://github.com/NYPL-Simplified/CardCreator-iOS.git
+
+CHECKOUT OPTIONS:
+  Bugsnag:
+    :commit: 8eaf62293d6343a83f3764a7fee1c2e4a251b0cc
+    :git: https://github.com/bugsnag/bugsnag-cocoa.git
+  HelpStack:
+    :commit: 59338f5920b76a234d5cfecc8639662ff5f51f9e
+    :git: https://github.com/NYPL-Simplified/helpstack-ios
+  NYPLCardCreator:
+    :commit: 5c2b6928bc74d32f0f165cb80455e4e505430bd7
+    :git: https://github.com/NYPL-Simplified/CardCreator-iOS.git
+
+SPEC CHECKSUMS:
+  AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
+  Bugsnag: 9c2d242eac7f215c40ff0f5813d378e9fcccf6e4
+  HelpStack: a9067738597ef81835d84ac8bb75ee346e34f000
+  KSCrash: 4c3a83f133b60f4bd57e05235ebf8d46e36d378d
+  NYPLCardCreator: e0f5034902008b4c8cdfb5edbffa2a51ec0b261d
+  PureLayout: 4d550abe49a94f24c2808b9b95db9131685fe4cd
+  SQLite.swift: 670c3e9e0a806bbfd56a3de5d530768dc0e6fe7c
+
+PODFILE CHECKSUM: 8bc1b2ad0946ab537f031f0dbf65997ce41778e2
+
+COCOAPODS: 1.2.0

--- a/Simplified/NYPLAccount.m
+++ b/Simplified/NYPLAccount.m
@@ -261,9 +261,11 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
   
   [[NYPLKeychain sharedKeychain] setObject:licensor forKey:licensorKey];
   
-  [[NSNotificationCenter defaultCenter]
-   postNotificationName:NYPLAccountDidChangeNotification
-   object:self];
+  //GODO come back to this
+//  
+//  [[NSNotificationCenter defaultCenter]
+//   postNotificationName:NYPLAccountDidChangeNotification
+//   object:self];
   
 }
 - (void)setAuthorizationIdentifier:(NSString *)identifier
@@ -273,10 +275,11 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
   }
   
   [[NYPLKeychain sharedKeychain] setObject:identifier forKey:authorizationIdentifierKey];
-  
-  [[NSNotificationCenter defaultCenter]
-   postNotificationName:NYPLAccountDidChangeNotification
-   object:self];
+
+  //GODO come back to this
+//  [[NSNotificationCenter defaultCenter]
+//   postNotificationName:NYPLAccountDidChangeNotification
+//   object:self];
   
 }
 - (void)setPatron:(NSDictionary *)patron

--- a/Simplified/NYPLAccount.m
+++ b/Simplified/NYPLAccount.m
@@ -260,13 +260,6 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
   }
   
   [[NYPLKeychain sharedKeychain] setObject:licensor forKey:licensorKey];
-  
-  //GODO come back to this
-//  
-//  [[NSNotificationCenter defaultCenter]
-//   postNotificationName:NYPLAccountDidChangeNotification
-//   object:self];
-  
 }
 - (void)setAuthorizationIdentifier:(NSString *)identifier
 {
@@ -275,12 +268,6 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
   }
   
   [[NYPLKeychain sharedKeychain] setObject:identifier forKey:authorizationIdentifierKey];
-
-  //GODO come back to this
-//  [[NSNotificationCenter defaultCenter]
-//   postNotificationName:NYPLAccountDidChangeNotification
-//   object:self];
-  
 }
 - (void)setPatron:(NSDictionary *)patron
 {

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -702,9 +702,7 @@ replacementString:(NSString *)string
   NSMutableURLRequest *const request =
     [NSMutableURLRequest requestWithURL:[NYPLConfiguration loanURL]];
   
-  // Necessary to support longer login times when using usernames.
   request.timeoutInterval = 20.0;
-  
   request.HTTPMethod = @"HEAD";
   
   self.isCurrentlySigningIn = YES;
@@ -715,13 +713,77 @@ replacementString:(NSString *)string
                          NSURLResponse *const response,
                          NSError *const error) {
        
+       //GODO audit this for blocking UI
        self.isCurrentlySigningIn = NO;
-       // This cast is always valid according to Apple's documentation for NSHTTPURLResponse.
+
        NSInteger const statusCode = ((NSHTTPURLResponse *) response).statusCode;
        
-       // Success.
        if(statusCode == 200) {
+         
+#if defined(FEATURE_DRM_CONNECTOR)
+         
+         // GODO If an old set of Adobe Keys is saved on the user, try and purge/deactivate those first..
+         // Log this case in bugsnag
+         
+         
+         //       NYPLXML *loansXML = [NYPLXML XMLWithData:data];
+         //       NYPLOPDSFeed *loansFeed = [[NYPLOPDSFeed alloc] initWithXML:loansXML];
+         //       if (!loansFeed.licensor) {
+         //         NYPLLOG(@"No Licensor received or parsed from OPDS Loans feed");
+         //         return;
+         //       }
+         //       [[NYPLAccount sharedAccount:self.accountType] setLicensor:loansFeed.licensor];
+         
+         NSDictionary *licensor = [[NYPLAccount sharedAccount] licensor];
+         
+         if (!licensor) {
+           NYPLLOG(@"No Licensor received or parsed from OPDS Loans feed");
+           return;
+         }
+         
+         NSMutableArray *licensorItems = [[licensor[@"clientToken"] stringByReplacingOccurrencesOfString:@"\n" withString:@""] componentsSeparatedByString:@"|"].mutableCopy;
+         NSString *tokenPassword = [licensorItems lastObject];
+         [licensorItems removeLastObject];
+         NSString *tokenUsername = [licensorItems componentsJoinedByString:@"|"];
+         
+         NYPLLOG(@"***DRM Auth/Activation Attempt***");
+         NYPLLOG_F(@"\nLicensor: %@\n",licensor);
+         NYPLLOG_F(@"Token Username: %@\n",tokenUsername);
+         NYPLLOG_F(@"Token Password: %@\n",tokenPassword);
+         
+         [[NYPLADEPT sharedInstance]
+          authorizeWithVendorID:[[NYPLAccount sharedAccount] licensor][@"vendor"]
+          username:tokenUsername
+          password:tokenPassword
+          completion:^(BOOL success, NSError *error, NSString *deviceID, NSString *userID) {
+            
+            NYPLLOG_F(@"Activation Success: %@\n", success ? @"Yes" : @"No");
+            NYPLLOG_F(@"Error: %@\n",error.localizedDescription);
+            NYPLLOG_F(@"UserID: %@\n",userID);
+            NYPLLOG_F(@"DeviceID: %@\n",deviceID);
+            NYPLLOG(@"***DRM Auth/Activation Completion***");
+            
+            if (success) {
+              // POST deviceID to adobeDevicesLink
+              NSURL *deviceManager = [NSURL URLWithString: [[NYPLAccount sharedAccount] licensor][@"deviceManager"]];
+              if (deviceManager != nil) {
+                [NYPLDeviceManager postDevice:deviceID url:deviceManager];
+              }
+              
+              [[NYPLAccount sharedAccount] setUserID:userID];
+              [[NYPLAccount sharedAccount] setDeviceID:deviceID];
+            }
+            
+            [self authorizationAttemptDidFinish:success error:error];
+            
+          }];
+         
+#else
+         
          [self authorizationAttemptDidFinish:YES error:nil];
+         
+#endif
+
          self.isLoggingInAfterSignUp = NO;
          return;
        }

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -262,6 +262,10 @@ static NSString *const RecordsKey = @"records";
      
      void (^commitBlock)() = ^void() {
        [self performSynchronizedWithoutBroadcasting:^{
+         
+         Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
+         [[NYPLAccount sharedAccount:currentAccount.id] setLicensor:feed.licensor];
+         
          NSMutableSet *identifiersToRemove = [NSMutableSet setWithArray:self.identifiersToRecords.allKeys];
          for(NYPLOPDSEntry *const entry in feed.entries) {
            NYPLBook *const book = [NYPLBook bookWithEntry:entry];

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -263,8 +263,9 @@ static NSString *const RecordsKey = @"records";
      void (^commitBlock)() = ^void() {
        [self performSynchronizedWithoutBroadcasting:^{
          
-         Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
-         [[NYPLAccount sharedAccount:currentAccount.id] setLicensor:feed.licensor];
+         //GODO bring back once i understand how 
+//         Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
+//         [[NYPLAccount sharedAccount:currentAccount.id] setLicensor:feed.licensor];
          
          NSMutableSet *identifiersToRemove = [NSMutableSet setWithArray:self.identifiersToRecords.allKeys];
          for(NYPLOPDSEntry *const entry in feed.entries) {

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -319,6 +319,8 @@ static NSString *const RecordsKey = @"records";
         otherButtonTitles:NSLocalizedString(@"OK", nil), nil]
        show];
     }
+    [[NSNotificationCenter defaultCenter]
+     postNotificationName:NYPLSyncEndedNotification object:nil];
   }];
 }
 

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -263,9 +263,8 @@ static NSString *const RecordsKey = @"records";
      void (^commitBlock)() = ^void() {
        [self performSynchronizedWithoutBroadcasting:^{
          
-         //GODO bring back once i understand how 
-//         Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
-//         [[NYPLAccount sharedAccount:currentAccount.id] setLicensor:feed.licensor];
+         [[NYPLAccount sharedAccount] setLicensor:feed.licensor];
+         NYPLLOG_F(@"\nLicensor Token Updated: %@\nFor account: %@",feed.licensor[@"clientToken"],[NYPLAccount sharedAccount].userID);
          
          NSMutableSet *identifiersToRemove = [NSMutableSet setWithArray:self.identifiersToRecords.allKeys];
          for(NYPLOPDSEntry *const entry in feed.entries) {

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -170,21 +170,27 @@
   }
   
   
+  //GODO is "needs auth" still applicable?
   if (account.needsAuth
       && [[NYPLAccount sharedAccount:account.id] hasBarcodeAndPIN]
       && [[NYPLAccount sharedAccount:account.id] hasLicensor])
   {
-    NSMutableArray* foo = [[[[NYPLAccount sharedAccount:account.id] licensor][@"clientToken"]
-                            stringByReplacingOccurrencesOfString:@"\n" withString:@""]
-                           componentsSeparatedByString: @"|"].mutableCopy;
-
-    NSString *last = foo.lastObject;
-    [foo removeLastObject];
-    NSString *first = [foo componentsJoinedByString:@"|"];
+    NSDictionary *licensor = [[NYPLAccount sharedAccount:account.id] licensor];
+    NSString *tokenString = [licensor[@"clientToken"] stringByReplacingOccurrencesOfString:@"\n"
+                                                                                       withString:@""];
+    NSMutableArray *tokenComponents = [tokenString componentsSeparatedByString: @"|"].mutableCopy;
+                                   
     
-    NYPLLOG([[NYPLAccount sharedAccount:account.id] licensor]);
-    NYPLLOG(first);
-    NYPLLOG(last);
+    NSString *tokenPassword = tokenComponents.lastObject;
+    [tokenComponents removeLastObject];
+    NSString *tokenUsername = [tokenComponents componentsJoinedByString:@"|"];
+    
+    NYPLLOG(@"***DRM Auth/Activation Attempt***");
+    NYPLLOG_F(@"\nLicensor: %@\n",licensor);
+    NYPLLOG_F(@"Username: %@\n",tokenUsername);
+    NYPLLOG_F(@"Password: %@\n",tokenPassword);
+    
+
 #if defined(FEATURE_DRM_CONNECTOR)
 
 //    [[NYPLADEPT sharedInstance]

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -187,35 +187,35 @@
     NYPLLOG(last);
 #if defined(FEATURE_DRM_CONNECTOR)
 
-    [[NYPLADEPT sharedInstance]
-     authorizeWithVendorID:[[NYPLAccount sharedAccount:account.id] licensor][@"vendor"]
-     username:first
-     password:last
-     userID:[[NYPLAccount sharedAccount:account.id] userID] deviceID:[[NYPLAccount sharedAccount:account.id] deviceID]
-     completion:^(BOOL success, NSError *error, NSString *deviceID, NSString *userID) {
-       
-       NYPLLOG(error);
-       
-       if (success)
-       {
-         [[NYPLAccount sharedAccount:account.id] setUserID:userID];
-         [[NYPLAccount sharedAccount:account.id] setDeviceID:deviceID];
-
-         [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL __unused success) {
-           [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
-         }];
-         
-         // POST deviceID to adobeDevicesLink
-         NSURL *deviceManager =  [NSURL URLWithString: [[NYPLAccount sharedAccount:account.id] licensor][@"deviceManager"]];
-         if (deviceManager != nil) {
-           [NYPLDeviceManager postDevice:deviceID url:deviceManager];
-         }
-       }
-       else
-       {
-         [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
-       }
-     }];
+//    [[NYPLADEPT sharedInstance]
+//     authorizeWithVendorID:[[NYPLAccount sharedAccount:account.id] licensor][@"vendor"]
+//     username:first
+//     password:last
+//     userID:[[NYPLAccount sharedAccount:account.id] userID] deviceID:[[NYPLAccount sharedAccount:account.id] deviceID]
+//     completion:^(BOOL success, NSError *error, NSString *deviceID, NSString *userID) {
+//       
+//       NYPLLOG(error);
+//       
+//       if (success)
+//       {
+//         [[NYPLAccount sharedAccount:account.id] setUserID:userID];
+//         [[NYPLAccount sharedAccount:account.id] setDeviceID:deviceID];
+//
+//         [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL __unused success) {
+//           [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
+//         }];
+//         
+//         // POST deviceID to adobeDevicesLink
+//         NSURL *deviceManager =  [NSURL URLWithString: [[NYPLAccount sharedAccount:account.id] licensor][@"deviceManager"]];
+//         if (deviceManager != nil) {
+//           [NYPLDeviceManager postDevice:deviceID url:deviceManager];
+//         }
+//       }
+//       else
+//       {
+//         [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
+//       }
+//     }];
 #endif
 
   }

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -169,68 +169,10 @@
     viewController.navigationItem.title = [[NYPLSettings sharedSettings] currentAccount].name;
   }
   
-  
-  //GODO is "needs auth" still applicable?
-  if (account.needsAuth
-      && [[NYPLAccount sharedAccount:account.id] hasBarcodeAndPIN]
-      && [[NYPLAccount sharedAccount:account.id] hasLicensor])
-  {
-    NSDictionary *licensor = [[NYPLAccount sharedAccount:account.id] licensor];
-    NSString *tokenString = [licensor[@"clientToken"] stringByReplacingOccurrencesOfString:@"\n"
-                                                                                       withString:@""];
-    NSMutableArray *tokenComponents = [tokenString componentsSeparatedByString: @"|"].mutableCopy;
-                                   
-    
-    NSString *tokenPassword = tokenComponents.lastObject;
-    [tokenComponents removeLastObject];
-    NSString *tokenUsername = [tokenComponents componentsJoinedByString:@"|"];
-    
-    NYPLLOG(@"***DRM Auth/Activation Attempt***");
-    NYPLLOG_F(@"\nLicensor: %@\n",licensor);
-    NYPLLOG_F(@"Username: %@\n",tokenUsername);
-    NYPLLOG_F(@"Password: %@\n",tokenPassword);
-    
-
-#if defined(FEATURE_DRM_CONNECTOR)
-
-//    [[NYPLADEPT sharedInstance]
-//     authorizeWithVendorID:[[NYPLAccount sharedAccount:account.id] licensor][@"vendor"]
-//     username:first
-//     password:last
-//     userID:[[NYPLAccount sharedAccount:account.id] userID] deviceID:[[NYPLAccount sharedAccount:account.id] deviceID]
-//     completion:^(BOOL success, NSError *error, NSString *deviceID, NSString *userID) {
-//       
-//       NYPLLOG(error);
-//       
-//       if (success)
-//       {
-//         [[NYPLAccount sharedAccount:account.id] setUserID:userID];
-//         [[NYPLAccount sharedAccount:account.id] setDeviceID:deviceID];
-//
-//         [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL __unused success) {
-//           [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
-//         }];
-//         
-//         // POST deviceID to adobeDevicesLink
-//         NSURL *deviceManager =  [NSURL URLWithString: [[NYPLAccount sharedAccount:account.id] licensor][@"deviceManager"]];
-//         if (deviceManager != nil) {
-//           [NYPLDeviceManager postDevice:deviceID url:deviceManager];
-//         }
-//       }
-//       else
-//       {
-//         [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
-//       }
-//     }];
-#endif
-
-  }
-  else{
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-      [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
-    }];
-  }
-  
+  //GODO is this even needed anymore?
+  [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+    [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
+  }];
 }
 
 - (void)viewDidLoad

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -169,7 +169,6 @@
     viewController.navigationItem.title = [[NYPLSettings sharedSettings] currentAccount].name;
   }
   
-  //GODO is this even needed anymore?
   [[NSOperationQueue mainQueue] addOperationWithBlock:^{
     [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
   }];

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -148,8 +148,11 @@
   
   [[NYPLSettings sharedSettings] setAccountMainFeedURL:[NSURL URLWithString:account.catalogUrl]];
   [UIApplication sharedApplication].delegate.window.tintColor = [NYPLConfiguration mainColor];
-  
+
   [[NYPLBookRegistry sharedRegistry] justLoad];
+  [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL __unused success) {
+    [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
+  }];
 
   if ([[self.visibleViewController class] isSubclassOfClass:[NYPLCatalogFeedViewController class]] &&
        [self.visibleViewController respondsToSelector:@selector(load)]) {

--- a/Simplified/NYPLConfiguration.m
+++ b/Simplified/NYPLConfiguration.m
@@ -22,12 +22,12 @@
   }
   
 #if defined(FEATURE_DRM_CONNECTOR)
-  [[NYPLADEPT sharedInstance] setLogCallback:^(__unused NSString *logLevel,
-                                               NSString *const exceptionName,
-                                               __unused NSDictionary *data,
-                                               NSString *const message) {
-    NSLog(@"ADEPT: %@: %@", exceptionName, message);
-  }];
+//  [[NYPLADEPT sharedInstance] setLogCallback:^(__unused NSString *logLevel,
+//                                               NSString *const exceptionName,
+//                                               __unused NSDictionary *data,
+//                                               NSString *const message) {
+//    NSLog(@"ADEPT: %@: %@", exceptionName, message);
+//  }];
 #endif
 }
 

--- a/Simplified/NYPLConfiguration.m
+++ b/Simplified/NYPLConfiguration.m
@@ -20,15 +20,6 @@
   if([NYPLConfiguration bugsnagEnabled]) {
     [Bugsnag startBugsnagWithApiKey:[NYPLConfiguration bugsnagID]];
   }
-  
-#if defined(FEATURE_DRM_CONNECTOR)
-//  [[NYPLADEPT sharedInstance] setLogCallback:^(__unused NSString *logLevel,
-//                                               NSString *const exceptionName,
-//                                               __unused NSDictionary *data,
-//                                               NSString *const message) {
-//    NSLog(@"ADEPT: %@: %@", exceptionName, message);
-//  }];
-#endif
 }
 
 

--- a/Simplified/NYPLHoldsNavigationController.m
+++ b/Simplified/NYPLHoldsNavigationController.m
@@ -117,8 +117,6 @@
   
   NYPLHoldsViewController *viewController = (NYPLHoldsViewController *)self.visibleViewController;
   viewController.navigationItem.title = [[NYPLSettings sharedSettings] currentAccount].name;
-  
-  [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:nil];
 }
 
 @end

--- a/Simplified/NYPLHoldsNavigationController.m
+++ b/Simplified/NYPLHoldsNavigationController.m
@@ -117,9 +117,8 @@
   
   NYPLHoldsViewController *viewController = (NYPLHoldsViewController *)self.visibleViewController;
   viewController.navigationItem.title = [[NYPLSettings sharedSettings] currentAccount].name;
-//  viewController.navigationItem.leftBarButtonItem.enabled = NO;
-//  [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncBeganNotification object:nil];
-
+  
+  [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:nil];
 }
 
 @end

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -170,7 +170,9 @@ didFinishDownloadingToURL:(NSURL *const)location
             
       case NYPLMyBooksDownloadRightsManagementAdobe:
       {
+        
 #if defined(FEATURE_DRM_CONNECTOR)
+        
         NSData *ACSMData = [NSData dataWithContentsOfURL:location];
         NSString *PDFString = @">application/pdf</dc:format>";
         if([[[NSString alloc] initWithData:ACSMData encoding:NSUTF8StringEncoding] containsString:PDFString]) {
@@ -182,26 +184,18 @@ didFinishDownloadingToURL:(NSURL *const)location
           [[NYPLBookRegistry sharedRegistry]
            setState:NYPLBookStateDownloadFailed
            forIdentifier:book.identifier];
+          
         } else {
           
+          NYPLLOG_F(@"Download attempt for book. userID: %@",[[NYPLAccount sharedAccount] userID]);
           [[NYPLADEPT sharedInstance]
-           switchAdeptActivationToAdobeID:[[NYPLAccount sharedAccount] userID]
-           deviceID:[[NYPLAccount sharedAccount] deviceID]
-           completion:^(BOOL success) {
-            
-            NYPLLOG_F(@"Attempting to Download book with userID: %@",[[NYPLAccount sharedAccount] userID]);
-            
-             if (success) {
-              [[NYPLADEPT sharedInstance]
-               fulfillWithACSMData:ACSMData
-               tag:book.identifier
-               userID:[[NYPLAccount sharedAccount] userID]
-               deviceID:[[NYPLAccount sharedAccount] deviceID]];
-             }
-          }];
-          
+           fulfillWithACSMData:ACSMData
+           tag:book.identifier
+           userID:[[NYPLAccount sharedAccount] userID]
+           deviceID:[[NYPLAccount sharedAccount] deviceID]];
         }
-#endif
+        
+#endif        
         break;
       }
         
@@ -333,23 +327,15 @@ didDismissWithButtonIndex:(NSInteger const)buttonIndex
   NSString *fulfillmentId = [[NYPLBookRegistry sharedRegistry] fulfillmentIdForIdentifier:identifier];
   if(fulfillmentId) {
     
-    [[NYPLADEPT sharedInstance]
-     switchAdeptActivationToAdobeID:[[NYPLAccount sharedAccount] userID]
-     deviceID:[[NYPLAccount sharedAccount] deviceID]
-     completion:^(BOOL success) {
-    
-      NYPLLOG_F(@"Attempting to Return Load with userID: %@",[[NYPLAccount sharedAccount] userID]);
-      [[NYPLADEPT sharedInstance] returnLoan:fulfillmentId
-                                      userID:[[NYPLAccount sharedAccount] userID]
-                                    deviceID:[[NYPLAccount sharedAccount] deviceID]
-                                  completion:^(BOOL success, __unused NSError *error) {
-                                    if(!success) {
-                                      NYPLLOG(@"Failed to return loan.");
-                                    }
-                                  }];
-    
-     }];
-    
+    NYPLLOG_F(@"Return attempt for book. userID: %@",[[NYPLAccount sharedAccount] userID]);
+    [[NYPLADEPT sharedInstance] returnLoan:fulfillmentId
+                                    userID:[[NYPLAccount sharedAccount] userID]
+                                  deviceID:[[NYPLAccount sharedAccount] deviceID]
+                                completion:^(BOOL success, __unused NSError *error) {
+                                  if(!success) {
+                                    NYPLLOG(@"Failed to return loan.");
+                                  }
+                                }];
   }
 #endif
   }

--- a/Simplified/NYPLMyBooksNavigationController.m
+++ b/Simplified/NYPLMyBooksNavigationController.m
@@ -121,9 +121,7 @@
   
   NYPLMyBooksViewController *viewController = (NYPLMyBooksViewController *)self.visibleViewController;
   viewController.navigationItem.title =  [[NYPLSettings sharedSettings] currentAccount].name;
-//  viewController.navigationItem.leftBarButtonItem.enabled = NO;
-//  [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncBeganNotification object:nil];
-
+  [viewController didSelectSync];
 }
 
 @end

--- a/Simplified/NYPLMyBooksNavigationController.m
+++ b/Simplified/NYPLMyBooksNavigationController.m
@@ -121,7 +121,6 @@
   
   NYPLMyBooksViewController *viewController = (NYPLMyBooksViewController *)self.visibleViewController;
   viewController.navigationItem.title =  [[NYPLSettings sharedSettings] currentAccount].name;
-  [viewController didSelectSync];
 }
 
 @end

--- a/Simplified/NYPLMyBooksViewController.h
+++ b/Simplified/NYPLMyBooksViewController.h
@@ -5,6 +5,8 @@
 - (id)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 
+- (void)didSelectSync;
+
 // designated initializer
 - (instancetype)init;
 

--- a/Simplified/NYPLMyBooksViewController.h
+++ b/Simplified/NYPLMyBooksViewController.h
@@ -5,8 +5,6 @@
 - (id)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 
-- (void)didSelectSync;
-
 // designated initializer
 - (instancetype)init;
 

--- a/Simplified/NYPLMyBooksViewController.m
+++ b/Simplified/NYPLMyBooksViewController.m
@@ -367,20 +367,7 @@ OK:
   if (account.needsAuth)
   {
     if([[NYPLAccount sharedAccount] hasBarcodeAndPIN]) {
-      [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL success) {
-        if(success) {
-          [[NYPLBookRegistry sharedRegistry] save];
-        } else {
-          [[[UIAlertView alloc]
-            initWithTitle:NSLocalizedString(@"SyncFailed", nil)
-            message:NSLocalizedString(@"CheckConnection", nil)
-            delegate:nil
-            cancelButtonTitle:nil
-            otherButtonTitles:NSLocalizedString(@"OK", nil), nil]
-           show];
-        }
-        [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
-      }];
+      [[NYPLBookRegistry sharedRegistry] syncWithStandardAlertsOnCompletion];
     } else {
       // We can't sync if we're not logged in, so let's log in. We don't need a completion handler
       // here because logging in will trigger a sync anyway. The only downside of letting the sync
@@ -398,7 +385,6 @@ OK:
   {
     [[NYPLBookRegistry sharedRegistry] justLoad];
     [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
-
   }
 }
 

--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -204,53 +204,6 @@ static NYPLOPDSFeedType TypeImpliedByEntry(NYPLOPDSEntry *const entry)
           continue;
         }
       }
-      
-      
-      
-       
-        Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
-        [[NYPLAccount sharedAccount:currentAccount.id] setLicensor:self.licensor];
-        
-        
-//        if (![[NYPLADEPT sharedInstance] isUserAuthorized:[[NYPLAccount sharedAccount:currentAccount.id] userID] withDevice:[[NYPLAccount sharedAccount:currentAccount.id] deviceID]]) {
-//          if (currentAccount.needsAuth && [[NYPLAccount sharedAccount:currentAccount.id] hasBarcodeAndPIN] && [[NYPLAccount sharedAccount:currentAccount.id] hasLicensor])
-//          {
-//            NSMutableArray* foo = [[[[NYPLAccount sharedAccount:currentAccount.id] licensor][@"clientToken"]  stringByReplacingOccurrencesOfString:@"\n" withString:@""] componentsSeparatedByString: @"|"].mutableCopy;
-//            
-//            NSString *last = foo.lastObject;
-//            [foo removeLastObject];
-//            NSString *first = [foo componentsJoinedByString:@"|"];
-//            
-//            NYPLLOG([[NYPLAccount sharedAccount:currentAccount.id] licensor]);
-//            NYPLLOG(first);
-//            NYPLLOG(last);
-//            NYPLLOG(@"#### feed reload ####");
-
-#if defined(FEATURE_DRM_CONNECTOR)
-//            [[NYPLADEPT sharedInstance]
-//             authorizeWithVendorID:[[NYPLAccount sharedAccount:currentAccount.id] licensor][@"vendor"]
-//             username:first
-//             password:last
-//             userID:[[NYPLAccount sharedAccount:currentAccount.id] userID] deviceID:[[NYPLAccount sharedAccount:currentAccount.id] deviceID]
-//             completion:^(BOOL success, NSError *error, NSString *deviceID, NSString *userID) {
-//               
-//               NYPLLOG(error);
-//               if (success) {
-//                 
-//                 [[NYPLAccount sharedAccount:currentAccount.id] setUserID:userID];
-//                 [[NYPLAccount sharedAccount:currentAccount.id] setDeviceID:deviceID];
-//                 
-//                 // POST deviceID to adobeDevicesLink
-//                 NSURL *deviceManager = [NSURL URLWithString: [[NYPLAccount sharedAccount:currentAccount.id] licensor][@"deviceManager"]];
-//                 if (deviceManager != nil) {
-//                   [NYPLDeviceManager postDevice:deviceID url:deviceManager];
-//                 }
-//               }
-//               
-//             }];
-#endif
-//          }
-//        }
       }
     }
   }

--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -213,41 +213,43 @@ static NYPLOPDSFeedType TypeImpliedByEntry(NYPLOPDSEntry *const entry)
         
         
 //        if (![[NYPLADEPT sharedInstance] isUserAuthorized:[[NYPLAccount sharedAccount:currentAccount.id] userID] withDevice:[[NYPLAccount sharedAccount:currentAccount.id] deviceID]]) {
-          if (currentAccount.needsAuth && [[NYPLAccount sharedAccount:currentAccount.id] hasBarcodeAndPIN] && [[NYPLAccount sharedAccount:currentAccount.id] hasLicensor])
-          {
-            NSMutableArray* foo = [[[[NYPLAccount sharedAccount:currentAccount.id] licensor][@"clientToken"]  stringByReplacingOccurrencesOfString:@"\n" withString:@""] componentsSeparatedByString: @"|"].mutableCopy;
-            
-            NSString *last = foo.lastObject;
-            [foo removeLastObject];
-            NSString *first = [foo componentsJoinedByString:@"|"];
-            
-            NYPLLOG([[NYPLAccount sharedAccount:currentAccount.id] licensor]);
-            NYPLLOG(first);
-            NYPLLOG(last);
-            NYPLLOG(@"#### feed reload ####");
+//          if (currentAccount.needsAuth && [[NYPLAccount sharedAccount:currentAccount.id] hasBarcodeAndPIN] && [[NYPLAccount sharedAccount:currentAccount.id] hasLicensor])
+//          {
+//            NSMutableArray* foo = [[[[NYPLAccount sharedAccount:currentAccount.id] licensor][@"clientToken"]  stringByReplacingOccurrencesOfString:@"\n" withString:@""] componentsSeparatedByString: @"|"].mutableCopy;
+//            
+//            NSString *last = foo.lastObject;
+//            [foo removeLastObject];
+//            NSString *first = [foo componentsJoinedByString:@"|"];
+//            
+//            NYPLLOG([[NYPLAccount sharedAccount:currentAccount.id] licensor]);
+//            NYPLLOG(first);
+//            NYPLLOG(last);
+//            NYPLLOG(@"#### feed reload ####");
 
-            [[NYPLADEPT sharedInstance]
-             authorizeWithVendorID:[[NYPLAccount sharedAccount:currentAccount.id] licensor][@"vendor"]
-             username:first
-             password:last
-             userID:[[NYPLAccount sharedAccount:currentAccount.id] userID] deviceID:[[NYPLAccount sharedAccount:currentAccount.id] deviceID]
-             completion:^(BOOL success, NSError *error, NSString *deviceID, NSString *userID) {
-               
-               NYPLLOG(error);
-               if (success) {
-                 
-                 [[NYPLAccount sharedAccount:currentAccount.id] setUserID:userID];
-                 [[NYPLAccount sharedAccount:currentAccount.id] setDeviceID:deviceID];
-                 
-                 // POST deviceID to adobeDevicesLink
-                 NSURL *deviceManager = [NSURL URLWithString: [[NYPLAccount sharedAccount:currentAccount.id] licensor][@"deviceManager"]];
-                 if (deviceManager != nil) {
-                   [NYPLDeviceManager postDevice:deviceID url:deviceManager];
-                 }
-               }
-               
-             }];
-          }
+#if defined(FEATURE_DRM_CONNECTOR)
+//            [[NYPLADEPT sharedInstance]
+//             authorizeWithVendorID:[[NYPLAccount sharedAccount:currentAccount.id] licensor][@"vendor"]
+//             username:first
+//             password:last
+//             userID:[[NYPLAccount sharedAccount:currentAccount.id] userID] deviceID:[[NYPLAccount sharedAccount:currentAccount.id] deviceID]
+//             completion:^(BOOL success, NSError *error, NSString *deviceID, NSString *userID) {
+//               
+//               NYPLLOG(error);
+//               if (success) {
+//                 
+//                 [[NYPLAccount sharedAccount:currentAccount.id] setUserID:userID];
+//                 [[NYPLAccount sharedAccount:currentAccount.id] setDeviceID:deviceID];
+//                 
+//                 // POST deviceID to adobeDevicesLink
+//                 NSURL *deviceManager = [NSURL URLWithString: [[NYPLAccount sharedAccount:currentAccount.id] licensor][@"deviceManager"]];
+//                 if (deviceManager != nil) {
+//                   [NYPLDeviceManager postDevice:deviceID url:deviceManager];
+//                 }
+//               }
+//               
+//             }];
+#endif
+//          }
 //        }
       }
     }

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -79,6 +79,10 @@ typedef NS_ENUM(NSInteger, Section) {
 
 @property (nonatomic) UISwitch* switchView;
 
+
+@property (nonatomic) bool firstAccount;
+
+
 @end
 
 NSString *const NYPLSettingsAccountsSignInFinishedNotification = @"NYPLSettingsAccountsSignInFinishedNotification";
@@ -336,7 +340,7 @@ NSString *const NYPLSettingsAccountsSignInFinishedNotification = @"NYPLSettingsA
 - (void)updateVisibilityForLicenseLinks
 {
   if ([self.account getLicenseURL:URLTypeEula]) {
-    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"EULA"
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Switch Account"
                                                                               style:UIBarButtonItemStylePlain
                                                                              target:self
                                                                              action:@selector(showEULA)];
@@ -416,35 +420,44 @@ NSString *const NYPLSettingsAccountsSignInFinishedNotification = @"NYPLSettingsA
        NYPLLOG(first);
        NYPLLOG(last);
 
-       [[NYPLADEPT sharedInstance]
-        deauthorizeWithUsername:first
-        password:last
-        userID:[[NYPLAccount sharedAccount:self.accountType] userID] deviceID:[[NYPLAccount sharedAccount:self.accountType] deviceID]
-        completion:^(BOOL success, __unused NSError *error) {
-          if(!success) {
-            // Even though we failed, all we do is log the error. The reason is
-            // that we want the user to be able to log out anyway because the
-            // failure is probably due to bad credentials and we do not want the
-            // user to have to change their barcode or PIN just to log out. This
-            // is only a temporary measure and we'll switch to deauthorizing with
-            // a token that will remain invalid indefinitely in the near future.
-            NYPLLOG(@"Failed to deauthorize successfully.");
-            
-          }
-          else {
-            
-            // DELETE deviceID to adobeDevicesLink
-            NSURL *deviceManager =  [NSURL URLWithString: [[NYPLAccount sharedAccount:self.accountType] licensor][@"deviceManager"]];
-            if (deviceManager != nil) {
-              [NYPLDeviceManager deleteDevice:[[NYPLAccount sharedAccount:self.accountType] deviceID] url:deviceManager];
-            }
+//       [[NYPLADEPT sharedInstance]
+//        deauthorizeWithUsername:first
+//        password:last
+//        userID:[[NYPLAccount sharedAccount:self.accountType] userID] deviceID:[[NYPLAccount sharedAccount:self.accountType] deviceID]
+//        completion:^(BOOL success, __unused NSError *error) {
+//          if(!success) {
+//            // Even though we failed, all we do is log the error. The reason is
+//            // that we want the user to be able to log out anyway because the
+//            // failure is probably due to bad credentials and we do not want the
+//            // user to have to change their barcode or PIN just to log out. This
+//            // is only a temporary measure and we'll switch to deauthorizing with
+//            // a token that will remain invalid indefinitely in the near future.
+//            NYPLLOG(@"Failed to deauthorize successfully.");
+//            
+//          }
+//          else {
+//            
+//            // DELETE deviceID to adobeDevicesLink
+//            NSURL *deviceManager =  [NSURL URLWithString: [[NYPLAccount sharedAccount:self.accountType] licensor][@"deviceManager"]];
+//            if (deviceManager != nil) {
+//              [NYPLDeviceManager deleteDevice:[[NYPLAccount sharedAccount:self.accountType] deviceID] url:deviceManager];
+//            }
+//
+//          }
+//       
+//          [self removeActivityTitle];
+//          [[UIApplication sharedApplication] endIgnoringInteractionEvents];
+//          afterDeauthorization();
+//        }];
+       
+       
+       //is this temp from me? i believe so
+       [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+         [self removeActivityTitle];
+         [[UIApplication sharedApplication] endIgnoringInteractionEvents];
+         afterDeauthorization();
+       }];
 
-          }
-          
-          [self removeActivityTitle];
-          [[UIApplication sharedApplication] endIgnoringInteractionEvents];
-          afterDeauthorization();
-        }];
        
      } else {
        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
@@ -492,7 +505,65 @@ NSString *const NYPLSettingsAccountsSignInFinishedNotification = @"NYPLSettingsA
      
      // Success.
      if(statusCode == 200) {
+//GODO
+       
+       
+       
+#if defined(FEATURE_DRM_CONNECTOR)
+       
+
+       
+////       //Eventually need to use licensor from feed and not manually
+//       NSDictionary *licensor = [[NYPLAccount sharedAccount:self.accountType] licensor];
+//       NSMutableArray *licensorItems = [[licensor[@"clientToken"] stringByReplacingOccurrencesOfString:@"\n" withString:@""] componentsSeparatedByString:@"|"].mutableCopy;
+//       NSString *tokenPassword = [licensorItems lastObject];
+//       [licensorItems removeLastObject];
+//       NSString *tokenUsername = [licensorItems componentsJoinedByString:@"|"];
+//       
+//       NYPLLOG(@"***DRM Auth/Activation Attempt***");
+//       NYPLLOG_F(@"\nLicensor: %@\n",licensor);
+//       NYPLLOG_F(@"Username: %@\n",tokenUsername);
+//       NYPLLOG_F(@"Password: %@\n",tokenPassword);
+//       
+//       [[NYPLADEPT sharedInstance]
+//        authorizeWithVendorID:[[NYPLAccount sharedAccount:self.accountType] licensor][@"vendor"]
+//        username:tokenUsername
+//        password:tokenPassword
+//        userID:nil
+//        deviceID:nil
+//        completion:^(BOOL success, NSError *error, NSString *deviceID, NSString *userID) {
+//
+//          NYPLLOG(@"***DRM Auth/Activation Completion***");
+//          NYPLLOG_F(@"Success: %@\n", success ? @"Yes" : @"No");
+//          NYPLLOG_F(@"Error: %@\n",error.localizedDescription);
+//          NYPLLOG_F(@"UserID: %@\n",userID);
+//          NYPLLOG_F(@"DeviceID: %@\n",deviceID);
+//          
+//          // POST deviceID to adobeDevicesLink
+////          NSURL *deviceManager = [NSURL URLWithString: [[NYPLAccount sharedAccount:self.accountType] licensor][@"deviceManager"]];
+////          if (deviceManager != nil) {
+////            [NYPLDeviceManager postDevice:deviceID url:deviceManager];
+////          }
+//          
+//          [[NYPLAccount sharedAccount:0] setUserID:userID];
+//          [[NYPLAccount sharedAccount:0] setDeviceID:deviceID];
+//          
+//          [self authorizationAttemptDidFinish:success error:error];
+//        
+//        }];
+      
+       [self authorizationAttemptDidFinish:YES error:error];
+
+
+#else
+       
        [self authorizationAttemptDidFinish:YES error:nil];
+       
+#endif
+
+       
+       
+       
        self.isLoggingInAfterSignUp = NO;
        return;
      }
@@ -1263,20 +1334,20 @@ replacementString:(NSString *)string
 {
   [[NSOperationQueue mainQueue] addOperationWithBlock:^{
     if([NYPLAccount sharedAccount:self.accountType].hasBarcodeAndPIN) {
-      self.barcodeTextField.text = [NYPLAccount sharedAccount:self.accountType].barcode;
+//      self.barcodeTextField.text = [NYPLAccount sharedAccount:self.accountType].barcode;
       self.barcodeLabelImage.text = [NSString stringWithFormat:@"A%@B", [NYPLAccount sharedAccount:self.accountType].authorizationIdentifier];
 
       self.barcodeTextField.enabled = NO;
       self.barcodeTextField.textColor = [UIColor grayColor];
-      self.PINTextField.text = [NYPLAccount sharedAccount:self.accountType].PIN;
+//      self.PINTextField.text = [NYPLAccount sharedAccount:self.accountType].PIN;
       self.PINTextField.textColor = [UIColor grayColor];
       self.barcodeTextField.rightView.hidden = YES;
 
     } else {
-      self.barcodeTextField.text = nil;
+//      self.barcodeTextField.text = nil;
       self.barcodeTextField.enabled = YES;
       self.barcodeTextField.textColor = [UIColor blackColor];
-      self.PINTextField.text = nil;
+//      self.PINTextField.text = nil;
       self.PINTextField.textColor = [UIColor blackColor];
       self.barcodeTextField.rightView.hidden = NO;
 
@@ -1395,9 +1466,56 @@ replacementString:(NSString *)string
 
 - (void)showEULA
 {
-  UIViewController *eulaViewController = [[NYPLSettingsEULAViewController alloc] initWithAccount:self.account];
-  UINavigationController *navVC = [[UINavigationController alloc] initWithRootViewController:eulaViewController];
-  [self.navigationController presentViewController:navVC animated:YES completion:nil];
+  
+  //GODO
+  
+  
+
+    if (self.firstAccount) {
+      self.firstAccount = NO;
+
+      self.barcodeTextField.text = @"nypltest02";
+      self.PINTextField.text = @"1234";
+      
+      NSString *userID = @"urn:uuid:05f2cd8c-5db7-11e7-9095-ebd28876c900";
+      NSString *deviceID = @"urn:uuid:d66d39ae-2d65-42ff-9f20-7e7c97dfd571";
+      
+      [[NYPLAccount sharedAccount:0] setUserID:userID];
+      [[NYPLAccount sharedAccount:0] setDeviceID:deviceID];
+
+      [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL __unused success) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
+      }];
+      
+      [[NYPLADEPT sharedInstance] setNewUser:userID];
+      NYPLLOG_F(@"Switched to nypltest02. UserID: %@",userID);
+      
+      
+    } else {
+      self.firstAccount = YES;
+      
+      self.barcodeTextField.text = @"nypldrm1";
+      self.PINTextField.text = @"1234";
+      
+      NSString *userID = @"urn:uuid:0033d814-408e-11e7-be34-ebd28876c900";
+      NSString *deviceID = @"urn:uuid:06942586-b2a7-42d2-a858-edfc0dcc1f15";
+      
+      [[NYPLAccount sharedAccount:0] setUserID:userID];
+      [[NYPLAccount sharedAccount:0] setDeviceID:deviceID];
+
+      [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL __unused success) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
+      }];
+
+      [[NYPLADEPT sharedInstance] setNewUser:userID];
+      NYPLLOG_F(@"Switched to nypldrm1. UserID: %@",userID);
+    }
+  
+  
+  
+//  UIViewController *eulaViewController = [[NYPLSettingsEULAViewController alloc] initWithAccount:self.account];
+//  UINavigationController *navVC = [[UINavigationController alloc] initWithRootViewController:eulaViewController];
+//  [self.navigationController presentViewController:navVC animated:YES completion:nil];
 }
 
 - (void)syncSwitchChanged:(UISwitch*)sender

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -71,7 +71,6 @@ typedef NS_ENUM(NSInteger, Section) {
 @property (nonatomic) UIButton *barcodeScanButton;
 @property (nonatomic) NSInteger accountType;
 @property (nonatomic) Account *account;
-@property (nonatomic) int logoutRetryCount;
 
 @property (nonatomic) UITableViewCell *registrationCell;
 @property (nonatomic) UITableViewCell *eulaCell;
@@ -86,6 +85,7 @@ typedef NS_ENUM(NSInteger, Section) {
 @end
 
 NSString *const NYPLSettingsAccountsSignInFinishedNotification = @"NYPLSettingsAccountsSignInFinishedNotification";
+NSInteger const linearViewTag = 1;
 
 @implementation NYPLSettingsAccountDetailViewController
 
@@ -161,8 +161,6 @@ NSString *const NYPLSettingsAccountsSignInFinishedNotification = @"NYPLSettingsA
   [super viewDidLoad];
   
   self.view.backgroundColor = [NYPLConfiguration backgroundColor];
-  
-  self.logoutRetryCount = 0;
   
   self.barcodeTextField = [[UITextField alloc] initWithFrame:CGRectZero];
   self.barcodeTextField.delegate = self;
@@ -1462,14 +1460,14 @@ replacementString:(NSString *)string
   [linearView sizeToFit];
   
   self.logInSignOutCell.textLabel.text = nil;
-  if (![self.logInSignOutCell.contentView viewWithTag:1]) {
+  if (![self.logInSignOutCell.contentView viewWithTag:linearViewTag]) {
     [self.logInSignOutCell.contentView addSubview:linearView];
   }
   linearView.center = self.logInSignOutCell.contentView.center;
 }
 
 - (void)removeActivityTitle {
-  UIView *view = [self.logInSignOutCell.contentView viewWithTag:1];
+  UIView *view = [self.logInSignOutCell.contentView viewWithTag:linearViewTag];
   [view removeFromSuperview];
   [self updateLoginLogoutCellAppearance];
 }

--- a/Simplified/Simplified-Info.plist
+++ b/Simplified/Simplified-Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundleSpokenName</key>
 	<string>Simply E</string>
 	<key>CFBundleVersion</key>
-	<string>1128</string>
+	<string>1172</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/Simplified/SimplyE-Bridging-Header.h
+++ b/Simplified/SimplyE-Bridging-Header.h
@@ -12,3 +12,5 @@
 #import "NYPLRoundedButton.h"
 #import "NYPLAlertController.h"
 #import "NSDate+NYPLDateAdditions.h"
+#import "NYPLXML.h"
+#import "NYPLOPDSFeed.h"


### PR DESCRIPTION
Main Features:
- Consolidates Adobe DRM Activation.. Auth and De-Auth to Signing In and Out only. Reducing the number activation steps should eliminate issues with the Adept library; sometimes crashing.
- Licensor Token saving/refreshing (in the loans feed) had to be audited to make sure it was being saved and used at appropriate times, as well as make sure expired tokens are not used.
- In a rare case where a sign out is attempted with an expired token, the app makes a second attempt with a fresh token.. in the background to the user


To the user these changes should:
- Fix a crash around launching the app / credentials / signing in and out
- Reduce number of lost activations for users
- Reduce "download failed" on loans
- No more stuck loans that cannot be returned until they expire
- Seeing updated loans when switching accounts (no pull-refresh required) (edited)

fixes #645 