### PR TITLE
Move secret gesture recognizer to footer text label

### DIFF
--- a/Simplified/NYPLSettingsPrimaryTableViewController.m
+++ b/Simplified/NYPLSettingsPrimaryTableViewController.m
@@ -92,15 +92,8 @@ NSIndexPath *NYPLSettingsPrimaryTableViewControllerIndexPathFromSettingsItem(
 
 - (void)viewDidLoad
 {
-  [super viewDidLoad];
-  
+  [super viewDidLoad];  
   self.view.backgroundColor = [NYPLConfiguration backgroundColor];
-
-  UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(revealCustomFeedUrl)];
-  tap.numberOfTapsRequired = 7;
-  
-  [[self.navigationController.navigationBar.subviews objectAtIndex:1] setUserInteractionEnabled:YES];
-  [[self.navigationController.navigationBar.subviews objectAtIndex:1] addGestureRecognizer:tap];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -141,6 +134,11 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       self.infoLabel.text = [NSString stringWithFormat:@"%@ version %@ (%@)", productName, version, build];
       self.infoLabel.textAlignment = NSTextAlignmentCenter;
       [self.infoLabel sizeToFit];
+
+      UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(revealCustomFeedUrl)];
+      tap.numberOfTapsRequired = 7;
+      [self.infoLabel setUserInteractionEnabled:YES];
+      [self.infoLabel addGestureRecognizer:tap];
     }
     return self.infoLabel;
   }


### PR DESCRIPTION
For some reason the gesture was no longer being recognized in the Navigation Bar in iOS 11, so it's been moved to the footer text label, which is also where it's located on Android.

I think it makes sense to just have an "Advanced" menu at some point as well as auditing to make sure everything still works past the Multi Library changes. Could also put in other things like supporting basic auth. For now though, just this adjustment.