### PR TITLE
2.1.3 Release Prep (Remove Black Gold)

### DIFF
--- a/Simplified/Accounts.json
+++ b/Simplified/Accounts.json
@@ -25,7 +25,7 @@
  "needsAuth" : true,
  "supportsSimplyESync" : false,
  "supportsBarcodeScanner" : true,
- "supportsBarcodeDisplay" : false,
+ "supportsBarcodeDisplay" : true,
  "supportsReservations" : true,
  "supportsCardCreator" : false,
  "supportsHelpCenter" : false,
@@ -49,24 +49,5 @@
  "supportsHelpCenter" : false,
  "catalogUrl" : "https://instantclassics.librarysimplified.org/index.xml",
  "mainColor" : "497049"
- },
- {
- "id" : 12,
- "pathComponent" : "12",
- "name" : "Black Gold Cooperative Library",
- "subtitle" : " ",
- "logo" : "LibraryLogoBlackGold",
- "needsAuth" : true,
- "supportsSimplyESync" : false,
- "supportsBarcodeScanner" : false,
- "supportsBarcodeDisplay" : false,
- "supportsCardCreator" : false,
- "supportsReservations" : true,
- "supportsHelpCenter" : false,
- "catalogUrl" : "http://bgc.simplye-ca.org/",
- "supportEmail": "blackgoldhq@blackgold.org",
- "mainColor" : "d2a74a",
- "authPasscodeLength" : 0,
- "authPasscodeAllowsLetters" : true
  }
 ]

--- a/Simplified/Simplified-Info.plist
+++ b/Simplified/Simplified-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>2.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSpokenName</key>


### PR DESCRIPTION
Remove Black Gold Coop until library gives final approval. Approval was pulled at last minute. Continuing release with significant stability enhancements.

Make change to enable Barcode Display for BPL.