### PR TITLE
Ios11 updates

### DIFF
--- a/Simplified/NYPLBookDetailViewController.m
+++ b/Simplified/NYPLBookDetailViewController.m
@@ -249,7 +249,7 @@
 {
   if (previousTraitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact &&
       self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
-    [self.navigationController popViewControllerAnimated:NO];
+    [self.navigationController popToRootViewControllerAnimated:NO];
   }
 }
 

--- a/Simplified/NYPLCatalogGroupedFeedViewController.m
+++ b/Simplified/NYPLCatalogGroupedFeedViewController.m
@@ -135,20 +135,21 @@ static CGFloat const sectionHeaderHeight = 50.0;
 // when changing between compact and regular size classes
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
 {
+  NYPLLOG_F(@"View's horizontal size class changed from %ld to %ld",
+            (long)previousTraitCollection.horizontalSizeClass,
+            (long)self.traitCollection.horizontalSizeClass);
+
   if (!self.mostRecentBookSelected) {
     return;
   }
-  if (previousTraitCollection.horizontalSizeClass != UIUserInterfaceSizeClassCompact &&
-      self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
-    if (!self.presentedViewController) {
-      return;
-    } else {
-      [self dismissViewControllerAnimated:NO completion:nil];
-    }
+
+  if (self.presentedViewController) {
+    [self dismissViewControllerAnimated:NO completion:nil];
+  } else if ([self.navigationController viewControllers].count > 1) {
+    [self.navigationController popToRootViewControllerAnimated:NO];
   }
-  if (self.mostRecentBookSelected) {
-    [[[NYPLBookDetailViewController alloc] initWithBook:self.mostRecentBookSelected] presentFromViewController:self];
-  }
+
+  [[[NYPLBookDetailViewController alloc] initWithBook:self.mostRecentBookSelected] presentFromViewController:self];
 }
 
 #pragma mark UITableViewDataSource

--- a/Simplified/NYPLFacetBarView.m
+++ b/Simplified/NYPLFacetBarView.m
@@ -1,4 +1,5 @@
 #import "NYPLFacetView.h"
+#import <PureLayout/PureLayout.h>
 
 #import "NYPLFacetBarView.h"
 
@@ -17,29 +18,53 @@
   
   self = [super initWithFrame:CGRectMake(origin.x, origin.y, width, borderHeight + toolbarHeight)];
   if(!self) return nil;
-  
-  // This is not really the correct way to use a UIToolbar, but it seems to be the simplest way to
-  // get a blur effect that matches that of the navigation bar.
-  UIToolbar *const toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0,
-                                                                         0,
-                                                                         width,
-                                                                         toolbarHeight)];
-  toolbar.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-  [self addSubview:toolbar];
-  
-  self.facetView = [[NYPLFacetView alloc] initWithFrame:toolbar.bounds];
-  self.facetView.autoresizingMask = (UIViewAutoresizingFlexibleHeight |
-                                     UIViewAutoresizingFlexibleWidth);
-  [toolbar addSubview:self.facetView];
-  
-  CGRect const frame = CGRectMake(0, CGRectGetMaxY(toolbar.frame), width, borderHeight);
-  
-  UIView *borderView = [[UIView alloc] initWithFrame:frame];
-  borderView.backgroundColor = [[UIColor lightGrayColor] colorWithAlphaComponent:0.9];
-  borderView.autoresizingMask = (UIViewAutoresizingFlexibleWidth |
-                                 UIViewAutoresizingFlexibleTopMargin);
-  [self addSubview:borderView];
-  
+
+  if (@available(iOS 11.0, *)) {
+
+    UIVisualEffect *blur = [UIBlurEffect effectWithStyle:UIBlurEffectStyleExtraLight];
+    UIVisualEffectView *bgBlur = [[UIVisualEffectView alloc] initWithEffect:blur];
+
+    self.facetView = [[NYPLFacetView alloc] init];
+
+    UIView *borderView = [[UIView alloc] init];
+    borderView.backgroundColor = [[UIColor lightGrayColor] colorWithAlphaComponent:0.9];
+
+    [self addSubview:bgBlur];
+    [bgBlur autoPinEdgesToSuperviewEdges];
+
+    [self addSubview:self.facetView];
+    [self.facetView autoPinEdgesToSuperviewEdges];
+
+    [self addSubview:borderView];
+    [borderView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeTop];
+    [borderView autoSetDimension:ALDimensionHeight toSize:borderHeight];
+
+  } else {
+
+    // This is not really the correct way to use a UIToolbar, but it seems to be the simplest way to
+    // get a blur effect that matches that of the navigation bar.
+    UIToolbar *const toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0,
+                                                                           0,
+                                                                           width,
+                                                                           toolbarHeight)];
+    toolbar.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    [self addSubview:toolbar];
+
+    self.facetView = [[NYPLFacetView alloc] initWithFrame:toolbar.bounds];
+    self.facetView.autoresizingMask = (UIViewAutoresizingFlexibleHeight |
+                                       UIViewAutoresizingFlexibleWidth);
+    [toolbar addSubview:self.facetView];
+
+    CGRect const frame = CGRectMake(0, CGRectGetMaxY(toolbar.frame), width, borderHeight);
+
+    UIView *borderView = [[UIView alloc] initWithFrame:frame];
+    borderView.backgroundColor = [[UIColor lightGrayColor] colorWithAlphaComponent:0.9];
+    borderView.autoresizingMask = (UIViewAutoresizingFlexibleWidth |
+                                   UIViewAutoresizingFlexibleTopMargin);
+    [self addSubview:borderView];
+
+  }
+
   return self;
 }
 

--- a/Simplified/NYPLProblemReportViewController.m
+++ b/Simplified/NYPLProblemReportViewController.m
@@ -91,7 +91,7 @@ static NSArray *s_problems = nil;
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
-  if(self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
+  if(self.presentingViewController.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
     [self.navigationController setNavigationBarHidden:NO];
   }
 }

--- a/Simplified/NYPLReaderViewController.m
+++ b/Simplified/NYPLReaderViewController.m
@@ -265,7 +265,13 @@ didEncounterCorruptionForBook:(__attribute__((unused)) NYPLBook *)book
       forControlEvents:UIControlEventTouchUpInside];
   
   UIBarButtonItem *const TOCBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:TOCButton];
-  
+
+  // Bar button items require autolayout help 11.0+
+  if (@available(iOS 11.0, *)) {
+    [self.settingsBarButtonItem.customView autoSetDimensionsToSize:CGSizeMake(55, 30)];
+    [TOCBarButtonItem.customView autoSetDimensionsToSize:CGSizeMake(55, 30)];
+  }
+
   // Corruption may have occurred before we added these, so we need to set their enabled status
   // here (in addition to |readerView:didEncounterCorruptionForBook:|).
   self.navigationItem.rightBarButtonItems = @[TOCBarButtonItem, self.settingsBarButtonItem];


### PR DESCRIPTION
More fixes around:

- Split view refactoring
- new iOS 11 auto layout requirements for bar button items
- creating new facet bar init. UIToolbar workaround no longer works in iOS 11