### PR TITLE
Handling Exceptions with ZXingObjc

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		E6B6E76F1F6859A4007EE361 /* NYPLKeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B6E76E1F6859A4007EE361 /* NYPLKeychainManager.swift */; };
 		E6BA02B81DE4B6F600F76404 /* RemoteHTMLViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BA02B71DE4B6F600F76404 /* RemoteHTMLViewController.swift */; };
 		E6BC315D1E009F3E0021B65E /* NYPLAgeCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BC315C1E009F3E0021B65E /* NYPLAgeCheck.swift */; };
+		E6C91BC21FD5F63B00A32F42 /* NYPLZXingEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = E6C91BC11FD5F63B00A32F42 /* NYPLZXingEncoder.m */; };
 		E6D775421F9FE0AF00C0B722 /* NYPLBarcodeScanningViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E6D7753D1F9FE0AF00C0B722 /* NYPLBarcodeScanningViewController.m */; };
 		E6DA7EA01F2A718600CFBEC8 /* NYPLBookAuthor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DA7E9F1F2A718600CFBEC8 /* NYPLBookAuthor.swift */; };
 		E6F26E731DFF672F00C103CA /* NYPLDirectoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F26E721DFF672F00C103CA /* NYPLDirectoryManager.swift */; };
@@ -553,6 +554,8 @@
 		E6B6E76E1F6859A4007EE361 /* NYPLKeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLKeychainManager.swift; sourceTree = "<group>"; };
 		E6BA02B71DE4B6F600F76404 /* RemoteHTMLViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteHTMLViewController.swift; sourceTree = "<group>"; };
 		E6BC315C1E009F3E0021B65E /* NYPLAgeCheck.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLAgeCheck.swift; sourceTree = "<group>"; };
+		E6C91BC01FD5F63B00A32F42 /* NYPLZXingEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NYPLZXingEncoder.h; sourceTree = "<group>"; };
+		E6C91BC11FD5F63B00A32F42 /* NYPLZXingEncoder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NYPLZXingEncoder.m; sourceTree = "<group>"; };
 		E6D7753D1F9FE0AF00C0B722 /* NYPLBarcodeScanningViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYPLBarcodeScanningViewController.m; sourceTree = "<group>"; };
 		E6D775431F9FE0C400C0B722 /* NYPLBarcodeScanningViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYPLBarcodeScanningViewController.h; sourceTree = "<group>"; };
 		E6DA7E9F1F2A718600CFBEC8 /* NYPLBookAuthor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLBookAuthor.swift; sourceTree = "<group>"; };
@@ -1062,6 +1065,8 @@
 				E6202A031DD52B8600C99553 /* NYPLWelcomeScreen.swift */,
 				111559EB19B8FA530003BE94 /* NYPLXML.h */,
 				111559EC19B8FA590003BE94 /* NYPLXML.m */,
+				E6C91BC01FD5F63B00A32F42 /* NYPLZXingEncoder.h */,
+				E6C91BC11FD5F63B00A32F42 /* NYPLZXingEncoder.m */,
 				AE77E8DE5454517F1AE119BF /* OPDS */,
 				119504051994061E009FB788 /* Reader */,
 				11C5DCEE1976D19E005A9945 /* Settings */,
@@ -1582,6 +1587,7 @@
 				1164A9F71A797238002BD3AE /* NYPLSettings.m in Sources */,
 				11BFDB39199C117B00378691 /* NYPLReaderTOCCell.m in Sources */,
 				E6F26E731DFF672F00C103CA /* NYPLDirectoryManager.swift in Sources */,
+				E6C91BC21FD5F63B00A32F42 /* NYPLZXingEncoder.m in Sources */,
 				085D31D71BE29E38007F7672 /* NYPLProblemReportViewController.m in Sources */,
 				11C5DCF21976D1E0005A9945 /* NYPLHoldsNavigationController.m in Sources */,
 				A42E0DF11B3F5A490095EBAE /* NYPLRemoteViewController.m in Sources */,

