### PR TITLE
Overhaul reader animation and gesture code

### DIFF
--- a/Simplified/NYPLReaderReadiumView.h
+++ b/Simplified/NYPLReaderReadiumView.h
@@ -23,7 +23,6 @@
 - (void) applyMediaOverlayPlaybackToggle;
 - (void) openPageLeft;
 - (void) openPageRight;
-- (BOOL) touchIntersectsLink:(UITouch *)touch;
 
 - (NSString*) currentChapter;
 

--- a/Simplified/NYPLReaderReadiumView.m
+++ b/Simplified/NYPLReaderReadiumView.m
@@ -398,9 +398,9 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
     NSArray *const components = [request.URL.resourceSpecifier componentsSeparatedByString:@"/"];
     NSString *const function = components[0];
     if([function isEqualToString:@"gesture-left"]) {
-      [self.delegate renderer:self didReceiveGesture:NYPLReaderRendererGestureTurnLeft];
+      [self sequentiallyEvaluateJavaScript:@"ReadiumSDK.reader.openPageLeft()"];
     } else if([function isEqualToString:@"gesture-right"]) {
-      [self.delegate renderer:self didReceiveGesture:NYPLReaderRendererGestureTurnRight];
+      [self sequentiallyEvaluateJavaScript:@"ReadiumSDK.reader.openPageRight()"];
     } else if([function isEqualToString:@"gesture-center"]) {
       [self.delegate renderer:self didReceiveGesture:NYPLReaderRendererGestureToggleUserInterface];
     } else {

--- a/Simplified/NYPLReaderReadiumView.m
+++ b/Simplified/NYPLReaderReadiumView.m
@@ -345,43 +345,6 @@ static void generateTOCElements(NSArray *const navigationElements,
   [self sequentiallyEvaluateJavaScript:@"ReadiumSDK.reader.openPageRight()"];
 }
 
-- (BOOL) touchIntersectsLink:(UITouch *)touch
-{
-  // Adapted from http://stackoverflow.com/questions/7216356/iphone-tapgesture-on-uiwebview-conflicts-with-the-link-clicking
-  
-  __block BOOL retVal = NO;
-  
-  //Check if a link was clicked
-  NSString *js = @"simplified.getSemicolonSeparatedLinkRects()";
-  
-  dispatch_semaphore_t sephamore = dispatch_semaphore_create(0);
-  
-  __weak NYPLReaderReadiumView *const weakSelf = self;
-  
-  [self
-   sequentiallyEvaluateJavaScript:js
-   withCompletionHandler:^(id _Nullable result, __unused NSError * _Nullable error) {
-     NSArray *linkArray = [result componentsSeparatedByString:@";"];
-     CGPoint touchPoint = [touch locationInView:weakSelf.webView];
-     for ( NSString *linkRectStr in linkArray ) {
-       CGRect rect = CGRectFromString(linkRectStr);
-       if ( CGRectContainsPoint( rect, touchPoint ) ) {
-         retVal = YES;
-         break;
-       }
-     }
-     dispatch_semaphore_signal(sephamore);
-   }];
-  
-  while(dispatch_semaphore_wait(sephamore, DISPATCH_TIME_NOW)) {
-    [[NSRunLoop currentRunLoop]
-     runMode:NSDefaultRunLoopMode
-     beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
-  }
-  
-  return retVal;
-}
-
 #pragma mark NSObject
 
 - (void)dealloc
@@ -434,9 +397,17 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
   NSURLRequest *const request = navigationAction.request;
   
   if([request.URL.scheme isEqualToString:@"simplified"]) {
-//    NSArray *const components = [request.URL.resourceSpecifier componentsSeparatedByString:@"/"];
-//    NSString *const function = components[0];
-    NYPLLOG(@"Ignoring unknown simplified function.");
+    NSArray *const components = [request.URL.resourceSpecifier componentsSeparatedByString:@"/"];
+    NSString *const function = components[0];
+    if([function isEqualToString:@"gesture-left"]) {
+      [self.delegate renderer:self didReceiveGesture:NYPLReaderRendererGestureTurnLeft];
+    } else if([function isEqualToString:@"gesture-right"]) {
+      [self.delegate renderer:self didReceiveGesture:NYPLReaderRendererGestureTurnRight];
+    } else if([function isEqualToString:@"gesture-center"]) {
+      [self.delegate renderer:self didReceiveGesture:NYPLReaderRendererGestureToggleUserInterface];
+    } else {
+      NYPLLOG(@"Ignoring unknown simplified function.");
+    }
     decisionHandler(WKNavigationActionPolicyCancel);
     return;
   }
@@ -727,7 +698,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
   self.isPageTurning = NO;
   
   // Readium needs a moment...
-  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
     [self
      sequentiallyEvaluateJavaScript:@"ReadiumSDK.reader.bookmarkCurrentPage()"
      withCompletionHandler:^(id  _Nullable result, __unused NSError *_Nullable error) {

--- a/Simplified/NYPLReaderReadiumView.m
+++ b/Simplified/NYPLReaderReadiumView.m
@@ -175,8 +175,6 @@ static void generateTOCElements(NSArray *const navigationElements,
   
   self.backgroundColor = [NYPLReaderSettings sharedSettings].backgroundColor;
   
-  [NYPLReaderSettings sharedSettings].currentReaderReadiumView = self;
-  
   self.javaScriptIsRunning = NO;
   self.javaScriptHandlerQueue = [NSMutableArray array];
   self.javaScriptStringQueue = [NSMutableArray array];

--- a/Simplified/NYPLReaderRenderer.h
+++ b/Simplified/NYPLReaderRenderer.h
@@ -7,7 +7,9 @@
 @class NYPLReaderBookmark;
 
 typedef NS_ENUM(NSInteger, NYPLReaderRendererGesture) {
-  NYPLReaderRendererGestureToggleUserInterface
+  NYPLReaderRendererGestureToggleUserInterface,
+  NYPLReaderRendererGestureTurnLeft,
+  NYPLReaderRendererGestureTurnRight
 };
 
 @protocol NYPLReaderRenderer
@@ -44,5 +46,7 @@ didUpdateProgressWithinBook:(float)progressWithinBook
 
 - (void)updateBookmarkIcon:(BOOL)on;
 - (void)updateCurrentBookmark:(nullable NYPLReaderBookmark*)bookmark;
+
+- (void)renderer:(nonnull id<NYPLReaderRenderer>)render didReceiveGesture:(NYPLReaderRendererGesture)gesture;
 
 @end

--- a/Simplified/NYPLReaderRenderer.h
+++ b/Simplified/NYPLReaderRenderer.h
@@ -7,9 +7,7 @@
 @class NYPLReaderBookmark;
 
 typedef NS_ENUM(NSInteger, NYPLReaderRendererGesture) {
-  NYPLReaderRendererGestureToggleUserInterface,
-  NYPLReaderRendererGestureTurnLeft,
-  NYPLReaderRendererGestureTurnRight
+  NYPLReaderRendererGestureToggleUserInterface
 };
 
 @protocol NYPLReaderRenderer

--- a/Simplified/NYPLReaderSettings.h
+++ b/Simplified/NYPLReaderSettings.h
@@ -63,7 +63,6 @@ BOOL NYPLReaderSettingsIncreasedFontSize(NYPLReaderSettingsFontSize input,
 @property (nonatomic) NYPLReaderSettingsFontSize fontSize;
 @property (nonatomic) NYPLReaderSettingsMediaOverlaysEnableClick mediaOverlaysEnableClick;
 @property (nonatomic, readonly) UIColor *foregroundColor;
-@property (nonatomic, weak) id currentReaderReadiumView;
 
 - (void) toggleMediaOverlayPlayback;
 

--- a/Simplified/NYPLReaderSettings.m
+++ b/Simplified/NYPLReaderSettings.m
@@ -346,10 +346,6 @@ static NSString *const MediaOverlaysEnableClick = @"mediaOverlaysEnableClick";
     }];
 }
 
--(void)setCurrentReaderReadiumView:(id)currentReaderReadiumView {
-  _currentReaderReadiumView = currentReaderReadiumView;
-}
-
 - (void) toggleMediaOverlayPlayback {
   __weak NYPLReaderSettings const *weakSelf = self;
   [[NSOperationQueue mainQueue] addOperationWithBlock:^{

--- a/Simplified/NYPLReaderTOCViewController.h
+++ b/Simplified/NYPLReaderTOCViewController.h
@@ -6,10 +6,17 @@
 @protocol NYPLReaderTOCViewControllerDelegate
 
 - (void)TOCViewController:(NYPLReaderTOCViewController *)controller
-didSelectOpaqueLocation:(NYPLReaderRendererOpaqueLocation *)opaqueLocation;
+  didSelectOpaqueLocation:(NYPLReaderRendererOpaqueLocation *)opaqueLocation;
 
 - (void)TOCViewController:(NYPLReaderTOCViewController *)controller
-didSelectBookmark:(NYPLReaderBookmark *)bookmark;
+        didSelectBookmark:(NYPLReaderBookmark *)bookmark;
+
+- (void)TOCViewController:(NYPLReaderTOCViewController *)controller
+        didDeleteBookmark:(NYPLReaderBookmark *)bookmark;
+
+- (void)TOCViewController:(NYPLReaderTOCViewController *)controller
+didRequestSyncBookmarksWithCompletion:
+  (void(^)(BOOL success, NSArray<NYPLReaderBookmark *> *bookmarks))completion;
 
 @end
 

--- a/Simplified/NYPLReaderViewController.m
+++ b/Simplified/NYPLReaderViewController.m
@@ -178,13 +178,7 @@ didEncounterCorruptionForBook:(__attribute__((unused)) NYPLBook *)book
 {
   switch (gesture) {
   case NYPLReaderRendererGestureToggleUserInterface:
-    self.interfaceHidden = !self.interfaceHidden;
-    break;
-  case NYPLReaderRendererGestureTurnLeft:
-    [self turnInDirection:NYPLReaderViewControllerDirectionLeft];
-    break;
-  case NYPLReaderRendererGestureTurnRight:
-    [self turnInDirection:NYPLReaderViewControllerDirectionRight];
+    [self setInterfaceHidden:!self.interfaceHidden animated:YES];
     break;
   }
 }
@@ -676,22 +670,12 @@ spineItemTitle:(NSString *const)title
 
 - (UIViewController *)pageViewController:(__unused UIPageViewController *)pageViewController viewControllerBeforeViewController:(UIViewController *)viewController
 {
-  NYPLReaderReadiumView *rv = self.rendererView;
-  if (rv.isPageTurning || ![rv canGoLeft])
-    return nil;
-  NSInteger i = [self.dummyViewControllers indexOfObject:viewController];
-  i = (i+2)%3;
-  return [self.dummyViewControllers objectAtIndex:i];
+  return nil;
 }
 
 - (UIViewController *)pageViewController:(__unused UIPageViewController *)pageViewController viewControllerAfterViewController:(UIViewController *)viewController
 {
-  NYPLReaderReadiumView *rv = self.rendererView;
-  if (rv.isPageTurning || ![rv canGoRight])
-    return nil;
-  NSInteger i = [self.dummyViewControllers indexOfObject:viewController];
-  i = (i+1)%3;
-  return [self.dummyViewControllers objectAtIndex:i];
+  return nil;
 }
 
 - (void)turnInDirection:(NYPLReaderViewControllerDirection const)direction {

--- a/Simplified/Simplified.js
+++ b/Simplified/Simplified.js
@@ -1,96 +1,153 @@
 function Simplified() {
-  
-  document.documentElement.style.webkitTouchCallout = "none";
-  document.documentElement.style.webkitUserSelect = "none";
-  
-  this.shouldUpdateVisibilityOnUpdate = false;
-  
-  this.getSemicolonSeparatedLinkRects = function() {
-    var offsetRect = document.getElementById('epubContentIframe').getBoundingClientRect();
-    var a = window.frames['epubContentIframe'].document.getElementsByTagName('a');
-    var retVal = new Array();
-    for (var idx= 0; idx < a.length; ++idx) {
-      var r = a[idx].getBoundingClientRect();
-      r.left += offsetRect.left;
-      r.top += offsetRect.top;
-      retVal[idx] = '{{'+r.left+','+r.top+'},{'+r.width+','+r.height+'}}';
+
+  // Valid states for the `tracking` property.
+  var TRACKING_IS_WAITING_FOR_TOUCH = 0;
+  var TRACKING_IS_ACTIVE = 1;
+  var TRACKING_HAS_BEEN_CANCELLED_DUE_TO_MULTITOUCH = 2;
+
+  // Stores whether or not we're still considering the current set of touches
+  // as a potential tap.
+  var tracking = TRACKING_IS_WAITING_FOR_TOUCH;
+
+  // The starting location of a tap.
+  var startX = 0;
+  var startY = 0;
+
+  // Called whenever the user puts a finger down anywhere within the webview.
+  var handleTouchStart = function(event) {
+
+    // We only want to detect taps made with a single finger. As such, if
+    // we ever have more than one touch active at a time, we make a note so
+    // that `handleTouchEnd` will not do anything later on.
+    if (event.touches.length > 1) {
+      tracking = TRACKING_HAS_BEEN_CANCELLED_DUE_TO_MULTITOUCH;
+      return;
     }
-    return retVal.join(';');
-  }
-  
-  function updateVisibility() {
-    
-    var iframe = window.frames["epubContentIframe"];
-    var childs = iframe.document.documentElement.getElementsByTagName('*');
-    
-    var firstElt = null;
-    for (var i=0; i<childs.length; ++i) {
-      var child = childs[i];
-      var visible = ReadiumSDK.reader.getElementVisibility(child);
-      child.setAttribute("aria-hidden", visible ? "false"   : "true");
-      child.setAttribute("tabindex", visible ? i : -1); // Make sure the elements are focusable
-      
-      if (visible) {
-        console.log("Vibisle element: " + child.tagName + " " + child.innerHTML.slice(0, 20));
-        if (firstElt == null && child.tagName == "p")
-          firstElt = child;
-      }
-      
-      var isBlock = window.getComputedStyle(child, "").display == "block";
-      if (!isBlock) {
-        child.setAttribute("role", "presentation");
-      }
+
+    if (tracking === TRACKING_IS_ACTIVE) {
+      tracking = TRACKING_HAS_BEEN_CANCELLED_DUE_TO_MULTITOUCH;
+      return;
     }
-    
-    return firstElt;
-  }
-  
-  this.beginVisibilityUpdates = function() {
-    this.shouldUpdateVisibilityOnUpdate = true;
-    var firstElt = updateVisibility();
-    if (firstElt)
-      firstElt.focus();
-  }
-  
-  this.settingsDidChange = function() {
-    if (this.shouldUpdateVisibilityOnUpdate) {
-      updateVisibility();
+
+    if (tracking === TRACKING_HAS_BEEN_CANCELLED_DUE_TO_MULTITOUCH) {
+      return;
+    }
+
+    tracking = TRACKING_IS_ACTIVE;
+
+    var touch = event.changedTouches[0];
+
+    if(touch.target.nodeName.toUpperCase() === "A") {
+      return;
+    }
+
+    startX = touch.screenX;
+    startY = touch.screenY;
+  };
+
+  // Called almost whenever the user lifts a finger that was previously placed
+  // within the webview. We say "almost" because the shuffling of views that the
+  // native layer does not handle the swipe transitions sometimes results in
+  // `ontuochend` events not being generated at the appropriate times.
+  var handleTouchEnd = function(event) {
+
+    // If the user just lifted up more than one finger...
+    if (event.changedTouches.length > 1) {
+      // ... we do not want to interpret it as the end of a tap because all taps
+      // should involve only a single finger.
+      return;
+    }
+
+    // If the user still has any fingers on the screen...
+    if (event.touches.length !== 0) {
+      // FIXME: Normally we would want to bail out here, but we do not reliably get
+      // `ontouchend` events at the moment because of how swiping is handled in the
+      // native layer of the application.
+      //
+      // return
+    }
+
+    // If tracking was previosuly aborted due to entering a multitouch state...
+    if (tracking !== TRACKING_IS_ACTIVE) {
+      // FIXME: We cannot bail out here as we'd like to for the same reason
+      // mentioned above.
+      ///
+      // tracking = TRACKING_IS_WAITING_FOR_TOUCH;
+      // return
+    }
+
+    tracking = TRACKING_IS_WAITING_FOR_TOUCH;
+
+    var touch = event.changedTouches[0];
+
+    // If the user tapped on a link...
+    if(touch.target.nodeName.toUpperCase() === "A") {
+      // ... let the webview apply its default behavior.
+      return;
+    }
+
+    var maxScreenX = window.orientation === 0 || window.orientation == 180
+      ? screen.width
+      : screen.height;
+
+    var relativeDistanceX = (touch.screenX - startX) / maxScreenX;
+
+    // If a touch began and ended in roughly the same place...
+    if(Math.abs(relativeDistanceX) < 0.1) {
+      // ... we consider it a tap (as opposed to a swipe) and handle it as such.
+      var position = touch.screenX / maxScreenX;
+      if(position <= 0.2) {
+        window.location = "simplified:gesture-left";
+      } else if(position >= 0.8) {
+        window.location = "simplified:gesture-right";
+      } else {
+        window.location = "simplified:gesture-center";
+      }
+
+      // Since we handled the event, we stop the webview from applying its
+      // default behavior.
+      event.stopPropagation();
+      event.preventDefault();
+
+      return;
     }
   };
-  
-  // Because WKWebKit cannot access application fonts, it is necessary to
-  // load them via a @font-face declaration. This declaration must be placed
-  // dynamically on the iframe managed by Readium: Adding it to the container
-  // HTML would not allow the iframe contents to use the font.
-  this.loadOpenDyslexicFonts = function() {
-    if(document.getElementById("openDyslexic") == null) {
-      var iframe = window.frames["epubContentIframe"];
-      var head = iframe.document.head;
-      var style = document.createElement("style");
-      style.id = "openDyslexic";
-      style.appendChild(document.createTextNode(
-        "@font-face { \
-          font-family: 'OpenDyslexic3'; \
-          src: url('/simplified-readium/OpenDyslexic3-Regular.ttf'); \
-        } \
-        @font-face { \
-          font-family: 'OpenDyslexic3'; \
-          src: url('/simplified-readium/OpenDyslexic3-Bold.ttf'); \
-          font-style: bold; \
-        }"));
-      head.appendChild(style);
-    }
-  }
-  
+
+  // Handle gestures between the inner content and the edge of the screen.
+  document.addEventListener("touchstart", handleTouchStart, false);
+  document.addEventListener("touchend", handleTouchEnd, false);
+
+  // Disable selection.
+  document.documentElement.style.webkitTouchCallout = "none";
+  document.documentElement.style.webkitUserSelect = "none";
+
   // This should be called by the host whenever the page changes. This is because a change in the
   // page can mean a change in the iframe and thus requires resetting properties.
   this.pageDidChange = function() {
-    this.loadOpenDyslexicFonts();
-    
-    if (this.shouldUpdateVisibilityOnUpdate) {
-      updateVisibility();
+
+    var iframe = window.frames["epubContentIframe"];
+    if (!iframe) {
+      return;
     }
+
+    // Disable selection.
+    iframe.document.documentElement.style.webkitTouchCallout = "none";
+    iframe.document.documentElement.style.webkitUserSelect = "none";
+
+    // Remove existing handlers, if any.
+    try {
+      iframe.removeEventListener("touchstart", handleTouchStart);
+      iframe.removeEventListener("touchend", handleTouchEnd);
+    } catch (e) {
+      // Do nothing.
+    }
+
+    // Handles gestures for the inner content.
+    iframe.addEventListener("touchstart", handleTouchStart, false);
+    iframe.addEventListener("touchend", handleTouchEnd, false);
   };
+
+  this.pageDidChange();
 }
 
 simplified = new Simplified();

--- a/Simplified/Simplified.js
+++ b/Simplified/Simplified.js
@@ -117,7 +117,10 @@ function Simplified() {
   document.addEventListener("touchstart", handleTouchStart, false);
   document.addEventListener("touchend", handleTouchEnd, false);
 
-  // Disable selection.
+  // Disable selection outside the iframe. This is probably not necessary as we
+  // do not disable it inside the iframe (because doing so breaks Readium's CFI
+  // logic), but it's safe to do and may avoid persistent selection strangeness
+  // across resource boundaries.
   document.documentElement.style.webkitTouchCallout = "none";
   document.documentElement.style.webkitUserSelect = "none";
 
@@ -129,10 +132,6 @@ function Simplified() {
     if (!iframe) {
       return;
     }
-
-    // Disable selection.
-    iframe.document.documentElement.style.webkitTouchCallout = "none";
-    iframe.document.documentElement.style.webkitUserSelect = "none";
 
     // Remove existing handlers, if any.
     try {

--- a/Simplified/Simplified.js
+++ b/Simplified/Simplified.js
@@ -96,9 +96,9 @@ function Simplified() {
     if(Math.abs(relativeDistanceX) < 0.1) {
       // ... we consider it a tap (as opposed to a swipe) and handle it as such.
       var position = touch.screenX / maxScreenX;
-      if(position <= 0.2) {
+      if(position <= 0.25) {
         window.location = "simplified:gesture-left";
-      } else if(position >= 0.8) {
+      } else if(position >= 0.75) {
         window.location = "simplified:gesture-right";
       } else {
         window.location = "simplified:gesture-center";

--- a/Simplified/Simplified.js
+++ b/Simplified/Simplified.js
@@ -45,9 +45,7 @@ function Simplified() {
   };
 
   // Called almost whenever the user lifts a finger that was previously placed
-  // within the webview. We say "almost" because the shuffling of views that the
-  // native layer does not handle the swipe transitions sometimes results in
-  // `ontuochend` events not being generated at the appropriate times.
+  // within the webview.
   var handleTouchEnd = function(event) {
 
     // If the user just lifted up more than one finger...

--- a/Simplified/Simplified.js
+++ b/Simplified/Simplified.js
@@ -127,6 +127,7 @@ function Simplified() {
 
     var iframe = window.frames["epubContentIframe"];
     if (!iframe) {
+      // This method was called too early, so do nothing.
       return;
     }
 

--- a/Simplified/Simplified.js
+++ b/Simplified/Simplified.js
@@ -133,14 +133,10 @@ function Simplified() {
     }
 
     // Remove existing handlers, if any.
-    try {
-      iframe.removeEventListener("touchstart", handleTouchStart);
-      iframe.removeEventListener("touchend", handleTouchEnd);
-    } catch (e) {
-      // Do nothing.
-    }
+    iframe.removeEventListener("touchstart", handleTouchStart);
+    iframe.removeEventListener("touchend", handleTouchEnd);
 
-    // Handles gestures for the inner content.
+    // Handle gestures for the inner content.
     iframe.addEventListener("touchstart", handleTouchStart, false);
     iframe.addEventListener("touchend", handleTouchEnd, false);
 

--- a/Simplified/Simplified.js
+++ b/Simplified/Simplified.js
@@ -59,12 +59,6 @@ function Simplified() {
 
     var touch = event.changedTouches[0];
 
-    // If the user tapped on a link...
-    if(touch.target.nodeName.toUpperCase() === "A") {
-      // ... let the webview apply its default behavior.
-      return;
-    }
-
     var maxScreenX = window.orientation === 0 || window.orientation == 180
       ? screen.width
       : screen.height;
@@ -74,6 +68,13 @@ function Simplified() {
     // If a touch began and ended in roughly the same place...
     if(Math.abs(relativeDistanceX) < 0.1) {
       // ... we consider it a tap (as opposed to a swipe) and handle it as such.
+
+      // If the user tapped on a link...
+      if(touch.target.nodeName.toUpperCase() === "A") {
+        // ... let the webview apply its default behavior.
+        return;
+      }
+
       var position = touch.screenX / maxScreenX;
       if(position <= 0.25) {
         window.location = "simplified:gesture-left";

--- a/Simplified/Simplified.js
+++ b/Simplified/Simplified.js
@@ -110,6 +110,24 @@ function Simplified() {
       event.preventDefault();
 
       return;
+    } else {
+      var slope = (touch.screenY - startY) / (touch.screenX - startX);
+      // If the user swiped horizontally...
+      if(Math.abs(slope) <= 0.5) {
+        // ... we consider it a swipe-to-turn gesture.
+        if(relativeDistanceX > 0) {
+          window.location = "simplified:gesture-left";
+        } else {
+          window.location = "simplified:gesture-right";
+        }
+
+        // Since we handled the event, we stop the webview from applying its
+        // default behavior.
+        event.stopPropagation();
+        event.preventDefault();
+
+        return;
+      }
     }
   };
 

--- a/Simplified/Simplified.js
+++ b/Simplified/Simplified.js
@@ -144,6 +144,9 @@ function Simplified() {
     // Handles gestures for the inner content.
     iframe.addEventListener("touchstart", handleTouchStart, false);
     iframe.addEventListener("touchend", handleTouchEnd, false);
+
+    // Set up the page turning animation.
+    iframe.document.documentElement.style["transition"] = "left 0.2s";
   };
 
   this.pageDidChange();

--- a/Simplified/Simplified.js
+++ b/Simplified/Simplified.js
@@ -5,8 +5,8 @@ function Simplified() {
   var TRACKING_IS_ACTIVE = 1;
   var TRACKING_HAS_BEEN_CANCELLED_DUE_TO_MULTITOUCH = 2;
 
-  // Stores whether or not we're still considering the current set of touches
-  // as a potential tap.
+  // Stores whether or not we're still considering the current set of touches as
+  // a potential tap.
   var tracking = TRACKING_IS_WAITING_FOR_TOUCH;
 
   // The starting location of a tap.
@@ -16,15 +16,15 @@ function Simplified() {
   // Called whenever the user puts a finger down anywhere within the webview.
   var handleTouchStart = function(event) {
 
-    // We only want to detect taps made with a single finger. As such, if
-    // we ever have more than one touch active at a time, we make a note so
-    // that `handleTouchEnd` will not do anything later on.
+    // We only want to detect taps made with a single finger. As such, if we
+    // ever have more than one touch active at a time, we make a note so that
+    // `handleTouchEnd` will not do anything later on.
     if (event.touches.length > 1) {
       tracking = TRACKING_HAS_BEEN_CANCELLED_DUE_TO_MULTITOUCH;
     }
 
-    // The user had more than one finger down during the current gesture so
-    // we do nothing.
+    // The user had more than one finger down during the current gesture so we
+    // do nothing.
     if (tracking === TRACKING_HAS_BEEN_CANCELLED_DUE_TO_MULTITOUCH) {
       return;
     }
@@ -121,8 +121,9 @@ function Simplified() {
   document.documentElement.style.webkitTouchCallout = "none";
   document.documentElement.style.webkitUserSelect = "none";
 
-  // This should be called by the host whenever the page changes. This is because a change in the
-  // page can mean a change in the iframe and thus requires resetting properties.
+  // This should be called by the host whenever the page changes. This is
+  // because a change in the page can mean a change in the iframe and thus
+  // requires resetting properties.
   this.pageDidChange = function() {
 
     var iframe = window.frames["epubContentIframe"];

--- a/Simplified/Simplified.js
+++ b/Simplified/Simplified.js
@@ -34,12 +34,6 @@ function Simplified() {
 
     var touch = event.changedTouches[0];
 
-    // If the user tapped a link...
-    if(touch.target.nodeName.toUpperCase() === "A") {
-      // ... let the webview handle it normally.
-      return;
-    }
-
     startX = touch.screenX;
     startY = touch.screenY;
   };
@@ -48,31 +42,19 @@ function Simplified() {
   // within the webview.
   var handleTouchEnd = function(event) {
 
-    // If the user just lifted up more than one finger...
-    if (event.changedTouches.length > 1) {
-      // ... we do not want to interpret it as the end of a tap because all taps
-      // should involve only a single finger.
+    // If tracking was aborted due to entering a multitouch state...
+    if (tracking !== TRACKING_IS_ACTIVE) {
+      // ... then if no fingers are on the screen...
+      if(event.touches.length === 0) {
+        // ... reset the tracking state.
+        tracking = TRACKING_IS_WAITING_FOR_TOUCH;
+      }
+
+      // Stop here because of having been in a multitouch state.
       return;
     }
 
-    // If the user still has any fingers on the screen...
-    if (event.touches.length !== 0) {
-      // FIXME: Normally we would want to bail out here, but we do not reliably get
-      // `ontouchend` events at the moment because of how swiping is handled in the
-      // native layer of the application.
-      //
-      // return
-    }
-
-    // If tracking was previosuly aborted due to entering a multitouch state...
-    if (tracking !== TRACKING_IS_ACTIVE) {
-      // FIXME: We cannot bail out here as we'd like to for the same reason
-      // mentioned above.
-      ///
-      // tracking = TRACKING_IS_WAITING_FOR_TOUCH;
-      // return
-    }
-
+    // This is the end of a single-finger gesture so reset tracking.
     tracking = TRACKING_IS_WAITING_FOR_TOUCH;
 
     var touch = event.changedTouches[0];

--- a/Simplified/Simplified.js
+++ b/Simplified/Simplified.js
@@ -21,23 +21,22 @@ function Simplified() {
     // that `handleTouchEnd` will not do anything later on.
     if (event.touches.length > 1) {
       tracking = TRACKING_HAS_BEEN_CANCELLED_DUE_TO_MULTITOUCH;
-      return;
     }
 
-    if (tracking === TRACKING_IS_ACTIVE) {
-      tracking = TRACKING_HAS_BEEN_CANCELLED_DUE_TO_MULTITOUCH;
-      return;
-    }
-
+    // The user had more than one finger down during the current gesture so
+    // we do nothing.
     if (tracking === TRACKING_HAS_BEEN_CANCELLED_DUE_TO_MULTITOUCH) {
       return;
     }
 
+    // We're beginning to track a single-finger tap.
     tracking = TRACKING_IS_ACTIVE;
 
     var touch = event.changedTouches[0];
 
+    // If the user tapped a link...
     if(touch.target.nodeName.toUpperCase() === "A") {
+      // ... let the webview handle it normally.
       return;
     }
 


### PR DESCRIPTION
This PR makes numerous improvements:

* Interactive EPUB 3.X content is now more likely to work as intended.
* It is now possible to swipe over a link to turn a page.
* Skeuomorphic page turn animations have been eliminated.
* Crashes related to the juggling of rasterized webviews will no longer happen.
* Crashes related to the use of synchronous JavaScript to detect link locations will no longer happen.
* `NYPLReaderSettings` no longer breaks abstraction boundaries by referencing an instance of `NYPLReaderReadiumView`. The proper plumbing is now handled via delegates.
* Much unnecessary code has been purged.

Closes #858
Closes #576