### PR TITLE
iPad split view #729

### DIFF
--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -825,7 +825,9 @@ replacementString:(NSString *)string
   // least work very well.
   
   [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-    if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+    if((UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) ||
+       (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact &&
+        self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact)) {
       CGSize const keyboardSize =
       [[notification userInfo][UIKeyboardFrameBeginUserInfoKey] CGRectValue].size;
       CGRect visibleRect = self.view.frame;

--- a/Simplified/NYPLAppDelegate.m
+++ b/Simplified/NYPLAppDelegate.m
@@ -97,7 +97,8 @@ didFinishLaunchingWithOptions:(__attribute__((unused)) NSDictionary *)launchOpti
   NYPLBookDetailViewController *modalBookController = [[NYPLBookDetailViewController alloc] initWithBook:book];
   NYPLRootTabBarController *tbc = (NYPLRootTabBarController *) self.window.rootViewController;
   
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ||
+     tbc.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
     if ([tbc.selectedViewController isKindOfClass:[UINavigationController class]])
       [tbc.selectedViewController pushViewController:modalBookController animated:YES];
   } else {

--- a/Simplified/NYPLBookCell.m
+++ b/Simplified/NYPLBookCell.m
@@ -154,7 +154,8 @@ NYPLBookCell *NYPLBookCellDequeue(UICollectionView *const collectionView,
   self = [super initWithFrame:frame];
   if(!self) return nil;
   
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  if(self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
+
     // This is no longer set by default as of iOS 8.0.
     self.contentView.autoresizingMask = (UIViewAutoresizingFlexibleHeight |
                                          UIViewAutoresizingFlexibleWidth);
@@ -192,7 +193,7 @@ NYPLBookCell *NYPLBookCellDequeue(UICollectionView *const collectionView,
 {
   CGRect frame = self.contentView.frame;
   
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  if(self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
     frame.size.width = CGRectGetWidth(frame) - 1;
     frame.size.height = CGRectGetHeight(frame) - 1;
     return frame;

--- a/Simplified/NYPLBookCellCollectionViewController.m
+++ b/Simplified/NYPLBookCellCollectionViewController.m
@@ -104,8 +104,8 @@
 
 - (void)viewWillTransitionToSize:(CGSize)size
        withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
-{
-  if(UI_USER_INTERFACE_IDIOM() != UIUserInterfaceIdiomPad) {
+{  
+  if(self.traitCollection.horizontalSizeClass != UIUserInterfaceSizeClassRegular) {
     return;
   }
   

--- a/Simplified/NYPLBookDetailView.m
+++ b/Simplified/NYPLBookDetailView.m
@@ -15,6 +15,7 @@
 #import "NYPLConfiguration.h"
 #import "NYPLBookDetailView.h"
 #import "NYPLConfiguration.h"
+#import "NYPLRootTabBarController.h"
 #import "NYPLOPDSFeed.h"
 #import "SimplyE-Swift.h"
 #import "UIFont+NYPLSystemFontOverride.h"
@@ -129,7 +130,8 @@ static NSString *DetailHTMLTemplate = nil;
   [self.contentView addSubview:self.footerTableView];
   [self.contentView addSubview:self.bottomFootnoteSeparator];
   
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
+     [[NYPLRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
     self.closeButton = [UIButton buttonWithType:UIButtonTypeSystem];
     [self.closeButton setTitle:NSLocalizedString(@"Close", nil) forState:UIControlStateNormal];
     [self.closeButton setTitleColor:[NYPLConfiguration mainColor] forState:UIControlStateNormal];
@@ -186,9 +188,12 @@ static NSString *DetailHTMLTemplate = nil;
   htmlString = [htmlString stringByReplacingOccurrencesOfString:@"</p>" withString:@"</span>"];
   NSData *htmlData = [htmlString dataUsingEncoding:NSUnicodeStringEncoding];
   NSDictionary *attributes = @{NSDocumentTypeDocumentAttribute:NSHTMLTextDocumentType};
-  NSAttributedString *atrString = [[NSAttributedString alloc] initWithData:htmlData options:attributes documentAttributes:nil error:nil];
-  self.summaryTextView.attributedText = atrString;
-  
+
+  [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+    NSAttributedString *atrString = [[NSAttributedString alloc] initWithData:htmlData options:attributes documentAttributes:nil error:nil];
+    self.summaryTextView.attributedText = atrString;
+  }];
+
   self.readMoreLabel = [[UIButton alloc] init];
   self.readMoreLabel.hidden = YES;
   self.readMoreLabel.titleLabel.textAlignment = NSTextAlignmentRight;
@@ -203,31 +208,32 @@ static NSString *DetailHTMLTemplate = nil;
 {
   UIVisualEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleLight];
   self.visualEffectView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
-  
+
   self.coverImageView = [[UIImageView alloc] init];
   self.coverImageView.contentMode = UIViewContentModeScaleAspectFit;
   self.blurCoverImageView = [[UIImageView alloc] init];
   self.blurCoverImageView.contentMode = UIViewContentModeScaleAspectFit;
   self.blurCoverImageView.alpha = 0.4f;
-  
+
   [[NYPLBookRegistry sharedRegistry]
    coverImageForBook:self.book handler:^(UIImage *image) {
      self.coverImageView.image = image;
      self.blurCoverImageView.image = image;
    }];
-  
+
   self.titleLabel = [[UILabel alloc] init];
   self.titleLabel.numberOfLines = 2;
   self.titleLabel.attributedText = NYPLAttributedStringForTitleFromString(self.book.title);
-  
+
   self.subtitleLabel = [[UILabel alloc] init];
   self.subtitleLabel.attributedText = NYPLAttributedStringForTitleFromString(self.book.subtitle);
   self.subtitleLabel.numberOfLines = 3;
-  
+
   self.authorsLabel = [[UILabel alloc] init];
   self.authorsLabel.autoresizingMask = UIViewAutoresizingFlexibleRightMargin;
   self.authorsLabel.numberOfLines = 2;
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
+      [[NYPLRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
     self.authorsLabel.text = self.book.authors;
   } else {
     self.authorsLabel.attributedText = NYPLAttributedStringForAuthorsFromString(self.book.authors);

--- a/Simplified/NYPLBookDetailViewController.m
+++ b/Simplified/NYPLBookDetailViewController.m
@@ -2,6 +2,7 @@
 #import "NYPLBookAcquisition.h"
 #import "NYPLBookDetailView.h"
 #import "NYPLBookRegistry.h"
+#import "NYPLCatalogFeedViewController.h"
 #import "NYPLCatalogLane.h"
 #import "NYPLCatalogLaneCell.h"
 #import "NYPLCatalogSearchViewController.h"
@@ -15,11 +16,9 @@
 #import "SimplyE-Swift.h"
 #import <PureLayout/PureLayout.h>
 
-#import "NYPLCatalogFeedViewController.h"
-
 #import "NYPLBookDetailViewController.h"
 
-@interface NYPLBookDetailViewController () <NYPLBookDetailViewDelegate, NYPLProblemReportViewControllerDelegate, NYPLCatalogLaneCellDelegate>
+@interface NYPLBookDetailViewController () <NYPLBookDetailViewDelegate, NYPLProblemReportViewControllerDelegate, NYPLCatalogLaneCellDelegate, UIAdaptivePresentationControllerDelegate>
 
 @property (nonatomic) NYPLBook *book;
 @property (nonatomic) NYPLBookDetailView *bookDetailView;
@@ -49,7 +48,8 @@
   [self.view addSubview:self.bookDetailView];
   [self.bookDetailView autoPinEdgesToSuperviewEdges];
   
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
+     [[NYPLRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
     self.modalPresentationStyle = UIModalPresentationFormSheet;
   }
   
@@ -88,7 +88,8 @@
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad && self.navigationController.viewControllers.count <= 1) {
+  if(self.presentingViewController.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular &&
+     self.navigationController.viewControllers.count <= 1) {
     self.navigationController.navigationBarHidden = YES;
   } else {
     self.navigationController.navigationBarHidden = NO;
@@ -172,14 +173,14 @@
 -(void)didSelectReportProblemForBook:(NYPLBook *)book sender:(id)sender
 {
   NYPLProblemReportViewController *problemVC = [[NYPLProblemReportViewController alloc] initWithNibName:@"NYPLProblemReportViewController" bundle:nil];
-  BOOL isIPad = [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
+  BOOL isIPad = self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular;
   problemVC.modalPresentationStyle = isIPad ? UIModalPresentationPopover : UIModalPresentationOverCurrentContext;
   problemVC.popoverPresentationController.sourceView = sender;
   problemVC.popoverPresentationController.sourceRect = ((UIView *)sender).bounds;
   problemVC.book = book;
   problemVC.delegate = self;
   UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:problemVC];
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  if(self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
     navController.modalPresentationStyle = UIModalPresentationFormSheet;
   }
   [self.navigationController pushViewController:problemVC animated:YES];
@@ -218,7 +219,7 @@
   }
   else if (index == 0) {
     if (viewController.navigationController.viewControllers.count <= 1 &&
-        UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+        viewController.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
       [navItem setBackBarButtonItem:[[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Catalog", nil) style:UIBarButtonItemStylePlain target:nil action:nil]];
     }
   }
@@ -228,14 +229,37 @@
   else if (index == 2) {
     [navItem setBackBarButtonItem:[[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"HoldsViewControllerTitle", nil) style:UIBarButtonItemStylePlain target:nil action:nil]];
   }
-  
+
   UIViewController *currentVCTab = [[[NYPLRootTabBarController sharedController] viewControllers] objectAtIndex:index];
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone || currentVCTab.presentedViewController != nil) {
+  // If a VC is already presented as a form sheet (iPad), we push the next one
+  // so the user can navigate through multiple book details without "stacking" them.
+  if((UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ||
+      viewController.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) ||
+     currentVCTab.presentedViewController != nil)
+  {
     [viewController.navigationController pushViewController:self animated:YES];
   } else {
     UINavigationController *navVC = [[UINavigationController alloc] initWithRootViewController:self];
     navVC.modalPresentationStyle = UIModalPresentationFormSheet;
     [viewController presentViewController:navVC animated:YES completion:nil];
+  }
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+  if (previousTraitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact &&
+      self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
+    [self.navigationController popViewControllerAnimated:NO];
+  }
+}
+
+- (UIModalPresentationStyle)adaptivePresentationStyleForPresentationController:(UIPresentationController *)__unused controller
+                                                               traitCollection:(UITraitCollection *)traitCollection
+{
+  if (traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
+    return UIModalPresentationFormSheet;
+  } else {
+    return UIModalPresentationNone;
   }
 }
 

--- a/Simplified/NYPLCatalogGroupedFeedViewController.m
+++ b/Simplified/NYPLCatalogGroupedFeedViewController.m
@@ -29,6 +29,7 @@ static CGFloat const sectionHeaderHeight = 50.0;
 @property (nonatomic) UIRefreshControl *refreshControl;
 @property (nonatomic) NYPLOpenSearchDescription *searchDescription;
 @property (nonatomic) UITableView *tableView;
+@property (nonatomic) NYPLBook *mostRecentBookSelected;
 
 @end
 
@@ -118,6 +119,34 @@ static CGFloat const sectionHeaderHeight = 50.0;
   
   [refreshControl endRefreshing];
   [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+  [super viewDidAppear:animated];
+  if (!self.presentedViewController) {
+    self.mostRecentBookSelected = nil;
+  }
+}
+
+// Transition book detail view between Form Sheet and Nav Controller
+// when changing between compact and regular size classes
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+  if (!self.mostRecentBookSelected) {
+    return;
+  }
+  if (previousTraitCollection.horizontalSizeClass != UIUserInterfaceSizeClassCompact &&
+      self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
+    if (!self.presentedViewController) {
+      return;
+    } else {
+      [self dismissViewControllerAnimated:NO completion:nil];
+    }
+  }
+  if (self.mostRecentBookSelected) {
+    [[[NYPLBookDetailViewController alloc] initWithBook:self.mostRecentBookSelected] presentFromViewController:self];
+  }
 }
 
 #pragma mark UITableViewDataSource
@@ -247,6 +276,7 @@ viewForHeaderInSection:(NSInteger const)section
   NYPLBook *const localBook = [[NYPLBookRegistry sharedRegistry] bookForIdentifier:feedBook.identifier];
   NYPLBook *const book = (localBook != nil) ? localBook : feedBook;
   [[[NYPLBookDetailViewController alloc] initWithBook:book] presentFromViewController:self];
+  self.mostRecentBookSelected = book;
 }
 
 #pragma mark -

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -277,16 +277,15 @@
     }];
       
       UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:welcomeScreenVC];
-      if([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+      
+      if([[NYPLRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
         [navController setModalPresentationStyle:UIModalPresentationFormSheet];
       }
       [navController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
       
       NYPLRootTabBarController *vc = [NYPLRootTabBarController sharedController];
       [vc safelyPresentViewController:navController animated:YES completion:nil];
-
     }
-    
   }
   else
   {

--- a/Simplified/NYPLHoldsViewController.m
+++ b/Simplified/NYPLHoldsViewController.m
@@ -297,4 +297,9 @@ didSelectItemAtIndexPath:(NSIndexPath *const)indexPath
   self.navigationItem.leftBarButtonItem.enabled = YES;
 }
 
+- (void)viewWillTransitionToSize:(CGSize)__unused size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)__unused coordinator
+{
+  [self.collectionView reloadData];
+}
+
 @end

--- a/Simplified/NYPLMyBooksViewController.m
+++ b/Simplified/NYPLMyBooksViewController.m
@@ -416,4 +416,9 @@ OK:
   self.navigationItem.leftBarButtonItem.enabled = YES;
 }
 
+- (void)viewWillTransitionToSize:(CGSize)__unused size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)__unused coordinator
+{
+  [self.collectionView reloadData];
+}
+
 @end

--- a/Simplified/NYPLProblemReportViewController.m
+++ b/Simplified/NYPLProblemReportViewController.m
@@ -91,7 +91,7 @@ static NSArray *s_problems = nil;
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  if(self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
     [self.navigationController setNavigationBarHidden:NO];
   }
 }

--- a/Simplified/NYPLReaderSettingsView.m
+++ b/Simplified/NYPLReaderSettingsView.m
@@ -620,9 +620,7 @@
   
   CGFloat const thin = 1.0 / [UIScreen mainScreen].scale;
   
-  //GODO
-  if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone
-      ) {
+  if (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
     UIView *const line = [[UIView alloc]
                           initWithFrame:CGRectMake(CGRectGetMinX(self.sansButton.frame),
                                                    CGRectGetMinY(self.sansButton.frame),

--- a/Simplified/NYPLReaderSettingsView.m
+++ b/Simplified/NYPLReaderSettingsView.m
@@ -620,6 +620,7 @@
   
   CGFloat const thin = 1.0 / [UIScreen mainScreen].scale;
   
+  //GODO
   if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone
       ) {
     UIView *const line = [[UIView alloc]

--- a/Simplified/NYPLReaderViewController.m
+++ b/Simplified/NYPLReaderViewController.m
@@ -718,7 +718,8 @@ didSelectOpaqueLocation:(NYPLReaderRendererOpaqueLocation *const)opaqueLocation
 {
   [self.rendererView openOpaqueLocation:opaqueLocation];
   
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
+     self.traitCollection.horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
     [self.activePopoverController dismissPopoverAnimated:YES];
     if (!UIAccessibilityIsVoiceOverRunning())
       self.interfaceHidden = YES;
@@ -844,9 +845,10 @@ didSelectOpaqueLocation:(NYPLReaderRendererOpaqueLocation *const)opaqueLocation
   }
   
   CGFloat const width =
-    (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
+    (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
+     self.traitCollection.horizontalSizeClass != UIUserInterfaceSizeClassCompact)
      ? 320
-     : CGRectGetWidth(self.view.frame));
+     : CGRectGetWidth(self.view.frame);
   
   NYPLReaderSettingsView *const readerSettingsView =
     [[NYPLReaderSettingsView alloc] initWithWidth:width];
@@ -855,7 +857,8 @@ didSelectOpaqueLocation:(NYPLReaderRendererOpaqueLocation *const)opaqueLocation
   readerSettingsView.fontSize = [NYPLReaderSettings sharedSettings].fontSize;
   readerSettingsView.fontFace = [NYPLReaderSettings sharedSettings].fontFace;
   
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
+     self.traitCollection.horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
     UIViewController *const viewController = [[UIViewController alloc] init];
     viewController.view = readerSettingsView;
     viewController.preferredContentSize = viewController.view.bounds.size;
@@ -891,7 +894,8 @@ didSelectOpaqueLocation:(NYPLReaderRendererOpaqueLocation *const)opaqueLocation
   viewController.bookTitle = [[NYPLBookRegistry sharedRegistry] bookForIdentifier:self.bookIdentifier].title;
 
   
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
+     self.traitCollection.horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
     [self.activePopoverController dismissPopoverAnimated:NO];
     self.activePopoverController =
       [[UIPopoverController alloc] initWithContentViewController:viewController];

--- a/Simplified/NYPLReportIssueViewController.swift
+++ b/Simplified/NYPLReportIssueViewController.swift
@@ -154,7 +154,7 @@ class NYPLReportIssueViewController: UIViewController, UITableViewDataSource, UI
   
   func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
     
-    if HSAppearance.isIPad()
+    if traitCollection.horizontalSizeClass == .regular
     {
       if(indexPath.row == 0){
         return 44.0;

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -855,7 +855,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       helpStack.gear = deskGear;
     
       if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
-         ([[NYPLRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact)) {
+         self.traitCollection.horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
         UIStoryboard* helpStoryboard = [UIStoryboard storyboardWithName:@"HelpStackStoryboard" bundle:[NSBundle mainBundle]];
         UINavigationController *mainNavVC = [helpStoryboard instantiateInitialViewController];
         UIViewController *firstVC = mainNavVC.viewControllers.firstObject;
@@ -897,7 +897,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
 - (void)showDetailVC:(UIViewController *)vc fromIndexPath:(NSIndexPath *)indexPath
 {
   if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
-     ([[NYPLRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact)) {
+     self.traitCollection.horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
     [self.splitViewController showDetailViewController:[[UINavigationController alloc]
                                                         initWithRootViewController:vc]
                                                 sender:self];
@@ -1306,7 +1306,9 @@ replacementString:(NSString *)string
   // least work very well.
   
   [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-    if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+    if((UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) ||
+       (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact &&
+        self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact)) {
       CGSize const keyboardSize =
       [[notification userInfo][UIKeyboardFrameBeginUserInfoKey] CGRectValue].size;
       CGRect visibleRect = self.view.frame;

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -727,7 +727,8 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       [self.tableView deselectRowAtIndexPath:indexPath animated:YES];
       if([[NYPLAccount sharedAccount:self.accountType] hasBarcodeAndPIN]) {
         UIAlertController *const alertController =
-        (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
+        (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
+         (self.traitCollection.horizontalSizeClass != UIUserInterfaceSizeClassCompact))
          ? [UIAlertController
             alertControllerWithTitle:NSLocalizedString(@"SignOut", nil)
             message:NSLocalizedString(@"SettingsAccountViewControllerLogoutMessage", nil)
@@ -736,7 +737,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
             alertControllerWithTitle:
             NSLocalizedString(@"SettingsAccountViewControllerLogoutMessage", nil)
             message:nil
-            preferredStyle:UIAlertControllerStyleActionSheet]);
+            preferredStyle:UIAlertControllerStyleActionSheet];
         [alertController addAction:[UIAlertAction
                                     actionWithTitle:NSLocalizedString(@"SignOut", nil)
                                     style:UIAlertActionStyleDestructive
@@ -853,7 +854,8 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       HSHelpStack *helpStack = [HSHelpStack instance];
       helpStack.gear = deskGear;
     
-      if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+      if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
+         ([[NYPLRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact)) {
         UIStoryboard* helpStoryboard = [UIStoryboard storyboardWithName:@"HelpStackStoryboard" bundle:[NSBundle mainBundle]];
         UINavigationController *mainNavVC = [helpStoryboard instantiateInitialViewController];
         UIViewController *firstVC = mainNavVC.viewControllers.firstObject;
@@ -894,7 +896,8 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
 
 - (void)showDetailVC:(UIViewController *)vc fromIndexPath:(NSIndexPath *)indexPath
 {
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
+     ([[NYPLRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact)) {
     [self.splitViewController showDetailViewController:[[UINavigationController alloc]
                                                         initWithRootViewController:vc]
                                                 sender:self];
@@ -1658,6 +1661,12 @@ replacementString:(NSString *)string
   [[NSOperationQueue mainQueue] addOperationWithBlock:^{
     [self updateShowHidePINState];
   }];
+}
+
+- (void)viewWillTransitionToSize:(__unused CGSize)size
+       withTransitionCoordinator:(__unused id<UIViewControllerTransitionCoordinator>)coordinator
+{
+  [self.tableView reloadData];
 }
 
 @end

--- a/Simplified/NYPLSettingsPrimaryTableViewController.m
+++ b/Simplified/NYPLSettingsPrimaryTableViewController.m
@@ -103,6 +103,14 @@ NSIndexPath *NYPLSettingsPrimaryTableViewControllerIndexPathFromSettingsItem(
   [[self.navigationController.navigationBar.subviews objectAtIndex:1] addGestureRecognizer:tap];
 }
 
+- (void)viewWillAppear:(BOOL)animated
+{
+  [super viewWillAppear:animated];
+  if (self.splitViewController.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
+    [self.tableView deselectRowAtIndexPath:[self.tableView indexPathForSelectedRow] animated:YES];
+  }
+}
+
 #pragma mark UITableViewDelegate
 
 - (void)tableView:(__attribute__((unused)) UITableView *)tableView
@@ -190,8 +198,10 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
                                  reuseIdentifier:nil];
   cell.textLabel.text = text;
   cell.textLabel.font = [UIFont systemFontOfSize:17];
-  if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+  if (self.splitViewController.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+  } else {
+    cell.accessoryType = UITableViewCellAccessoryNone;
   }
   return cell;
 }

--- a/Simplified/Simplified-Info.plist
+++ b/Simplified/Simplified-Info.plist
@@ -54,8 +54,6 @@
 	<array>
 		<string>armv7</string>
 	</array>
-	<key>UIRequiresFullScreen</key>
-	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Simplified/Simplified-Info.plist
+++ b/Simplified/Simplified-Info.plist
@@ -65,5 +65,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>UIWhitePointAdaptivityStyle</key>
+	<string>UIWhitePointAdaptivityStyleReading</string>
 </dict>
 </plist>


### PR DESCRIPTION
Adds split view support to select iPad models. Mostly removes rigid checks on device type and uses the newer trait collection property.

resolves #729 