### PR TITLE
Bug device auth #673

### DIFF
--- a/Simplified/NYPLAccount.m
+++ b/Simplified/NYPLAccount.m
@@ -60,9 +60,8 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
     userIDKey = @"NYPLAccountUserIDKey";
     deviceIDKey = @"NYPLAccountDeviceIDKey";
     licensorKey = @"NYPLAccountLicensorKey";
-
-
   }
+
   return sharedAccount;
 }
 

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -421,7 +421,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
                        initWithStyle:UITableViewCellStyleDefault
                        reuseIdentifier:nil];
       Account *currentAccount = [[NYPLSettings sharedSettings] currentAccount];
-      if (currentAccount.eulaIsAccepted) {
+      if (currentAccount.eulaIsAccepted || [[NYPLAccount sharedAccount] hasBarcodeAndPIN]) {
         self.eulaCell.accessoryView = [[UIImageView alloc] initWithImage:
                                        [UIImage imageNamed:@"CheckboxOn"]];
         self.eulaCell.accessibilityLabel = NSLocalizedString(@"AccessibilityEULAChecked", nil);
@@ -621,6 +621,7 @@ replacementString:(NSString *)string
 - (void)updateLoginLogoutCellAppearance
 {
   if (self.isCurrentlySigningIn) {
+    self.eulaCell.userInteractionEnabled = NO;
     return;
   }
   if([[NYPLAccount sharedAccount] hasBarcodeAndPIN]) {
@@ -935,6 +936,8 @@ completionHandler:(void (^)())handler
       }];
 
     } else {
+      [[NYPLAccount sharedAccount] removeAll];
+      [self accountDidChange];
       [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
       [self showLoginAlertWithError:error];
     }

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -621,7 +621,6 @@ replacementString:(NSString *)string
 - (void)updateLoginLogoutCellAppearance
 {
   if (self.isCurrentlySigningIn) {
-    self.eulaCell.userInteractionEnabled = NO;
     return;
   }
   if([[NYPLAccount sharedAccount] hasBarcodeAndPIN]) {

--- a/Simplified/NYPLAppDelegate.m
+++ b/Simplified/NYPLAppDelegate.m
@@ -35,11 +35,21 @@
 - (BOOL)application:(__attribute__((unused)) UIApplication *)application
 didFinishLaunchingWithOptions:(__attribute__((unused)) NSDictionary *)launchOptions
 {
-  NSArray *const paths =
-  NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
-  NYPLLOG(paths);
-  
-  
+  // App does not currently handle DRM authorization when
+  // keychain items persist from previous app installs.
+  if (![[NSUserDefaults standardUserDefaults] objectForKey:userHasSeenWelcomeScreenKey]) {
+    NYPLLOG(@"Fresh install detected. Purging any keychain items...");
+    NSArray *secItemClasses = @[(__bridge id)kSecClassGenericPassword,
+                                (__bridge id)kSecClassInternetPassword,
+                                (__bridge id)kSecClassCertificate,
+                                (__bridge id)kSecClassKey,
+                                (__bridge id)kSecClassIdentity];
+    for (id secItemClass in secItemClasses) {
+      NSDictionary *spec = @{(__bridge id)kSecClass: secItemClass};
+      SecItemDelete((__bridge CFDictionaryRef)spec);
+    }
+  }
+
   // This is normally not called directly, but we put all programmatic appearance setup in
   // NYPLConfiguration's class initializer.
   [NYPLConfiguration initialize];

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -187,7 +187,7 @@ didFinishDownloadingToURL:(NSURL *const)location
           
         } else {
           
-          NYPLLOG_F(@"Download attempt for book. userID: %@",[[NYPLAccount sharedAccount] userID]);
+          NYPLLOG_F(@"Download finished. Fulfilling with userID: %@",[[NYPLAccount sharedAccount] userID]);
           [[NYPLADEPT sharedInstance]
            fulfillWithACSMData:ACSMData
            tag:book.identifier
@@ -751,12 +751,17 @@ didDismissWithButtonIndex:(NSInteger const)buttonIndex
   
 - (void)adept:(__attribute__((unused)) NYPLADEPT *)adept didCancelDownloadWithTag:(NSString *)tag
 {
-   [[NYPLBookRegistry sharedRegistry]
-    setState:NYPLBookStateDownloadNeeded forIdentifier:tag];
-   
-   [self broadcastUpdate];
+  [[NYPLBookRegistry sharedRegistry]
+   setState:NYPLBookStateDownloadNeeded forIdentifier:tag];
+
+  [self broadcastUpdate];
 }
-  
+
+- (void)didIgnoreFulfillmentWithNoAuthorizationPresent
+{
+  [NYPLAccountSignInViewController authorizeUsingExistingBarcodeAndPinWithCompletionHandler:nil];
+}
+
 #endif
 
 @end

--- a/Simplified/NYPLSettings.h
+++ b/Simplified/NYPLSettings.h
@@ -3,6 +3,8 @@ static NSString *const NYPLCurrentAccountDidChangeNotification = @"NYPLCurrentAc
 static NSString *const NYPLSyncBeganNotification = @"NYPLSyncBeganNotification";
 static NSString *const NYPLSyncEndedNotification = @"NYPLSyncEndedNotification";
 
+static NSString *const userHasSeenWelcomeScreenKey = @"NYPLUserHasSeenWelcomeScreenKey";
+
 typedef NS_ENUM(NSInteger, NYPLSettingsRenderingEngine) {
   NYPLSettingsRenderingEngineAutomatic,
   NYPLSettingsRenderingEngineReadium

--- a/Simplified/NYPLSettings.m
+++ b/Simplified/NYPLSettings.m
@@ -16,8 +16,6 @@ static NSString *const renderingEngineKey = @"NYPLSettingsRenderingEngine";
 
 static NSString *const legacyUserAcceptedEULAKey = @"NYPLSettingsUserAcceptedEULA";
 
-static NSString *const userHasSeenWelcomeScreenKey = @"NYPLUserHasSeenWelcomeScreenKey";
-
 //static NSString *const settingsSynchronizeAnnotationsKey = @"NYPLSettingsSynchronizeAnnotationsKey";
 
 static NSString *const userPresentedAgeCheckKey = @"NYPLUserPresentedAgeCheckKey";


### PR DESCRIPTION
Fixes crash caused by a nil parameter. The source of the flow turns out to be from old keychain credentials persisting across app installs. In those cases the device is considered "logged in" but is not actually DRM-authorized with Adobe.

This PR both prevents keychain items from persisting across app deletions and re-installs, and also has a one-time attempt to authorize any devices that are in this current state. It will purge the account if that retry fails, forcing the user to explicitly log back in.

fixes #673 
The related change to the adept submodule:
[PR 12](https://github.com/NYPL-Simplified/DRM-iOS-Adobe/pull/12)