### PR TITLE
Get pull-to-fresh activity indicator to hide correctly #697

### DIFF
--- a/Simplified/NYPLHoldsViewController.m
+++ b/Simplified/NYPLHoldsViewController.m
@@ -113,6 +113,7 @@
   [super viewWillAppear:animated];
   if([NYPLBookRegistry sharedRegistry].syncing == NO) {
     [self.refreshControl endRefreshing];
+    self.collectionView.contentOffset = CGPointZero;
     [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
   }
 }

--- a/Simplified/NYPLHoldsViewController.m
+++ b/Simplified/NYPLHoldsViewController.m
@@ -106,7 +106,11 @@
                        action:@selector(didSelectSearch)];
   self.searchButton.accessibilityLabel = NSLocalizedString(@"Search", nil);
   self.navigationItem.rightBarButtonItem = self.searchButton;
-  
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+  [super viewWillAppear:animated];
   if([NYPLBookRegistry sharedRegistry].syncing == NO) {
     [self.refreshControl endRefreshing];
     [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];

--- a/Simplified/NYPLMyBooksViewController.m
+++ b/Simplified/NYPLMyBooksViewController.m
@@ -157,16 +157,16 @@ typedef NS_ENUM(NSInteger, FacetSort) {
                        action:@selector(didSelectSearch)];
   self.searchButton.accessibilityLabel = NSLocalizedString(@"Search", nil);
   self.navigationItem.rightBarButtonItem = self.searchButton;
-  
-  if([NYPLBookRegistry sharedRegistry].syncing == NO) {
-    [self.refreshControl endRefreshing];
-    [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
-  }
 }
 
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
+  if([NYPLBookRegistry sharedRegistry].syncing == NO) {
+    [self.refreshControl endRefreshing];
+    self.collectionView.contentOffset = CGPointZero;
+    [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
+  }
   [self.navigationController setNavigationBarHidden:NO];
 }
 
@@ -378,12 +378,6 @@ OK:
        requestCredentialsUsingExistingBarcode:NO
        completionHandler:nil];
       [self.refreshControl endRefreshing];
-
-      // the following lines will force a screen refresh so the
-      // activity indicator doesn't stay stuck on the screen
-      [self viewDidLoad];
-      [self viewWillAppear:YES];
-
       [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
     }
   }

--- a/Simplified/NYPLMyBooksViewController.m
+++ b/Simplified/NYPLMyBooksViewController.m
@@ -378,6 +378,12 @@ OK:
        requestCredentialsUsingExistingBarcode:NO
        completionHandler:nil];
       [self.refreshControl endRefreshing];
+
+      // the following lines will force a screen refresh so the
+      // activity indicator doesn't stay stuck on the screen
+      [self viewDidLoad];
+      [self viewWillAppear:YES];
+
       [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
     }
   }


### PR DESCRIPTION
This PR addresses issue #697 , by hiding the activity indicator after the user dismisses the login prompt on either the My Books or Reservations tab. It also fixes a related problem where, if the user had an account with books, the Collection View would not move up to the top of the screen. In both cases, either an empty View or a Collection View with books now moves up to the top of screen, properly hiding the activity indicator behind it.