### PR TITLE
Reservation messaging #842

### DIFF
--- a/Simplified/NYPLBook.h
+++ b/Simplified/NYPLBook.h
@@ -19,6 +19,8 @@ typedef NS_ENUM(NSInteger, NYPLBookAvailabilityStatus) {
 @property (nonatomic, readonly) NYPLBookAvailabilityStatus availabilityStatus;
 @property (nonatomic, readonly) NSInteger availableCopies;
 @property (nonatomic, readonly) NSDate *availableUntil;
+@property (nonatomic, readonly) NSInteger totalCopies;
+@property (nonatomic, readonly) NSInteger holdsPosition;
 @property (nonatomic, readonly) NSString *categories;
 @property (nonatomic, readonly) NSArray *categoryStrings;
 @property (nonatomic, readonly) NSString *distributor; // nilable
@@ -54,6 +56,8 @@ typedef NS_ENUM(NSInteger, NYPLBookAvailabilityStatus) {
                  availabilityStatus:(NYPLBookAvailabilityStatus)availabilityStatus
                     availableCopies:(NSInteger)availableCopies
                      availableUntil:(NSDate *)availableUntil
+                        totalCopies:(NSInteger)totalCopies
+                      holdsPosition:(NSInteger)holdsPosition
                     categoryStrings:(NSArray *)categoryStrings
                         distributor:(NSString *)distributor
                          identifier:(NSString *)identifier

--- a/Simplified/NYPLBook.m
+++ b/Simplified/NYPLBook.m
@@ -14,6 +14,8 @@
 @property (nonatomic) NYPLBookAvailabilityStatus availabilityStatus;
 @property (nonatomic) NSInteger availableCopies;
 @property (nonatomic) NSDate *availableUntil;
+@property (nonatomic) NSInteger totalCopies;
+@property (nonatomic) NSInteger holdsPosition;
 @property (nonatomic) NSArray *categoryStrings;
 @property (nonatomic) NSString *distributor;
 @property (nonatomic) NSString *identifier;
@@ -41,6 +43,8 @@ static NSString *const AuthorLinksKey = @"author-links";
 static NSString *const AvailabilityStatusKey = @"availability-status";
 static NSString *const AvailableCopiesKey = @"available-copies";
 static NSString *const AvailableUntilKey = @"available-until";
+static NSString *const TotalCopiesKey = @"total-copies";
+static NSString *const HoldsPositionKey = @"holds-position";
 static NSString *const CategoriesKey = @"categories";
 static NSString *const DistributorKey = @"distributor";
 static NSString *const IdentifierKey = @"id";
@@ -98,6 +102,8 @@ static NSString *const AlternateURLKey = @"alternate";
 
   NYPLBookAvailabilityStatus availabilityStatus = NYPLBookAvailabilityStatusUnknown;
   NSInteger availableCopies = 0;
+  NSInteger totalCopies = 0;
+  NSInteger holdsPosition = 0;
   NSDate *availableUntil = nil;
   NSArray *borrowFormats = @[];
   BOOL isEPUBAvailable = NO;
@@ -128,6 +134,12 @@ static NSString *const AlternateURLKey = @"alternate";
     }
     if(link.availableUntil) {
       availableUntil = link.availableUntil;
+    }
+    if(link.totalCopies > totalCopies) {
+      totalCopies = link.totalCopies;
+    }
+    if(link.holdsPosition > holdsPosition) {
+      holdsPosition = link.holdsPosition;
     }
     
     if([link.rel isEqualToString:NYPLOPDSRelationAcquisition]) {
@@ -203,6 +215,8 @@ static NSString *const AlternateURLKey = @"alternate";
           availabilityStatus:availabilityStatus
           availableCopies:availableCopies
           availableUntil:availableUntil
+          totalCopies:totalCopies
+          holdsPosition:holdsPosition
           categoryStrings:[[self class] categoryStringsFromCategories:entry.categories]
           distributor:entry.providerName
           identifier:entry.identifier
@@ -230,6 +244,8 @@ static NSString *const AlternateURLKey = @"alternate";
           availabilityStatus:self.availabilityStatus
           availableCopies:self.availableCopies
           availableUntil:self.availableUntil
+          totalCopies:self.totalCopies
+          holdsPosition:self.holdsPosition
           categoryStrings:book.categoryStrings
           distributor:book.distributor
           identifier:self.identifier
@@ -254,6 +270,8 @@ static NSString *const AlternateURLKey = @"alternate";
                  availabilityStatus:(NYPLBookAvailabilityStatus)availabilityStatus
                     availableCopies:(NSInteger)availableCopies
                      availableUntil:(NSDate *)availableUntil
+                        totalCopies:(NSInteger)totalCopies
+                      holdsPosition:(NSInteger)holdsPosition
                     categoryStrings:(NSArray *)categoryStrings
                         distributor:(NSString *)distributor
                          identifier:(NSString *)identifier
@@ -287,6 +305,8 @@ static NSString *const AlternateURLKey = @"alternate";
   self.availabilityStatus = availabilityStatus;
   self.availableCopies = availableCopies;
   self.availableUntil = availableUntil;
+  self.totalCopies = totalCopies;
+  self.holdsPosition = holdsPosition;
   self.categoryStrings = categoryStrings;
   self.distributor = distributor;
   self.identifier = identifier;
@@ -353,8 +373,9 @@ static NSString *const AlternateURLKey = @"alternate";
   self.bookAuthors = authors;
   
   self.availabilityStatus = [dictionary[AvailabilityStatusKey] integerValue];
-  
   self.availableCopies = [dictionary[AvailableCopiesKey] integerValue];
+  self.totalCopies = [dictionary[TotalCopiesKey] integerValue];
+  self.holdsPosition = [dictionary[HoldsPositionKey] integerValue];
   
   NSString *const availableUntilString = NYPLNullToNil(dictionary[AvailableUntilKey]);
   self.availableUntil = NYPLNullToNil(availableUntilString ? [NSDate dateWithRFC3339String:availableUntilString] : nil);

--- a/Simplified/NYPLBookButtonsView.m
+++ b/Simplified/NYPLBookButtonsView.m
@@ -235,20 +235,6 @@
     // Re-enable animations as per usual.
     [UIView setAnimationsEnabled:YES];
     
-    if ([buttonInfo[AddIndicatorKey] isEqualToValue:@(YES)]) {
-      if (self.book.availableUntil && [self.book.availableUntil timeIntervalSinceNow] > 0) {
-        button.type = NYPLRoundedButtonTypeClock;
-        button.endDate = self.book.availableUntil;
-      } else {
-        button.type = NYPLRoundedButtonTypeNormal;
-        // We could handle queue support here if we wanted it.
-        // button.type = NYPLRoundedButtonTypeQueue;
-        // button.queuePosition = self.book.holdPosition;
-      }
-    } else {
-      button.type = NYPLRoundedButtonTypeNormal;
-    }
-    
     [visibleButtons addObject:button];
   }
   for (NYPLRoundedButton *button in @[self.downloadButton, self.deleteButton, self.readButton]) {

--- a/Simplified/NYPLBookDetailButtonsView.m
+++ b/Simplified/NYPLBookDetailButtonsView.m
@@ -34,25 +34,21 @@
   self.constraints = [[NSMutableArray alloc] init];
   
   self.deleteButton = [NYPLRoundedButton button];
-  self.deleteButton.fromDetailView = YES;
   self.deleteButton.titleLabel.minimumScaleFactor = 0.8f;
   [self.deleteButton addTarget:self action:@selector(didSelectReturn) forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.deleteButton];
 
   self.downloadButton = [NYPLRoundedButton button];
-  self.downloadButton.fromDetailView = YES;
   self.downloadButton.titleLabel.minimumScaleFactor = 0.8f;
   [self.downloadButton addTarget:self action:@selector(didSelectDownload) forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.downloadButton];
 
   self.readButton = [NYPLRoundedButton button];
-  self.readButton.fromDetailView = YES;
   self.readButton.titleLabel.minimumScaleFactor = 0.8f;
   [self.readButton addTarget:self action:@selector(didSelectRead) forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.readButton];
   
   self.cancelButton = [NYPLRoundedButton button];
-  self.cancelButton.fromDetailView = YES;
   self.cancelButton.titleLabel.minimumScaleFactor = 0.8f;
   [self.cancelButton addTarget:self action:@selector(didSelectCancel) forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.cancelButton];
@@ -270,20 +266,6 @@
     
     // Re-enable animations as per usual.
     [UIView setAnimationsEnabled:YES];
-    
-    if ([buttonInfo[AddIndicatorKey] isEqualToValue:@(YES)]) {
-      if (self.book.availableUntil && [self.book.availableUntil timeIntervalSinceNow] > 0) {
-        button.type = NYPLRoundedButtonTypeClock;
-        button.endDate = self.book.availableUntil;
-      } else {
-        button.type = NYPLRoundedButtonTypeNormal;
-        // We could handle queue support here if we wanted it.
-        // button.type = NYPLRoundedButtonTypeQueue;
-        // button.queuePosition = self.book.holdPosition;
-      }
-    } else {
-      button.type = NYPLRoundedButtonTypeNormal;
-    }
     
     [visibleButtons addObject:button];
   }

--- a/Simplified/NYPLBookDetailNormalView.m
+++ b/Simplified/NYPLBookDetailNormalView.m
@@ -121,8 +121,7 @@ typedef NS_ENUM (NSInteger, NYPLProblemReportButtonState) {
       newMessageString = NSLocalizedString(@"BookDetailViewControllerDownloadSuccessfulTitle", nil);
       break;
     case NYPLBookButtonsStateHolding:
-      newMessageString = [NSString stringWithFormat:NSLocalizedString(@"BookDetailViewControllerHoldingTitleFormat", nil),
-                                [self.book.availableUntil longTimeUntilString]];
+      newMessageString = [self messageStringForNYPLBookButtonsStateHolding];
       break;
     case NYPLBookButtonsStateHoldingFOQ:
       newMessageString = [NSString stringWithFormat:NSLocalizedString(@"BookDetailViewControllerReservedTitleFormat", nil),
@@ -153,6 +152,18 @@ typedef NS_ENUM (NSInteger, NYPLProblemReportButtonState) {
         self.messageLabel.alpha = 1.0f;
       }];
     }];
