### PR TITLE
NYPLRoundedButton IconView update

### DIFF
--- a/Simplified/NYPLBookButtonsView.m
+++ b/Simplified/NYPLBookButtonsView.m
@@ -235,6 +235,18 @@
     // Re-enable animations as per usual.
     [UIView setAnimationsEnabled:YES];
     
+    // Provide End-Date for checked out loans
+    if ([buttonInfo[AddIndicatorKey] isEqualToValue:@(YES)]) {
+      if (self.book.availableUntil && [self.book.availableUntil timeIntervalSinceNow] > 0 && self.state != NYPLBookButtonsStateHolding) {
+        button.type = NYPLRoundedButtonTypeClock;
+        button.endDate = self.book.availableUntil;
+      } else {
+        button.type = NYPLRoundedButtonTypeNormal;
+      }
+    } else {
+      button.type = NYPLRoundedButtonTypeNormal;
+    }
+
     [visibleButtons addObject:button];
   }
   for (NYPLRoundedButton *button in @[self.downloadButton, self.deleteButton, self.readButton]) {

--- a/Simplified/NYPLBookDetailButtonsView.m
+++ b/Simplified/NYPLBookDetailButtonsView.m
@@ -34,21 +34,25 @@
   self.constraints = [[NSMutableArray alloc] init];
   
   self.deleteButton = [NYPLRoundedButton button];
+  self.deleteButton.fromDetailView = YES;
   self.deleteButton.titleLabel.minimumScaleFactor = 0.8f;
   [self.deleteButton addTarget:self action:@selector(didSelectReturn) forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.deleteButton];
 
   self.downloadButton = [NYPLRoundedButton button];
+  self.downloadButton.fromDetailView = YES;
   self.downloadButton.titleLabel.minimumScaleFactor = 0.8f;
   [self.downloadButton addTarget:self action:@selector(didSelectDownload) forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.downloadButton];
 
   self.readButton = [NYPLRoundedButton button];
+  self.readButton.fromDetailView = YES;
   self.readButton.titleLabel.minimumScaleFactor = 0.8f;
   [self.readButton addTarget:self action:@selector(didSelectRead) forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.readButton];
   
   self.cancelButton = [NYPLRoundedButton button];
+  self.cancelButton.fromDetailView = YES;
   self.cancelButton.titleLabel.minimumScaleFactor = 0.8f;
   [self.cancelButton addTarget:self action:@selector(didSelectCancel) forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.cancelButton];
@@ -266,6 +270,18 @@
     
     // Re-enable animations as per usual.
     [UIView setAnimationsEnabled:YES];
+
+    // Provide End-Date for checked out loans
+    if ([buttonInfo[AddIndicatorKey] isEqualToValue:@(YES)]) {
+      if (self.book.availableUntil && [self.book.availableUntil timeIntervalSinceNow] > 0 && self.state != NYPLBookButtonsStateHolding) {
+        button.type = NYPLRoundedButtonTypeClock;
+        button.endDate = self.book.availableUntil;
+      } else {
+        button.type = NYPLRoundedButtonTypeNormal;
+      }
+    } else {
+      button.type = NYPLRoundedButtonTypeNormal;
+    }
     
     [visibleButtons addObject:button];
   }

--- a/Simplified/NYPLBookDetailNormalView.m
+++ b/Simplified/NYPLBookDetailNormalView.m
@@ -118,7 +118,7 @@ typedef NS_ENUM (NSInteger, NYPLProblemReportButtonState) {
       newMessageString = NSLocalizedString(@"BookDetailViewControllerDownloadNeededTitle", nil);
       break;
     case NYPLBookButtonsStateDownloadSuccessful:
-      newMessageString = NSLocalizedString(@"BookDetailViewControllerDownloadSuccessfulTitle", nil);
+      newMessageString = [self messageStringForNYPLBookButtonStateSuccessful];
       break;
     case NYPLBookButtonsStateHolding:
       newMessageString = [self messageStringForNYPLBookButtonsStateHolding];
@@ -164,6 +164,18 @@ typedef NS_ENUM (NSInteger, NYPLProblemReportButtonState) {
     return [newMessageString stringByAppendingString:positionString];
   } else {
     return newMessageString;
+  }
+}
+
+-(NSString *)messageStringForNYPLBookButtonStateSuccessful
+{
+  NSString *message = NSLocalizedString(@"BookDetailViewControllerDownloadSuccessfulTitle", nil);
+  if (self.book.availableUntil) {
+    NSString *timeUntilString = [self.book.availableUntil longTimeUntilString];
+    NSString *timeEstimateMessage = [NSString stringWithFormat:NSLocalizedString(@"It will expire in %@.", @"Tell the user how much time they have left for the book they have borrowed."),timeUntilString];
+    return [NSString stringWithFormat:@"%@\n%@",message,timeEstimateMessage];
+  } else {
+    return message;
   }
 }
 

