### PR TITLE
Changed Alameda's entry ID to 7.

### DIFF
--- a/Simplified/Accounts.json
+++ b/Simplified/Accounts.json
@@ -51,8 +51,8 @@
  "mainColor" : "497049"
  },
  {
- "id" : 3,
- "pathComponent" : "3",
+ "id" : 7,
+ "pathComponent" : "7",
  "name" : "Alameda County Library",
  "subtitle" : "Infinite possibilities",
  "logo" : "LibraryLogoAlameda",


### PR DESCRIPTION
Just noticed this issue as I was taking screenshots for Carroll County. I assume we originally had 3 as a placeholder and never went back and updated it.