### PR TITLE
Add authPasscode fields to Alameda

### DIFF
--- a/Simplified/Accounts.json
+++ b/Simplified/Accounts.json
@@ -69,7 +69,9 @@
  "supportsHelpCenter" : false,
  "catalogUrl" : "http://acl.simplye-ca.org/CALMDA/",
  "supportEmail" : "ask@aclibrary.libanswers.com",
- "mainColor" : "#58a6f5"
+ "mainColor" : "#58a6f5",
+ "authPasscodeLength" : 0,
+ "authPasscodeAllowsLetters" : true
  },
  {
  "id" : 8,


### PR DESCRIPTION
Adds the authPasscodeAllowLetters and authPasscodeLength where they were not previously in Maryland and Califa libraries. In the iOS client, only Alameda County was found to be missing these fields.