### PR TITLE
Bug annotations #672

### DIFF
--- a/Simplified/NYPLAnnotations.swift
+++ b/Simplified/NYPLAnnotations.swift
@@ -298,11 +298,19 @@ final class NYPLAnnotations: NSObject {
   
   class var headers: [String:String]
   {
-    let authenticationString = "\(NYPLAccount.shared().barcode!):\(NYPLAccount.shared().pin!)"
-    let authenticationData:Data = authenticationString.data(using: String.Encoding.ascii)!
-    let authenticationValue = "Basic \(authenticationData.base64EncodedString(options: Data.Base64EncodingOptions.lineLength64Characters))"
-    
-    return ["Authorization" : "\(authenticationValue)",
+    if let barcode = NYPLAccount.shared().barcode, let pin = NYPLAccount.shared().pin {
+      let authenticationString = "\(barcode):\(pin)"
+      if let authenticationData = authenticationString.data(using: String.Encoding.ascii) {
+        let authenticationValue = "Basic \(authenticationData.base64EncodedString(options: Data.Base64EncodingOptions.lineLength64Characters))"
+        return ["Authorization" : "\(authenticationValue)",
+                "Content-Type" : "application/json"]
+      } else {
+        Log.error(#file, "Error formatting auth headers.")
+      }
+    } else {
+      Log.error(#file, "Attmpeted to create authorization header without a barcode or pin.")
+    }
+    return ["Authorization" : "",
             "Content-Type" : "application/json"]
   }
 }


### PR DESCRIPTION
Fixes #672  crash when accessing headers var getter.
Should resolve bugsnag bug referenced ticket.

Whatever cause of missing credential header, passing an empty field as the fail-case should allow server and networking method to handle error more gracefully.