### PR TITLE
Update account sign out to allow edge case of user-changed credentials.

### DIFF
--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -402,11 +402,10 @@ NSInteger const linearViewTag = 1;
        [self deauthorizeDevice];
 
      } else {
-       [self showLogoutAlertWithErrorCode:statusCode];
+       [self showLogoutAlertWithError:error];
+       [self removeActivityTitle];
+       [[UIApplication sharedApplication] endIgnoringInteractionEvents];
      }
-
-     [self removeActivityTitle];
-     [[UIApplication sharedApplication] endIgnoringInteractionEvents];
    }];
 
   [task resume];
@@ -431,6 +430,8 @@ NSInteger const linearViewTag = 1;
 #if defined(FEATURE_DRM_CONNECTOR)
 
   void (^afterDeauthorization)() = ^() {
+    [self removeActivityTitle];
+    [[UIApplication sharedApplication] endIgnoringInteractionEvents];
     
     [[NYPLMyBooksDownloadCenter sharedDownloadCenter] reset:self.accountType];
     [[NYPLBookRegistry sharedRegistry] reset:self.accountType];
@@ -604,21 +605,18 @@ NSInteger const linearViewTag = 1;
   [self removeActivityTitle];
 }
 
-- (void)showLogoutAlertWithErrorCode:(NSInteger)code
+- (void)showLogoutAlertWithError:(NSError *)error
 {
-  NSString *title;
-  NSString *message;
-  if (code == 401) {
+  NSString *title; NSString *message;
+  if (error.code == 401) {
     title = @"Unexpected Credentials";
     message = @"Your username or password may have changed since the last time you logged in.\n\nIf you believe this is an error, please contact your library.";
     [self deauthorizeDevice];
   } else {
     title = @"SettingsAccountViewControllerLogoutFailed";
-    message = @"TimedOut";
+    message = error.localizedDescription;
   }
-  [self presentViewController:[NYPLAlertController
-                               alertWithTitle:title
-                               message:message]
+  [self presentViewController:[NYPLAlertController alertWithTitle:title message:message]
                      animated:YES
                    completion:nil];
 }

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -400,14 +400,9 @@ NSInteger const linearViewTag = 1;
        NYPLLOG_F(@"\nLicensor Token Updated: %@\nFor account: %@",loansFeed.licensor[@"clientToken"],[NYPLAccount sharedAccount:self.accountType].userID);
        
        [self deauthorizeDevice];
-     
-     } else {
 
-       [self presentViewController:[NYPLAlertController
-                                    alertWithTitle:@"SettingsAccountViewControllerLogoutFailed"
-                                    message:@"TimedOut"]
-                          animated:YES
-                        completion:nil];
+     } else {
+       [self showLogoutAlertWithErrorCode:statusCode];
      }
 
      [self removeActivityTitle];
@@ -607,6 +602,25 @@ NSInteger const linearViewTag = 1;
                                                                   animated:YES
                                                                 completion:nil];
   [self removeActivityTitle];
+}
+
+- (void)showLogoutAlertWithErrorCode:(NSInteger)code
+{
+  NSString *title;
+  NSString *message;
+  if (code == 401) {
+    title = @"Unexpected Credentials";
+    message = @"Your username or password may have changed since the last time you logged in.\n\nIf you believe this is an error, please contact your library.";
+    [self deauthorizeDevice];
+  } else {
+    title = @"SettingsAccountViewControllerLogoutFailed";
+    message = @"TimedOut";
+  }
+  [self presentViewController:[NYPLAlertController
+                               alertWithTitle:title
+                               message:message]
+                     animated:YES
+                   completion:nil];
 }
 
 - (void)authorizationAttemptDidFinish:(BOOL)success error:(NSError *)error


### PR DESCRIPTION
fixes #709 

Fixes: user could not sign out of an account that had its credentials changed.