### PR TITLE
Ios11 font override#710

### DIFF
--- a/Simplified/UIFont+NYPLSystemFontOverride.m
+++ b/Simplified/UIFont+NYPLSystemFontOverride.m
@@ -7,13 +7,14 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
 
-+ (UIFont *)boldSystemFontOfSize:(CGFloat)fontSize {
-  return [UIFont fontWithName:[NYPLConfiguration boldSystemFontName] size:fontSize];
-}
-
-+ (UIFont *)systemFontOfSize:(CGFloat)fontSize {
-  return [UIFont fontWithName:[NYPLConfiguration systemFontName] size:fontSize];
-}
+//GODO change to a unique method name
+//+ (UIFont *)boldSystemFontOfSize:(CGFloat)fontSize {
+//  return [UIFont fontWithName:[NYPLConfiguration boldSystemFontName] size:fontSize];
+//}
+//
+//+ (UIFont *)systemFontOfSize:(CGFloat)fontSize {
+//  return [UIFont fontWithName:[NYPLConfiguration systemFontName] size:fontSize];
+//}
 
 #pragma clang diagnostic pop
 

--- a/Simplified/UIFont+NYPLSystemFontOverride.m
+++ b/Simplified/UIFont+NYPLSystemFontOverride.m
@@ -1,22 +1,7 @@
 #import "NYPLConfiguration.h"
-
 #import "UIFont+NYPLSystemFontOverride.h"
 
 @implementation UIFont (NYPLSystemFontOverride)
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
-
-//GODO change to a unique method name
-//+ (UIFont *)boldSystemFontOfSize:(CGFloat)fontSize {
-//  return [UIFont fontWithName:[NYPLConfiguration boldSystemFontName] size:fontSize];
-//}
-//
-//+ (UIFont *)systemFontOfSize:(CGFloat)fontSize {
-//  return [UIFont fontWithName:[NYPLConfiguration systemFontName] size:fontSize];
-//}
-
-#pragma clang diagnostic pop
 
 + (UIFont *)customFontForTextStyle:(UIFontTextStyle)style
 {


### PR DESCRIPTION
iOS 11 no longer looks to these extension method overrides, so they are being removed to universally use the SF system font across the app.

Custom methods still exist for using text styles and dynamic text.

fixes #710 