--- a/Simplified/NYPLBarcode.swift
+++ b/Simplified/NYPLBarcode.swift
@@ -28,25 +28,20 @@ fileprivate func ZXBarcodeFormatFor(_ NYPLBarcodeType:NYPLBarcodeType) -> ZXBarc
 /// Keep any third party dependency abstracted out of the main app.
 final class NYPLBarcode: NSObject {
 
-  class func image(fromString string: String, superviewWidth: CGFloat, type: NYPLBarcodeType) -> UIImage?
+  class func image(fromString stringToEncode: String, superviewWidth: CGFloat, type: NYPLBarcodeType) -> UIImage?
   {
     let barcodeWidth = imageWidthFor(superviewWidth)
-    guard let writer = ZXMultiFormatWriter.writer() as? ZXWriter else { return nilWithGenericError() }
-    do {
-      let encodeHints = ZXEncodeHints.init()
-      encodeHints.margin = 0
-      let result = try writer.encode(string,
-                                     format: ZXBarcodeFormatFor(type),
-                                     width: Int32(barcodeWidth),
-                                     height: Int32(barcodeHeight),
-                                     hints: encodeHints)
-      if let cgImage = ZXImage.init(matrix: result).cgimage {
-        return UIImage.init(cgImage: cgImage)
-      } else {
-        return nilWithGenericError()
-      }
-    } catch {
-      Log.error(#file, "Failed to create barcode image: \(error.localizedDescription)")
+    let encodeHints = ZXEncodeHints.init()
+    encodeHints.margin = 0
+    if let image = NYPLZXingEncoder.encode(with: stringToEncode,
+                                           format: ZXBarcodeFormatFor(type),
+                                           width: Int32(barcodeWidth),
+                                           height: Int32(barcodeHeight),
+                                           encodeHints: encodeHints)
+    {
+      return image
+    } else {
+      Log.error(#file, "Failed to create barcode image.")
       return nil
     }
   }

--- a/Simplified/NYPLBarcode.swift
+++ b/Simplified/NYPLBarcode.swift
@@ -28,7 +28,13 @@ fileprivate func ZXBarcodeFormatFor(_ NYPLBarcodeType:NYPLBarcodeType) -> ZXBarc
 /// Keep any third party dependency abstracted out of the main app.
 final class NYPLBarcode: NSObject {
 
-  class func image(fromString stringToEncode: String, superviewWidth: CGFloat, type: NYPLBarcodeType) -> UIImage?
+  var libraryName: String?
+
+  init (library: String) {
+    self.libraryName = library
+  }
+
+  func image(fromString stringToEncode: String, superviewWidth: CGFloat, type: NYPLBarcodeType) -> UIImage?
   {
     let barcodeWidth = imageWidthFor(superviewWidth)
     let encodeHints = ZXEncodeHints.init()
@@ -37,6 +43,7 @@ final class NYPLBarcode: NSObject {
                                            format: ZXBarcodeFormatFor(type),
                                            width: Int32(barcodeWidth),
                                            height: Int32(barcodeHeight),
+                                           library: self.libraryName ?? "Unknown",
                                            encodeHints: encodeHints)
     {
       return image
@@ -53,18 +60,12 @@ final class NYPLBarcode: NSObject {
     NYPLRootTabBarController.shared().safelyPresentViewController(navController, animated: true, completion: nil)
   }
 
-  private class func imageWidthFor(_ superviewWidth: CGFloat) -> CGFloat
+  private func imageWidthFor(_ superviewWidth: CGFloat) -> CGFloat
   {
     if superviewWidth > maxBarcodeWidth {
       return maxBarcodeWidth
     } else {
       return superviewWidth
     }
-  }
-
-  private class func nilWithGenericError() -> UIImage?
-  {
-    Log.error(#file, "Error creating image from barcode string.")
-    return nil
   }
 }

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -923,9 +923,11 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       if (![self librarySupportsBarcodeDisplay]) {
         NYPLLOG(@"A nonvalid library was attempting to create a barcode image.");
       } else {
-        UIImage *barcodeImage = [NYPLBarcode imageFromString:account.authorizationIdentifier
-                                              superviewWidth:self.tableView.bounds.size.width
-                                                        type:NYPLBarcodeTypeCodabar];
+        NYPLBarcode *barcode = [[NYPLBarcode alloc] initWithLibrary:self.account.name];
+        UIImage *barcodeImage = [barcode imageFromString:account.authorizationIdentifier
+                                          superviewWidth:self.tableView.bounds.size.width
+                                                    type:NYPLBarcodeTypeCodabar];
+
         if (barcodeImage) {
           self.barcodeImageView = [[UIImageView alloc] initWithImage:barcodeImage];
           self.barcodeImageLabel = [[UILabel alloc] init];

--- a/Simplified/NYPLZXingEncoder.h
+++ b/Simplified/NYPLZXingEncoder.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+@import Bugsnag;
 @import ZXingObjC;
 
 /// The ZXingObj framework encoder throws exceptions, which Swift is not
@@ -9,6 +10,7 @@
                        format:(ZXBarcodeFormat)format
                         width:(int)width
                        height:(int)height
+                      library:(NSString *)library
                   encodeHints:(ZXEncodeHints *)hints;
 
 @end

--- a/Simplified/NYPLZXingEncoder.h
+++ b/Simplified/NYPLZXingEncoder.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+@import ZXingObjC;
+
+/// The ZXingObj framework encoder throws exceptions, which Swift is not
+/// built to handle, so this class wraps the encoding function.
+@interface NYPLZXingEncoder : NSObject
+
++ (UIImage *)encodeWithString:(NSString *)string
+                       format:(ZXBarcodeFormat)format
+                        width:(int)width
+                       height:(int)height
+                  encodeHints:(ZXEncodeHints *)hints;
+
+@end

--- a/Simplified/NYPLZXingEncoder.m
+++ b/Simplified/NYPLZXingEncoder.m
@@ -1,0 +1,40 @@
+#import "NYPLZXingEncoder.h"
+
+@implementation NYPLZXingEncoder
+
++ (UIImage *)encodeWithString:(NSString *)string
+                       format:(ZXBarcodeFormat)format
+                        width:(int)width
+                       height:(int)height
+                  encodeHints:(ZXEncodeHints *)hints
+{
+  @try {
+    NSError *error = nil;
+    ZXMultiFormatWriter *writer = [ZXMultiFormatWriter writer];
+    ZXBitMatrix* result = [writer encode:string
+                                  format:format
+                                   width:width
+                                  height:height
+                                   hints:hints
+                                   error:&error];
+    if (result) {
+      CGImageRef imageRef = [[ZXImage imageWithMatrix:result] cgimage];
+      UIImage *image = [[UIImage alloc] initWithCGImage:imageRef];
+      if (image) {
+        return image;
+      } else {
+        return nil;
+      }
+    } else {
+      NSString *errorMessage = [error localizedDescription];
+      NYPLLOG_F(@"Error encoding barcode string. Description: %@", errorMessage);
+      return nil;
+    }
+  }
+  @catch (NSException *exception) {
+    NYPLLOG_F(@"Exception thrown during barcode image encoding: %@",exception.name);
+    return nil;
+  }
+}
+
+@end

--- a/Simplified/NYPLZXingEncoder.m
+++ b/Simplified/NYPLZXingEncoder.m
@@ -6,6 +6,7 @@
                        format:(ZXBarcodeFormat)format
                         width:(int)width
                        height:(int)height
+                      library:(NSString *)library
                   encodeHints:(ZXEncodeHints *)hints
 {
   @try {
@@ -33,8 +34,19 @@
   }
   @catch (NSException *exception) {
     NYPLLOG_F(@"Exception thrown during barcode image encoding: %@",exception.name);
+    if (exception.name && exception.reason) [self logExceptionToBugsnag:exception library:library];
     return nil;
   }
+}
+
++ (void)logExceptionToBugsnag:(NSException *)exception library:(NSString *)library
+{
+  [Bugsnag notifyError:[NSError errorWithDomain:@"org.nypl.labs.SimplyE" code:8 userInfo:nil]
+                 block:^(BugsnagCrashReport * _Nonnull report) {
+                   report.context = @"NYPLZXingEncoder";
+                   report.severity = BSGSeverityInfo;
+                   report.errorMessage = [NSString stringWithFormat:@"%@: %@. %@", library, exception.name, exception.reason];
+                 }];
 }
 
 @end

--- a/Simplified/SimplyE-Bridging-Header.h
+++ b/Simplified/SimplyE-Bridging-Header.h
@@ -27,3 +27,4 @@
 #import "NYPLKeychain.h"
 #import "NYPLBarcodeScanningViewController.h"
 #import "NYPLRootTabBarController.h"
+#import "NYPLZXingEncoder.h"


### PR DESCRIPTION
Create Objective-C method wrapper to handle thrown NSExceptions.
Add logging for interest in collecting authorization ID's that are not valid barcode numbers.

Fixes #846 