+  }
+}
+
+-(NSString *)messageStringForNYPLBookButtonsStateHolding
+{
+  NSString *newMessageString = [NSString stringWithFormat:NSLocalizedString(@"BookDetailViewControllerHoldingTitleFormat", nil),[self.book.availableUntil longTimeUntilString]];
+
+  if ((self.book.holdsPosition > 0) && (self.book.totalCopies > 0)) {
+    NSString *positionString = [NSString stringWithFormat:NSLocalizedString(@"\n#%d in line for %d copies.", @"Describe the line that a person is waiting in for a total number of books that are available for everyone to check out, to help tell them how long they will be waiting."), self.book.holdsPosition, self.book.totalCopies];
+    return [newMessageString stringByAppendingString:positionString];
+  } else {
+    return newMessageString;
   }
 }
 

--- a/Simplified/NYPLOPDSLink.h
+++ b/Simplified/NYPLOPDSLink.h
@@ -11,6 +11,8 @@
 @property (nonatomic, readonly) NSString *length; // nilable
 @property (nonatomic, readonly) NSString *availabilityStatus; // nilable
 @property (nonatomic, readonly) NSInteger availableCopies;
+@property (nonatomic, readonly) NSInteger totalCopies;
+@property (nonatomic, readonly) NSInteger holdsPosition; // nilable
 @property (nonatomic, readonly) NSDate *availableSince; // nilable
 @property (nonatomic, readonly) NSDate *availableUntil; // nilable
 @property (nonatomic, readonly) NSDictionary *licensor; // nilable

