### PR TITLE
UIAlertController popover anchor bug

### DIFF
--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -89,11 +89,16 @@
 
 - (void)switchLibrary
 {
-  
-  
   NYPLCatalogFeedViewController *viewController = (NYPLCatalogFeedViewController *)self.visibleViewController;
 
-  UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"PickYourLibrary", nil) message:nil preferredStyle:(UIAlertControllerStyleActionSheet)];
+  UIAlertControllerStyle style;
+  if (viewController) {
+    style = UIAlertControllerStyleActionSheet;
+  } else {
+    style = UIAlertControllerStyleAlert;
+  }
+
+  UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"PickYourLibrary", nil) message:nil preferredStyle:(style)];
   alert.popoverPresentationController.barButtonItem = viewController.navigationItem.leftBarButtonItem;
   alert.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp;
   

--- a/Simplified/NYPLHoldsNavigationController.m
+++ b/Simplified/NYPLHoldsNavigationController.m
@@ -64,7 +64,14 @@
 {
   NYPLHoldsViewController *viewController = (NYPLHoldsViewController *)self.visibleViewController;
 
-  UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"PickYourLibrary", nil) message:nil preferredStyle:(UIAlertControllerStyleActionSheet)];
+  UIAlertControllerStyle style;
+  if (viewController) {
+    style = UIAlertControllerStyleActionSheet;
+  } else {
+    style = UIAlertControllerStyleAlert;
+  }
+
+  UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"PickYourLibrary", nil) message:nil preferredStyle:(style)];
   alert.popoverPresentationController.barButtonItem = viewController.navigationItem.leftBarButtonItem;
   alert.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp;
   

--- a/Simplified/NYPLMyBooksNavigationController.m
+++ b/Simplified/NYPLMyBooksNavigationController.m
@@ -66,8 +66,15 @@
 - (void) switchLibrary
 {
   NYPLMyBooksViewController *viewController = (NYPLMyBooksViewController *)self.visibleViewController;
-  
-  UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"PickYourLibrary", nil) message:nil preferredStyle:(UIAlertControllerStyleActionSheet)];
+
+  UIAlertControllerStyle style;
+  if (viewController) {
+    style = UIAlertControllerStyleActionSheet;
+  } else {
+    style = UIAlertControllerStyleAlert;
+  }
+
+  UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"PickYourLibrary", nil) message:nil preferredStyle:(style)];
   alert.popoverPresentationController.barButtonItem = viewController.navigationItem.leftBarButtonItem;
   alert.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp;
   


### PR DESCRIPTION
Update UIAlertController's to protect against possible nil that anchors iPad-style ...crashes when presenting.

fixes #704 

3 instances of UIAlertController that could produce this bug; when the visible view controller is cast and ends up being nil, the bar button anchor would not be set, triggering this exact exception and trace.