### PR TITLE
'Report an Issue' frame cut-off on iPad #640

### DIFF
--- a/Simplified/NYPLReportIssueViewController.swift
+++ b/Simplified/NYPLReportIssueViewController.swift
@@ -147,43 +147,33 @@ class NYPLReportIssueViewController: UITableViewController, UITextFieldDelegate,
   }
   
   override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-    
-    if HSAppearance.isIPad()
-    {
-      if(indexPath.row == 0){
-        return 44.0;
-      }else if(indexPath.row == 1){
-        return self.view.frame.size.height - 44.0;
-      }else{
-        return 44.0;
-      }
+
+    // height for the subject line of the message
+    let subjectHeight:CGFloat = 44.0
+
+    // height for the actual message body, it gets increased as we increase device screen size
+    var messageHeight:CGFloat = subjectHeight
+
+    let iPhonePadding:CGFloat  = 155.0
+    let iPadPadding:CGFloat    = 200.0
+
+    if indexPath.row == 0 {
+      return subjectHeight
     }
-    else{
-      if(indexPath.row == 0) {
-        return 44.0;
+    // we're at the message body
+    else if indexPath.row == 1 {
+      // is iPad
+      if HSAppearance.isIPad() {
+        messageHeight = messageHeight + iPadPadding
       }
-      else if(indexPath.row == 1) {
-        var messageHeight:CGFloat;
-        //Instead, get the keyboard height and calculate the message field height
-        let orientation:UIDeviceOrientation = UIDevice.current.orientation;
-        if (UIDeviceOrientationIsLandscape(orientation))
-        {
-          messageHeight = 68.0;
-        }
-        else {
-          
-          if (HSAppearance.isTall()) {
-            messageHeight = 249.0;
-          }else{
-            messageHeight = 155.0 + 44.0;
-          }
-        }
-        // return self.view.bounds.size.height - 88.0;
-        return messageHeight;
-        
+      // is iPhone
+      else {
+        messageHeight = messageHeight + iPhonePadding
       }
+
+      return messageHeight
     }
-    
+
     return 0.0
   }
   


### PR DESCRIPTION
This PR addresses issue #640 , where the subject line would move up and out of view in the "Report an Issue" screen on the iPad, when the user tapped on the message body area beneath the subject line. The problem was that the message body was too tall on the iPad. The solution is to reduce the size of the message body on the "Report an Issue" screen. Doing this, however, creates some empty gray rows beneath the message body, which may not be "aesthetically pleasing" and might confuse the user. But at least we don't lose the subject line anymore. I will continue to investigate whether anything can be done about the gray rows.

iPad screen with code change, landscape
![8cbb6458-0817-4913-85b3-1a4fe4dd6b97](https://user-images.githubusercontent.com/1022275/29044365-57f95c58-7b7c-11e7-98df-bda1a5c3ac6b.PNG)

iPad screen with code change, portrait
![fb3717a2-c016-4896-a6ee-7f119f15979e](https://user-images.githubusercontent.com/1022275/29044389-6f94c050-7b7c-11e7-86e8-bafc10de68b8.PNG)
