### PR TITLE
Increased network timeouts for sign in/out. Re-adding protection for …

### DIFF
--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -1,6 +1,7 @@
 @import LocalAuthentication;
 @import NYPLCardCreator;
 
+#import "Bugsnag.h"
 #import "NYPLAccount.h"
 #import "NYPLAlertController.h"
 #import "NYPLBasicAuth.h"
@@ -139,7 +140,7 @@ NSInteger const linearViewTag = 1;
   NSURLSessionConfiguration *const configuration =
     [NSURLSessionConfiguration ephemeralSessionConfiguration];
   
-  configuration.timeoutIntervalForResource = 10.0;
+  configuration.timeoutIntervalForResource = 20.0;
   
   self.session = [NSURLSession
                   sessionWithConfiguration:configuration
@@ -382,7 +383,7 @@ NSInteger const linearViewTag = 1;
   NSMutableURLRequest *const request =
   [NSMutableURLRequest requestWithURL:[[NSURL URLWithString:[account catalogUrl]] URLByAppendingPathComponent:@"loans"]];
   
-  request.timeoutInterval = 8.0;
+  request.timeoutInterval = 20.0;
   
   NSURLSessionDataTask *const task =
   [self.session
@@ -403,14 +404,15 @@ NSInteger const linearViewTag = 1;
      
      } else {
 
-       [self removeActivityTitle];
-       [[UIApplication sharedApplication] endIgnoringInteractionEvents];
        [self presentViewController:[NYPLAlertController
                                     alertWithTitle:@"SettingsAccountViewControllerLogoutFailed"
                                     message:@"TimedOut"]
                           animated:YES
                         completion:nil];
      }
+
+     [self removeActivityTitle];
+     [[UIApplication sharedApplication] endIgnoringInteractionEvents];
    }];
 
   [task resume];
@@ -423,13 +425,17 @@ NSInteger const linearViewTag = 1;
   [self setupTableData];
   [self.tableView reloadData];
   [self removeActivityTitle];
-  
+  [[UIApplication sharedApplication] endIgnoringInteractionEvents];
+
 #endif
   
 }
 
 - (void)deauthorizeDevice
 {
+
+#if defined(FEATURE_DRM_CONNECTOR)
+
   void (^afterDeauthorization)() = ^() {
     
     [[NYPLMyBooksDownloadCenter sharedDownloadCenter] reset:self.accountType];
@@ -442,10 +448,12 @@ NSInteger const linearViewTag = 1;
 
   NSDictionary *licensor = [[NYPLAccount sharedAccount:self.accountType] licensor];
   if (!licensor) {
-    NYPLLOG(@"No Licensor received or parsed from OPDS Loans feed");
+    NYPLLOG(@"No Licensor available to deauthorize device. Signing out NYPLAccount creds anyway.");
+    [self bugsnagLogInvalidLicensor];
+    afterDeauthorization();
     return;
   }
-  
+
   NSMutableArray *licensorItems = [[licensor[@"clientToken"] stringByReplacingOccurrencesOfString:@"\n" withString:@""] componentsSeparatedByString:@"|"].mutableCopy;
   NSString *tokenPassword = [licensorItems lastObject];
   [licensorItems removeLastObject];
@@ -482,10 +490,12 @@ NSInteger const linearViewTag = 1;
          [NYPLDeviceManager deleteDevice:[[NYPLAccount sharedAccount:self.accountType] deviceID] url:deviceManager];
        }
      }
-     [self removeActivityTitle];
-     [[UIApplication sharedApplication] endIgnoringInteractionEvents];
+
      afterDeauthorization();
    }];
+  
+#endif
+
 }
 
 - (void)validateCredentials
@@ -639,6 +649,18 @@ NSInteger const linearViewTag = 1;
       [self showLoginAlertWithError:error];
     }
   }];
+}
+
+- (void)bugsnagLogInvalidLicensor
+{
+  [Bugsnag notifyError:[NSError errorWithDomain:@"org.nypl.labs.SimplyE" code:3 userInfo:nil]
+                 block:^(BugsnagCrashReport * _Nonnull report) {
+                   report.context = @"NYPLSettingsAccountDetailViewController";
+                   report.severity = BSGSeverityWarning;
+                   report.errorMessage = @"No Valid Licensor available to deauthorize device. Signing out NYPLAccount credentials anyway with no message to the user.";
+                   NSDictionary *metadata = @{@"accountTypeID" : @(self.accountType)};
+                   [report addMetadata:metadata toTabWithName:@"Extra Data"];
+                 }];
 }
 
 #pragma mark


### PR DESCRIPTION
…non-DRM builds.

fixes #666 

Meant to still allow sign in/out during backend issues like when NYPL ILS experienced issues for several days that made loans responses 15+ seconds. Keeps the timeout reasonable for a process that disables the UI on screen.