--- a/Simplified/NYPLOPDSLink.m
+++ b/Simplified/NYPLOPDSLink.m
@@ -14,6 +14,8 @@
 @property (nonatomic) NSString *length;
 @property (nonatomic) NSString *availabilityStatus;
 @property (nonatomic) NSInteger availableCopies;
+@property (nonatomic) NSInteger totalCopies;
+@property (nonatomic) NSInteger holdsPosition;
 @property (nonatomic) NSDate *availableSince;
 @property (nonatomic) NSDate *availableUntil;
 @property (nonatomic) NSMutableArray *mutableAcquisitionFormats;
@@ -61,6 +63,12 @@
   NYPLXML *copiesXML = [linkXML firstChildWithName:@"copies"];
   if (copiesXML) {
     self.availableCopies = [copiesXML.attributes[@"available"] integerValue];
+    self.totalCopies = [copiesXML.attributes[@"total"] integerValue];
+  }
+  
+  NYPLXML *holdsXML = [linkXML firstChildWithName:@"holds"];
+  if (holdsXML) {
+    self.holdsPosition = [holdsXML.attributes[@"position"] integerValue];
   }
   
   [self addAcquisitionFormatsWithXML:linkXML];

--- a/Simplified/NYPLReaderViewController.m
+++ b/Simplified/NYPLReaderViewController.m
@@ -250,6 +250,7 @@ didEncounterCorruptionForBook:(__attribute__((unused)) NYPLBook *)book
   self.view.backgroundColor = [NYPLConfiguration backgroundColor];
   
   NYPLRoundedButton *const settingsButton = [NYPLRoundedButton button];