--- a/Simplified/NYPLRoundedButton.h
+++ b/Simplified/NYPLRoundedButton.h
@@ -1,3 +1,8 @@
+typedef NS_ENUM(NSInteger, NYPLRoundedButtonType) {
+  NYPLRoundedButtonTypeNormal = 0,
+  NYPLRoundedButtonTypeClock
+};
+
 @interface NYPLRoundedButton : UIButton
 
 + (id)buttonWithType:(UIButtonType)buttonType NS_UNAVAILABLE;
@@ -5,6 +10,10 @@
 - (id)init NS_UNAVAILABLE;
 - (id)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (id)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
+
+@property (nonatomic) NYPLRoundedButtonType type;
+@property (nonatomic) NSDate *endDate;
+@property (nonatomic) BOOL fromDetailView;
 
 + (instancetype)button;
 

--- a/Simplified/NYPLRoundedButton.m
+++ b/Simplified/NYPLRoundedButton.m
@@ -5,6 +5,7 @@
 
 @interface NYPLRoundedButton ()
 
+@property (nonatomic) UIImageView *iconView;
 @property (nonatomic) UILabel *label;
 
 @end
@@ -21,15 +22,54 @@
   button.layer.borderWidth = 1;
   button.layer.cornerRadius = 3;
   
-  button.contentEdgeInsets = UIEdgeInsetsMake(8, 8, 8, 8);
-  
+  button.iconView = [UIImageView new];
   button.label = [UILabel new];
   button.label.textColor = button.tintColor;
   button.label.font = [UIFont systemFontOfSize:9];
   
+  [button addSubview:button.iconView];
   [button addSubview:button.label];
   
+  button.type = NYPLRoundedButtonTypeNormal;
+
   return button;
+}
+
+- (void)setType:(NYPLRoundedButtonType)type
+{
+  _type = type;
+  [self updateViews];
+}
+
+- (void)setEndDate:(NSDate *)endDate
+{
+  _endDate = endDate;
+  [self updateViews];
+}
+
+- (void)updateViews
+{
+  if(self.type == NYPLRoundedButtonTypeNormal || self.fromDetailView) {
+    if (!self.fromDetailView) {
+      self.contentEdgeInsets = UIEdgeInsetsZero;
+    } else {
+      self.contentEdgeInsets = UIEdgeInsetsMake(8, 20, 8, 20);
+    }
+    self.iconView.hidden = YES;
+    self.label.hidden = YES;
+  } else {
+    self.iconView.image = [[UIImage imageNamed:@"Clock"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    self.iconView.hidden = NO;
+    self.label.hidden = NO;
+    self.label.text = [self.endDate shortTimeUntilString];
+    [self.label sizeToFit];
+
+    self.iconView.frame = CGRectMake(8, 3, 14, 14);
+    CGRect frame = self.label.frame;
+    frame.origin = CGPointMake(self.iconView.center.x - frame.size.width/2, CGRectGetMaxY(self.iconView.frame));
+    self.label.frame = frame;
+    self.contentEdgeInsets = UIEdgeInsetsMake(6, self.iconView.frame.size.width + 8, 6, 0);
+  }
 }
 
 - (void)updateColors
@@ -37,6 +77,7 @@
   UIColor *color = self.enabled ? self.tintColor : [UIColor grayColor];
   self.layer.borderColor = color.CGColor;
   self.label.textColor = color;
+  self.iconView.tintColor = color;
 }
 
 - (void)setEnabled:(BOOL)enabled


### PR DESCRIPTION
Bring back the clock icon view for loan due dates. This was useful contextual information. Keep out the guess for reservation times, since that has been moved to book detail with more information like queue position and total books in circulation for those in line.