### PR TITLE
Privacy Violation Crash (potential fixes)

### DIFF
--- a/Simplified/Simplified-Info.plist
+++ b/Simplified/Simplified-Info.plist
@@ -47,9 +47,7 @@
 		<true/>
 	</dict>
 	<key>NSCameraUsageDescription</key>
-	<string>For Barcode Scanning</string>
-	<key>NSLocationUsageDescription</key>
-	<string>This service is available to New York State residents only. In order to determine your location, please allow access</string>
+	<string>SimplyE requires access to the camera in order to scan your library card.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This service is available to New York State residents only. In order to determine your location, please allow access</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
Only happening on iOS 11, and cannot currently reproduce. But potential changes to address fix:

- Properly check and request access for the camera.
- Remove a plist key no longer used by the OS. (7.0+)
- Add a plist key for adding photos to the camera roll, as this may be allowed in an unknown dark corner of HelpStack.

Observe Crash analytics for further possible maintenance.

fixes #845 