+  settingsButton.contentEdgeInsets = UIEdgeInsetsZero;
   settingsButton.accessibilityLabel = NSLocalizedString(@"ReaderViewControllerToggleReaderSettings", nil);
   [settingsButton setTitle:@"Aa" forState:UIControlStateNormal];
   [settingsButton sizeToFit];
@@ -261,6 +262,7 @@ didEncounterCorruptionForBook:(__attribute__((unused)) NYPLBook *)book
   self.settingsBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:settingsButton];
   
   NYPLRoundedButton *const TOCButton = [NYPLRoundedButton button];
+  TOCButton.contentEdgeInsets = UIEdgeInsetsZero;
   TOCButton.accessibilityLabel = [[NSString alloc] initWithFormat:NSLocalizedString(@"TOC", nil)];
   TOCButton.bounds = settingsButton.bounds;
   [TOCButton setImage:[UIImage imageNamed:@"TOC"] forState:UIControlStateNormal];

--- a/Simplified/NYPLRoundedButton.h
+++ b/Simplified/NYPLRoundedButton.h
@@ -1,9 +1,3 @@
-typedef NS_ENUM(NSInteger, NYPLRoundedButtonType) {
-  NYPLRoundedButtonTypeNormal = 0,
-  NYPLRoundedButtonTypeClock,
-  NYPLRoundedButtonTypeQueue
-};
-
 @interface NYPLRoundedButton : UIButton
 
 + (id)buttonWithType:(UIButtonType)buttonType NS_UNAVAILABLE;
