### PR TITLE
Licensor parse bug#788

### DIFF
--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -262,9 +262,13 @@ static NSString *const RecordsKey = @"records";
      
      void (^commitBlock)() = ^void() {
        [self performSynchronizedWithoutBroadcasting:^{
-         
-         [[NYPLAccount sharedAccount] setLicensor:feed.licensor];
-         NYPLLOG_F(@"\nLicensor Token Updated: %@\nFor account: %@",feed.licensor[@"clientToken"],[NYPLAccount sharedAccount].userID);
+
+         if (feed.licensor) {
+           [[NYPLAccount sharedAccount] setLicensor:feed.licensor];
+           NYPLLOG_F(@"\nLicensor Token Updated: %@\nFor account: %@",feed.licensor[@"clientToken"],[NYPLAccount sharedAccount].userID);
+         } else {
+           NYPLLOG(@"A Licensor Token was not received or parsed from the OPDS feed.");
+         }
          
          NSMutableSet *identifiersToRemove = [NSMutableSet setWithArray:self.identifiersToRecords.allKeys];
          for(NYPLOPDSEntry *const entry in feed.entries) {

--- a/Simplified/NYPLCatalogGroupedFeed.m
+++ b/Simplified/NYPLCatalogGroupedFeed.m
@@ -82,7 +82,7 @@
     
     NYPLBook *book = [NYPLBook bookWithEntry:entry];
     if(!book) {
-      NYPLLOG(@"Failed to create book from entry.");
+      NYPLLOG_F(@"Failed to create book from entry: %@",entry.title);
       continue;
     }
     

--- a/Simplified/NYPLKeychain.m
+++ b/Simplified/NYPLKeychain.m
@@ -75,13 +75,13 @@
     status = SecItemUpdate((__bridge CFDictionaryRef) dictionary,
                            (__bridge CFDictionaryRef) updateDictionary);
     if (status != noErr) {
-      NYPLLOG_F(@"Failed to UPDATE secure values to keychain for group: %@. This is a known issue when running from the debugger", groupID);
+      NYPLLOG_F(@"Failed to UPDATE secure values to keychain for group: %@. This is a known issue when running from the debugger. Error: %d", groupID, status);
     }
   } else {
     dictionary[(__bridge __strong id) kSecValueData] = valueData;
     status = SecItemAdd((__bridge CFDictionaryRef) dictionary, NULL);
     if (status != noErr) {
-      NYPLLOG_F(@"Failed to ADD secure values to keychain for group: %@. This is a known issue when running from the debugger", groupID);
+      NYPLLOG_F(@"Failed to ADD secure values to keychain for group: %@. This is a known issue when running from the debugger. Error: %d", groupID, status);
     }
   }
 }
@@ -103,7 +103,7 @@
   
   OSStatus status = SecItemDelete((__bridge CFDictionaryRef) dictionary);
   if (status != noErr) {
-    NYPLLOG_F(@"Failed to REMOVE object from keychain group: %@",groupID);
+    NYPLLOG_F(@"Failed to REMOVE object from keychain group: %@. error: %d", groupID, (int)status);
   }
 }
 

--- a/Simplified/NYPLOPDSEntry.m
+++ b/Simplified/NYPLOPDSEntry.m
@@ -153,18 +153,20 @@
       return nil;
     }
   }
-  
+
   {
-    NYPLXML *const linkXML = [entryXML firstChildWithName:@"Series"];
-    self.seriesLink = [[NYPLOPDSLink alloc] initWithXML:linkXML];
-    if (!self.seriesLink) {
-      NYPLLOG(@"Ignoring malformed 'link' element for Series title.");
+    NYPLXML *const seriesXML = [entryXML firstChildWithName:@"Series"];
+    NYPLXML *const linkXML = [seriesXML firstChildWithName:@"link"];
+    if (linkXML) {
+      self.seriesLink = [[NYPLOPDSLink alloc] initWithXML:linkXML];
+      if (!self.seriesLink) {
+        NYPLLOG(@"Ignoring malformed 'link' element for schema:Series.");
+      }
     }
   }
   
   return self;
 }
