### PR TITLE
Stability improvements, Bugsnag Issues Closed

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ target 'SimplyE' do
   use_frameworks!
 
   pod 'HelpStack', :git => 'https://github.com/NYPL-Simplified/helpstack-ios'
-  pod 'Bugsnag', '~> 5.11'
+  pod 'Bugsnag', '~> 5.13.1'
   pod 'NYPLCardCreator', :git => 'https://github.com/NYPL-Simplified/CardCreator-iOS.git'
   pod 'SQLite.swift', :git => 'https://github.com/NYPL-Simplified/SQLite.swift', :branch => 'nypl-swift4-ios8-target'
   pod 'ZXingObjC', '~> 3.2.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -20,7 +20,7 @@ PODS:
   - AFNetworking/UIKit (2.6.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - Bugsnag (5.13.0)
+  - Bugsnag (5.13.2)
   - HelpStack (1.1.2):
     - AFNetworking (~> 2.0)
     - HelpStack/Core (= 1.1.2)
@@ -52,7 +52,7 @@ PODS:
   - ZXingObjC/All (3.2.1)
 
 DEPENDENCIES:
-  - Bugsnag (~> 5.11)
+  - Bugsnag (~> 5.13.1)
   - HelpStack (from `https://github.com/NYPL-Simplified/helpstack-ios`)
   - NYPLCardCreator (from `https://github.com/NYPL-Simplified/CardCreator-iOS.git`)
   - SQLite.swift (from `https://github.com/NYPL-Simplified/SQLite.swift`, branch `nypl-swift4-ios8-target`)
@@ -80,13 +80,13 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
-  Bugsnag: 530eda12cfc85026cb67e1c12bdfabc7a319f59c
+  Bugsnag: c70c32f69a756a46b49acbb47a3998450636493a
   HelpStack: a9067738597ef81835d84ac8bb75ee346e34f000
   NYPLCardCreator: e0f5034902008b4c8cdfb5edbffa2a51ec0b261d
   PureLayout: 4d550abe49a94f24c2808b9b95db9131685fe4cd
   SQLite.swift: 0cb8585c21684b2290ec7792b3ca8089f68bdd29
   ZXingObjC: bbf7b8f0cf8933fdd33eb4f9f46e22308552869b
 
-PODFILE CHECKSUM: dcfc1f09653a38172d8283a7819757b90bfd6823
+PODFILE CHECKSUM: 40dfa0fcd93208f7c20331fbb959cb5b78627d92
 
 COCOAPODS: 1.3.1

--- a/Simplified/NYPLCatalogGroupedFeedViewController.m
+++ b/Simplified/NYPLCatalogGroupedFeedViewController.m
@@ -301,7 +301,9 @@ viewForHeaderInSection:(NSInteger const)section
 {
   NSIndexPath *indexPath = [self.tableView indexPathForRowAtPoint:location];
   NYPLCatalogLaneCell *cell = (NYPLCatalogLaneCell *)[self.tableView cellForRowAtIndexPath:indexPath];
-  
+  if (!cell) {
+    return nil;
+  }
   UIViewController *vc = [[UIViewController alloc] init];
   vc.view.tag = cell.laneIndex;
   

--- a/Simplified/NYPLReaderReadiumView.m
+++ b/Simplified/NYPLReaderReadiumView.m
@@ -819,21 +819,20 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
         NSData *data;
         if (url) {
           data = [NSData dataWithContentsOfURL:url options:NSDataReadingUncached error:&dataError];
+          if (data && !dataError) {
+            NSNumber *length = [NSNumber numberWithUnsignedInteger:data.length];
+            expectedLengthDec = [NSDecimalNumber decimalNumberWithDecimal:length.decimalValue];
+          }
         } else {
           [self reportNilUrlToBugsnagWithSpineItem:spineItem];
-        }
-        
-        if (data || !dataError) {
-          NSNumber *length = [NSNumber numberWithUnsignedInteger:data.length];
-          expectedLengthDec = [NSDecimalNumber decimalNumberWithDecimal:length.decimalValue];
         }
       }
       
       NSMutableDictionary *spineItemDict = [[NSMutableDictionary alloc] init];
-      [spineItemDict setObject:expectedLengthDec forKey:@"spineItemBytesLength"];
-      [spineItemDict setObject:spineItem.baseHref forKey:@"spineItemBaseHref"];
-      [spineItemDict setObject:spineItem.idref forKey:@"spineItemIdref"];
-      [spineItemDict setObject:totalLength forKey:@"totalLengthSoFar"];
+      if (expectedLengthDec) [spineItemDict setObject:expectedLengthDec forKey:@"spineItemBytesLength"];
+      if (spineItem.baseHref) [spineItemDict setObject:spineItem.baseHref forKey:@"spineItemBaseHref"];
+      if (spineItem.idref) [spineItemDict setObject:spineItem.idref forKey:@"spineItemIdref"];
+      if (totalLength) [spineItemDict setObject:totalLength forKey:@"totalLengthSoFar"];
       
       NSString *title = [self tocTitleForSpineItem:spineItem];
       if (title && [[title class] isSubclassOfClass:[NSString class]]) {

--- a/Simplified/NYPLReaderViewController.m
+++ b/Simplified/NYPLReaderViewController.m
@@ -1,3 +1,4 @@
+@import Bugsnag;
 @import WebKit;
 
 #import "NYPLBook.h"
@@ -300,16 +301,23 @@ didEncounterCorruptionForBook:(__attribute__((unused)) NYPLBook *)book
     if ([gr isKindOfClass:[UITapGestureRecognizer class]])
       gr.enabled = NO;
   }
-  
-  self.dummyViewControllers = @[[[UIViewController alloc] init], [[UIViewController alloc] init], [[UIViewController alloc] init]];
-  for (UIViewController *v in self.dummyViewControllers)
-    [v.view setBackgroundColor:[UIColor whiteColor]];
-  [self.dummyViewControllers.firstObject.view addSubview:self.rendererView];
+
   self.renderedImageView = [[UIImageView alloc] init];
-  
-  NSArray *viewControllers = [NSArray arrayWithObject:self.dummyViewControllers.firstObject];
-  
-  [self.pageViewController setViewControllers:viewControllers direction:UIPageViewControllerNavigationDirectionForward animated:NO completion:nil];
+  UIViewController *viewController1 = [[UIViewController alloc] init];
+  UIViewController *viewController2 = [[UIViewController alloc] init];
+  UIViewController *viewController3 = [[UIViewController alloc] init];
+  self.dummyViewControllers = @[viewController1, viewController2, viewController3];
+  for (UIViewController *v in self.dummyViewControllers) {
+    [v.view setBackgroundColor:[UIColor whiteColor]];
+  }
+  [self.dummyViewControllers.firstObject.view addSubview:self.rendererView];
+
+  NSArray *viewControllerArray = @[self.dummyViewControllers.firstObject];
+  if (viewControllerArray.count != 0) {
+    [self.pageViewController setViewControllers:viewControllerArray direction:UIPageViewControllerNavigationDirectionForward animated:NO completion:nil];
+  } else {
+    [self reportPageViewControllerErrorToBugnsag];
+  }
   
   [self addChildViewController:self.pageViewController];
   [[self view] addSubview:[self.pageViewController view]];
@@ -944,6 +952,18 @@ didSelectOpaqueLocation:(NYPLReaderRendererOpaqueLocation *const)opaqueLocation
   if (self.renderedImageView.superview != nil && (self.renderedImageView.superview == self.rendererView.superview)) {
     [self.renderedImageView removeFromSuperview];
   }
+}
+
+// FIXME: This can be removed when sufficient data has been collected
+// Bug: Something has gone wrong with the VC array configuration. Observed in crash analytics.
+- (void)reportPageViewControllerErrorToBugnsag
+{
+  [Bugsnag notifyError:[NSError errorWithDomain:@"org.nypl.labs.SimplyE" code:6 userInfo:nil]
+                 block:^(BugsnagCrashReport * _Nonnull report) {
+                   report.context = @"NYPLReaderViewController";
+                   report.severity = BSGSeverityWarning;
+                   report.errorMessage = @"UIPageViewController was attempting to set 0 view controllers.";
+                 }];
 }
 
 @end

--- a/Simplified/NYPLReaderViewController.m
+++ b/Simplified/NYPLReaderViewController.m
@@ -349,8 +349,8 @@ didEncounterCorruptionForBook:(__attribute__((unused)) NYPLBook *)book
 
 - (void)didReceiveMemoryWarning
 {
-  [super didReceiveMemoryWarning];
   [[NYPLBookRegistry sharedRegistry] save];
+  [super didReceiveMemoryWarning];
 }
 
 -(void)didMoveToParentViewController:(UIViewController *)parent {


### PR DESCRIPTION
several top bugnsag crashes addressed:

fixes #824
fixes #825
fixes #826
fixes #827
fixes #828

#670 is not solved, but in order to reduce the user-frustration around the crash, book position is now locally saved every 6 pages forward or backward in the book. Enabling SimplyE Sync in 2.2.0 is also going to dramatically reduce the the loss of reading position.

We still need to solve this crash, but it's a good band-aid for now.