### PR TITLE
Allow scaling of logos on accounts list to correct dimensions #613

### DIFF
--- a/Simplified/NYPLBook.m
+++ b/Simplified/NYPLBook.m
@@ -91,10 +91,10 @@ static NSString *const AlternateURLKey = @"alternate";
   for (int i = 0; i < (int)entry.authorStrings.count; i++) {
     if ((int)entry.authorLinks.count > i) {
       [authors addObject:[[NYPLBookAuthor alloc] initWithAuthorName:entry.authorStrings[i]
-                                                   relatedBooksLink:entry.authorLinks[i].href]];
+                                                   relatedBooksURL:entry.authorLinks[i].href]];
     } else {
       [authors addObject:[[NYPLBookAuthor alloc] initWithAuthorName:entry.authorStrings[i]
-                                                   relatedBooksLink:nil]];
+                                                   relatedBooksURL:nil]];
     }
   }
 
@@ -334,14 +334,14 @@ static NSString *const AlternateURLKey = @"alternate";
         NSURL *url = [NSURL URLWithString:authorLinks[i]];
         if (url) {
           [authors addObject:[[NYPLBookAuthor alloc] initWithAuthorName:authorStrings[i]
-                                                       relatedBooksLink:authorLinks[i]]];
+                                                       relatedBooksURL:url]];
         } else {
           [authors addObject:[[NYPLBookAuthor alloc] initWithAuthorName:authorStrings[i]
-                                                       relatedBooksLink:nil]];
+                                                       relatedBooksURL:nil]];
         }
       } else {
         [authors addObject:[[NYPLBookAuthor alloc] initWithAuthorName:authorStrings[i]
-                                                     relatedBooksLink:nil]];
+                                                     relatedBooksURL:nil]];
       }
     }
   } else {
@@ -432,7 +432,7 @@ static NSString *const AlternateURLKey = @"alternate";
 - (NSArray *)authorLinkArray {
   NSMutableArray *array = [[NSMutableArray alloc] init];
   for (NYPLBookAuthor *auth in self.bookAuthors) {
-    [array addObject:auth.relatedBooksLink.absoluteString];
+    [array addObject:auth.relatedBooksURL.absoluteString];
   }
   return array;
 }

--- a/Simplified/NYPLBookAuthor.swift
+++ b/Simplified/NYPLBookAuthor.swift
@@ -3,10 +3,10 @@ import Foundation
 final class NYPLBookAuthor: NSObject {
 
   let name: String
-  let relatedBooksLink: URL?
+  let relatedBooksURL: URL?
 
-  init(authorName: String, relatedBooksLink: URL?) {
+  init(authorName: String, relatedBooksURL: URL?) {
     self.name = authorName
-    self.relatedBooksLink = relatedBooksLink
+    self.relatedBooksURL = relatedBooksURL
   }
 }

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -62,7 +62,7 @@ static NSString *const RecordsKey = @"records";
   
   void (^handlerBlock)(BOOL success)= ^(BOOL success){
     if(success) {
-      [[NYPLBookRegistry sharedRegistry] save];
+      [self save];
     } else {
     }};
   
@@ -309,7 +309,7 @@ static NSString *const RecordsKey = @"records";
 {
   [self syncWithCompletionHandler:^(BOOL success) {
     if(success) {
-      [[NYPLBookRegistry sharedRegistry] save];
+      [self save];
     } else {
       [[[UIAlertView alloc]
         initWithTitle:NSLocalizedString(@"SyncFailed", nil)

--- a/Simplified/NYPLSettingsAccountsList.swift
+++ b/Simplified/NYPLSettingsAccountsList.swift
@@ -163,7 +163,7 @@ class NYPLSettingsAccountsTableViewController: UIViewController, UITableViewDele
       imageView = UIImageView(image: #imageLiteral(resourceName: "LibraryLogoMagic"))
     }
     
-    imageView.contentMode = .center
+    imageView.contentMode = .scaleAspectFit
     
     let textLabel = UILabel()
     textLabel.font = UIFont.systemFont(ofSize: 14)


### PR DESCRIPTION
This PR addresses issue #613 , by allowing library logos that are too small, to scale up to the correct dimensions on the accounts list page