### PR TITLE
Fix iOS 11 blank pages by keeping callout bar

### DIFF
--- a/Simplified/NYPLReaderReadiumView.m
+++ b/Simplified/NYPLReaderReadiumView.m
@@ -93,26 +93,6 @@ static void generateTOCElements(NSArray *const navigationElements,
   }
 }
 
-// The idea for this was taken from here:
-// http://stackoverflow.com/a/34679880
-//
-// We must use this approach to disable text selection beause "user-select: none;"
-// breaks bookmarking in Readium due to a bug in WebKit:
-// https://bugs.chromium.org/p/chromium/issues/detail?id=263813
-
-static void removeCalloutBarFromSuperviewStartingFromView(UIView *const view)
-{
-  // This seems to be the only reliable way of finding the correct view.
-  if([view isMemberOfClass:[UIView class]] && CGRectIsEmpty(view.frame))
-  {
-    [view removeFromSuperview];
-  } else {
-    for(UIView *const subview in [view subviews]) {
-      removeCalloutBarFromSuperviewStartingFromView(subview);
-    }
-  }
-}
-
 @implementation NYPLReaderReadiumView
 
 - (instancetype)initWithFrame:(CGRect const)frame
@@ -168,9 +148,6 @@ static void removeCalloutBarFromSuperviewStartingFromView(UIView *const view)
      [NSString stringWithFormat:
       @"http://127.0.0.1:%d/simplified-readium/reader.html",
       self.server.port]]]];
-  
-  // Disable text selection.
-  removeCalloutBarFromSuperviewStartingFromView(self.webView);
   
   [self addObservers];
   


### PR DESCRIPTION
@gioneill Please merge this after reviewing it as I will be unable to do so. Thank you!

---

The code that hunted around the internals of the web view and removed the callout bar was inadvertently removing more important things on iOS 11. After confirming we no longer need to remove the callout bar at all, I removed the code that deleted it thus fixing the iOS 11 issue and allowing copying, definition lookup, and sharing.

Fixes #646.