### PR TITLE
Card Creator review and modal dismissal

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -74,7 +74,7 @@ CHECKOUT OPTIONS:
     :commit: 7cdcdf6327936080eac728566cc86bab5e914700
     :git: https://github.com/NYPL-Simplified/helpstack-ios
   NYPLCardCreator:
-    :commit: 5c2b6928bc74d32f0f165cb80455e4e505430bd7
+    :commit: 0225028ae6ccad34eeb4e375bb02127c8a0bd5c1
     :git: https://github.com/NYPL-Simplified/CardCreator-iOS.git
 
 SPEC CHECKSUMS:

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -778,7 +778,6 @@ replacementString:(NSString *)string
          
 #endif
 
-         self.isLoggingInAfterSignUp = NO;
          return;
        }
        

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -84,7 +84,6 @@ typedef NS_ENUM(NSInteger, Section) {
 
 @end
 
-NSString *const NYPLSettingsAccountsSignInFinishedNotification = @"NYPLSettingsAccountsSignInFinishedNotification";
 NSInteger const linearViewTag = 1;
 
 @implementation NYPLSettingsAccountDetailViewController
@@ -502,12 +501,7 @@ NSInteger const linearViewTag = 1;
    completionHandler:^(NSData *data,
                        NSURLResponse *const response,
                        NSError *const error) {
-     
-     if (self.isLoggingInAfterSignUp) {
-       [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSettingsAccountsSignInFinishedNotification
-                                                           object:self];
-     }
-     
+
      NSInteger const statusCode = ((NSHTTPURLResponse *) response).statusCode;
 
      if(statusCode == 200) {
@@ -570,7 +564,6 @@ NSInteger const linearViewTag = 1;
        
 #endif
 
-       self.isLoggingInAfterSignUp = NO;
        return;
      }
      
@@ -603,8 +596,6 @@ NSInteger const linearViewTag = 1;
    [NYPLAlertController alertWithTitle:@"SettingsAccountViewControllerLoginFailed" error:error]
                                                                   animated:YES
                                                                 completion:nil];
-  [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSettingsAccountsSignInFinishedNotification
-                                                      object:self];
   [self removeActivityTitle];
 }
 


### PR DESCRIPTION
Continuation of work in:
https://github.com/NYPL-Simplified/Simplified-iOS/pull/641

The UX was re-tested against both master branches.

Resolves #595 

User must now explicitly dismiss the final review screen during Card Creation. PR also removes coupling of main app and the library. Changes to Card Creator repo are merged.