### PR TITLE
Standardize usage of sync notifications

### DIFF
--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -230,7 +230,12 @@ static NSString *const RecordsKey = @"records";
 - (void)syncWithCompletionHandler:(void (^)(BOOL success))handler
 {
   @synchronized(self) {
-    if(self.syncing || ![[NYPLAccount sharedAccount] hasBarcodeAndPIN]) {
+    if(self.syncing) {
+      return;
+    } else if (![[NYPLAccount sharedAccount] hasBarcodeAndPIN]) {
+      [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        if(handler) handler(NO);
+      }];
       return;
     } else {
       self.syncing = YES;

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -162,6 +162,7 @@
   [UIApplication sharedApplication].delegate.window.tintColor = [NYPLConfiguration mainColor];
 
   [[NYPLBookRegistry sharedRegistry] justLoad];
+  [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncBeganNotification object:nil];
   [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL __unused success) {
     [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
   }];
@@ -171,7 +172,6 @@
     NYPLCatalogFeedViewController *viewController = (NYPLCatalogFeedViewController *)self.visibleViewController;
     viewController.URL = [NYPLConfiguration mainFeedURL]; // It may have changed
     [viewController load];
-    [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncBeganNotification object:nil];
 
     viewController.navigationItem.title = [[NYPLSettings sharedSettings] currentAccount].name;
   } else if ([[self.topViewController class] isSubclassOfClass:[NYPLCatalogFeedViewController class]] &&
@@ -179,14 +179,9 @@
     NYPLCatalogFeedViewController *viewController = (NYPLCatalogFeedViewController *)self.topViewController;
     viewController.URL = [NYPLConfiguration mainFeedURL]; // It may have changed
     [viewController load];
-    [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncBeganNotification object:nil];
 
     viewController.navigationItem.title = [[NYPLSettings sharedSettings] currentAccount].name;
   }
-  
-  [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-    [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
-  }];
 }
 
 - (void)viewDidLoad
@@ -291,20 +286,6 @@
       [vc safelyPresentViewController:navController animated:YES completion:nil];
     }
   }
-  else
-  {
-    Account *account = [[AccountsManager sharedInstance] currentAccount];
-
-    if ((account.needsAuth
-        && ![[NYPLAccount sharedAccount:account.id] hasBarcodeAndPIN]) || !account.needsAuth)
-    {
-      [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
-      }];
-    }
-    
-  }
-  
 }
 
 @end

--- a/Simplified/NYPLHoldsNavigationController.m
+++ b/Simplified/NYPLHoldsNavigationController.m
@@ -120,9 +120,6 @@
 }
 
 - (void) reloadSelected {
-  
-  [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncBeganNotification object:nil];
-
   NYPLCatalogNavigationController * catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
   [catalog reloadSelectedLibraryAccount];
   

--- a/Simplified/NYPLMyBooksNavigationController.m
+++ b/Simplified/NYPLMyBooksNavigationController.m
@@ -124,9 +124,6 @@
 }
 
 - (void) reloadSelected {
-  
-  [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncBeganNotification object:nil];
-
   NYPLCatalogNavigationController * catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
   [catalog reloadSelectedLibraryAccount];
   


### PR DESCRIPTION
...for hiding/showing library switch

The code in viewDidAppear as well as the no-completion return in the book registry created a situation where one library's book registry would copy over into a non-auth library like the SimplyE collection, at the end of a sync.

Also tried to standardize the notifications to eliminate vectors for the app to think it was in the wrong sync state.

fixes #676 