@@ -11,11 +5,6 @@ typedef NS_ENUM(NSInteger, NYPLRoundedButtonType) {
 - (id)init NS_UNAVAILABLE;
 - (id)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (id)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
-
-@property (nonatomic) NYPLRoundedButtonType type;
-@property (nonatomic) NSInteger queuePosition;
-@property (nonatomic) NSDate *endDate;
-@property (nonatomic) BOOL fromDetailView;
 
 + (instancetype)button;
 

--- a/Simplified/NYPLRoundedButton.m
+++ b/Simplified/NYPLRoundedButton.m
@@ -1,11 +1,11 @@
+@import PureLayout;
+
 #import "NYPLRoundedButton.h"
 #import "NSDate+NYPLDateAdditions.h"
 
 @interface NYPLRoundedButton ()
 
-@property (nonatomic) UIImageView *iconView;
 @property (nonatomic) UILabel *label;
-
 
 @end
 
@@ -21,67 +21,15 @@
   button.layer.borderWidth = 1;
   button.layer.cornerRadius = 3;
   
-  button.iconView = [UIImageView new];
+  button.contentEdgeInsets = UIEdgeInsetsMake(8, 8, 8, 8);
+  
   button.label = [UILabel new];
   button.label.textColor = button.tintColor;
   button.label.font = [UIFont systemFontOfSize:9];
   
-  [button addSubview:button.iconView];
   [button addSubview:button.label];
   
-  button.type = NYPLRoundedButtonTypeNormal;
-
   return button;
-}
-
-- (void)setType:(NYPLRoundedButtonType)type
-{
-  _type = type;
-  [self updateViews];
-}
-
-- (void)setQueuePosition:(NSInteger)queuePosition
-{
-  _queuePosition = queuePosition;
-  [self updateViews];
-}
-
-- (void)setEndDate:(NSDate *)endDate
-{
-  _endDate = endDate;
-  [self updateViews];
-}
-
-- (void)updateViews
-{
-  if(self.type == NYPLRoundedButtonTypeNormal || self.fromDetailView) {
-    if (!self.fromDetailView) {
-      self.contentEdgeInsets = UIEdgeInsetsZero;
-    } else {
-      self.contentEdgeInsets = UIEdgeInsetsMake(8, 20, 8, 20);
-    }
-    self.iconView.hidden = YES;
-    self.label.hidden = YES;
-  } else {
-    // If we ever actually use a queue, that icon should be specified here
-    NSString *imageName = self.type == NYPLRoundedButtonTypeClock ? @"Clock" : @"Clock";
-    self.iconView.image = [[UIImage imageNamed:imageName] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-    self.iconView.hidden = NO;
-    self.label.hidden = NO;
-    if(self.type == NYPLRoundedButtonTypeClock) {
-      self.label.text = [self.endDate shortTimeUntilString];
-    } else {
-      self.label.text = [@(self.queuePosition) stringValue];
-    }
-    
-    [self.label sizeToFit];
-    
-    self.iconView.frame = CGRectMake(8, 3, 14, 14);
-    CGRect frame = self.label.frame;
-    frame.origin = CGPointMake(self.iconView.center.x - frame.size.width/2, CGRectGetMaxY(self.iconView.frame));
-    self.label.frame = frame;
-    self.contentEdgeInsets = UIEdgeInsetsMake(6, self.iconView.frame.size.width + 8, 6, 0);
-  }
 }
 
 - (void)updateColors
@@ -89,7 +37,6 @@
   UIColor *color = self.enabled ? self.tintColor : [UIColor grayColor];
   self.layer.borderColor = color.CGColor;
   self.label.textColor = color;
-  self.iconView.tintColor = color;
 }
 
 - (void)setEnabled:(BOOL)enabled

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -103,7 +103,7 @@
 "BookDetailViewControllerAvailableToBorrowTitle" = "This book is available to borrow.";
 "BookDetailViewControllerCanHoldTitle" = "All licenses of this book are currently checked out";
 "BookDetailViewControllerCanKeepTitle" = "This open-access book is available to keep.";
-"BookDetailViewControllerHoldingTitleFormat" = "Available for checkout in approximately %@.";
+"BookDetailViewControllerHoldingTitleFormat" = "Available for checkout in less than %@.";
 "BookDetailViewControllerReservedTitleFormat" = "This reservation will be automatically cancelled in %@.";
 "BookDetailViewControllerDistributedByFormat" = "Distributed by: ";
 


### PR DESCRIPTION
fixes #842 

Unifies look to NYPLRoundedButton.
Removes "Clock" icon view from buttons, as well as stubs for "Queue" icon.

Move language into book detail to provide queue and total copies information while a book is in "Reserved" Status.