-
 - (NYPLOPDSEntryGroupAttributes *)groupAttributes
 {
   for(NYPLOPDSLink *const link in self.links) {

--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -178,33 +178,29 @@ static NYPLOPDSFeedType TypeImpliedByEntry(NYPLOPDSEntry *const entry)
   }
   
   {
-    //licensor
     NYPLXML *licensorXML = [feedXML firstChildWithName:@"licensor"];
     if (licensorXML && licensorXML.attributes.allValues.count>0) {
       NSString *vendor = licensorXML.attributes[@"drm:vendor"];
-      NYPLXML *vendorXML = [licensorXML firstChildWithName:@"clientToken"];
+      NYPLXML *tokenXML = [licensorXML firstChildWithName:@"clientToken"];
       
-     if (vendorXML) {
-       
-       NSString *clientToken = vendorXML.value;
-       
-       self.licensor = @{@"vendor":vendor,
-                         @"clientToken":clientToken}.mutableCopy;
+      if (tokenXML) {
+        NSString *clientToken = tokenXML.value;
+        self.licensor = @{@"vendor":vendor,
+                          @"clientToken":clientToken}.mutableCopy;
 
-       
-      for(NYPLXML *const linkXML in [licensorXML childrenWithName:@"link"]) {
-        NYPLOPDSLink *const link = [[NYPLOPDSLink alloc] initWithXML:linkXML];
-        if(!link) {
-          NYPLLOG(@"Ignoring malformed 'link' element.");
-          continue;
+        for(NYPLXML *const linkXML in [licensorXML childrenWithName:@"link"]) {
+          NYPLOPDSLink *const link = [[NYPLOPDSLink alloc] initWithXML:linkXML];
+          if ([link.rel isEqualToString:@"http://librarysimplified.org/terms/drm/rel/devices"]) {
+            [self.licensor setValue:link.href.absoluteString forKey:@"deviceManager"];
+            continue;
+          }
         }
-        if ([link.rel isEqualToString:@"http://librarysimplified.org/terms/drm/rel/devices"])
-        {
-          [self.licensor setValue:link.href.absoluteString forKey:@"deviceManager"];
-          continue;
-        }
+
+      } else {
+        NYPLLOG(@"Licensor not saved. Error parsing clientToken into XML.");
       }
-      }
+    } else {
+      NYPLLOG(@"No Licensor found in OPDS feed. Moving on.");
     }
   }
   

--- a/Simplified/NYPLOPDSLink.m
+++ b/Simplified/NYPLOPDSLink.m
@@ -17,7 +17,6 @@
 @property (nonatomic) NSDate *availableSince;
 @property (nonatomic) NSDate *availableUntil;
 @property (nonatomic) NSMutableArray *mutableAcquisitionFormats;
-@property (nonatomic) NSMutableDictionary *licensor;
 
 @end
 
@@ -63,32 +62,6 @@
   if (copiesXML) {
     self.availableCopies = [copiesXML.attributes[@"available"] integerValue];
   }
-  
-  NYPLXML *licensorXML = [linkXML firstChildWithName:@"licensor"];
-  if (licensorXML && licensorXML.attributes.allValues.count>0) {
-    NSString *vendor = licensorXML.attributes.allValues.firstObject;
-    NYPLXML *vendorXML = [licensorXML firstChildWithName:@"clientToken"];
-    if (vendorXML) {
-      NSString *clientToken = vendorXML.value;
-      
-      self.licensor = @{@"vendor":vendor,
-                        @"clientToken":clientToken}.mutableCopy;
-    
-      for(NYPLXML *const linkXML in [licensorXML childrenWithName:@"link"]) {
-        NYPLOPDSLink *const link = [[NYPLOPDSLink alloc] initWithXML:linkXML];
-        if(!link) {
-          NYPLLOG(@"Ignoring malformed 'link' element.");
-          continue;
-        }
-        if ([link.rel isEqualToString:@"http://librarysimplified.org/terms/drm/rel/devices"])
-        {
-          [self.licensor setValue:link.href.absoluteString forKey:@"deviceManager"];
-          continue;
-        }
-      }
-    }
-  }
-  
   
   [self addAcquisitionFormatsWithXML:linkXML];
   


### PR DESCRIPTION
This ended up just being an oversight that the client assumed the licensor to exist in a spot where it can be optional.

Also refactored parsing of the Licensor to provide better context to errors in the console.

There was also logic to look for and parse a client token inside the OPDSLink class. This has been removed. Even if a token did exist within a link child of an entry, the client uses the property at the "feed" level so at least we're being consistent in execution now.

Finally, I saw that the `schema:Series` child link was not being parsed correctly.

resolves #788 