### PR TITLE
Bookmark Sync Improvements + NYPLAccount stopgaps

### DIFF
--- a/Simplified/NYPLAccount.m
+++ b/Simplified/NYPLAccount.m
@@ -222,7 +222,7 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
 - (void)setAuthorizationIdentifier:(NSString *)identifier
 {
   if(!(identifier)) {
-    @throw NSInvalidArgumentException;
+    NYPLLOG(@"Authorization ID (Barcode String) was nil.");
   }
   
   [[NYPLKeychain sharedKeychain] setObject:identifier forKey:authorizationIdentifierKey];

--- a/Simplified/NYPLAccount.m
+++ b/Simplified/NYPLAccount.m
@@ -222,7 +222,7 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
 - (void)setAuthorizationIdentifier:(NSString *)identifier
 {
   if(!(identifier)) {
-    NYPLLOG(@"Authorization ID (Barcode String) was nil.");
+    @throw NSInvalidArgumentException;
   }
   
   [[NYPLKeychain sharedKeychain] setObject:identifier forKey:authorizationIdentifierKey];

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -849,7 +849,11 @@ completionHandler:(void (^)())handler
          NYPLXML *loansXML = [NYPLXML XMLWithData:data];
          NYPLOPDSFeed *loansFeed = [[NYPLOPDSFeed alloc] initWithXML:loansXML];
 
-         [[NYPLAccount sharedAccount] setAuthorizationIdentifier:loansFeed.authorizationIdentifier];
+         if (loansFeed.authorizationIdentifier) {
+           [[NYPLAccount sharedAccount] setAuthorizationIdentifier:loansFeed.authorizationIdentifier];
+         } else {
+           NYPLLOG(@"Authorization ID (Barcode String) was nil.");
+         }
          if (loansFeed.licensor) {
            [[NYPLAccount sharedAccount] setLicensor:loansFeed.licensor];
          } else {

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -848,7 +848,8 @@ completionHandler:(void (^)())handler
 
          NYPLXML *loansXML = [NYPLXML XMLWithData:data];
          NYPLOPDSFeed *loansFeed = [[NYPLOPDSFeed alloc] initWithXML:loansXML];
-         
+
+         [[NYPLAccount sharedAccount] setAuthorizationIdentifier:loansFeed.authorizationIdentifier];
          if (loansFeed.licensor) {
            [[NYPLAccount sharedAccount] setLicensor:loansFeed.licensor];
          } else {

--- a/Simplified/NYPLAnnotations.swift
+++ b/Simplified/NYPLAnnotations.swift
@@ -8,11 +8,12 @@ final class NYPLAnnotations: NSObject {
   // If the user has never seen it before, show it.
   // If the user has seen it on one of their other devices, suppress it.
   // Opting in will attempt to enable on the server, with appropriate error handling.
-  class func requestServerSyncSettingWithUserAlert(
-    _ completion: @escaping (_ enableSync: Bool) -> ()) {
+  class func requestServerSyncStatus(forAccount account: NYPLAccount,
+                                     completion: @escaping (_ enableSync: Bool) -> ()) {
     
-    if !syncIsPossible() {
+    if !syncIsPossible(account) {
       Log.debug(#file, "Account does not satisfy conditions for sync setting request.")
+      completion(false)
       return
     }
 
@@ -645,14 +646,14 @@ final class NYPLAnnotations: NSObject {
 
   // MARK: -
   
-  class func syncIsPossible() -> Bool {
-    let acct = AccountsManager.shared.currentAccount
-    return NYPLAccount.shared().hasBarcodeAndPIN() && acct.supportsSimplyESync
+  class func syncIsPossible(_ account: NYPLAccount) -> Bool {
+    let library = AccountsManager.shared.currentAccount
+    return account.hasBarcodeAndPIN() && library.supportsSimplyESync
   }
 
   class func syncIsPossibleAndPermitted() -> Bool {
     let acct = AccountsManager.shared.currentAccount
-    return syncIsPossible() && acct.syncPermissionGranted
+    return syncIsPossible(NYPLAccount.shared()) && acct.syncPermissionGranted
   }
 
   class func setDefaultAnnotationHeaders(forRequest request: inout URLRequest) {

--- a/Simplified/NYPLBookCellDelegate.m
+++ b/Simplified/NYPLBookCellDelegate.m
@@ -70,7 +70,7 @@
 {
   [NYPLCirculationAnalytics postEvent:@"open_book" withBook:book];
   [[NYPLRootTabBarController sharedController] pushViewController:[[NYPLReaderViewController alloc] initWithBookIdentifier:book.identifier] animated:YES];
-  [NYPLAnnotations requestServerSyncSettingWithUserAlert:^(BOOL enableSync) {
+  [NYPLAnnotations requestServerSyncStatusForAccount:[NYPLAccount sharedAccount] completion:^(BOOL enableSync) {
     if (enableSync == YES) {
       Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
       currentAccount.syncPermissionGranted = enableSync;

--- a/Simplified/NYPLOPDSFeed.h
+++ b/Simplified/NYPLOPDSFeed.h
@@ -16,6 +16,7 @@ typedef NS_ENUM(NSInteger, NYPLOPDSFeedType) {
 @property (nonatomic, readonly) NYPLOPDSFeedType type;
 @property (nonatomic, readonly) NSDate *updated;
 @property (nonatomic, readonly) NSDictionary *licensor;
+@property (nonatomic, readonly) NSString *authorizationIdentifier;
 
 + (id)new NS_UNAVAILABLE;
 - (id)init NS_UNAVAILABLE;

--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -23,6 +23,7 @@
 @property (nonatomic) BOOL typeIsCached;
 @property (nonatomic) NSDate *updated;
 @property (nonatomic) NSMutableDictionary *licensor;
+@property (nonatomic) NSString *authorizationIdentifier;
 
 @end
 
@@ -169,11 +170,7 @@ static NYPLOPDSFeedType TypeImpliedByEntry(NYPLOPDSEntry *const entry)
     NYPLXML *patronXML = [feedXML firstChildWithName:@"patron"];
     if (patronXML && patronXML.attributes.allValues.count>0) {
       NSString *barcode = patronXML.attributes[@"simplified:authorizationIdentifier"];
-      
-      Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
-
-      [[NYPLAccount sharedAccount:currentAccount.id] setAuthorizationIdentifier:barcode];
-
+      self.authorizationIdentifier = barcode;
     }
   }
   

--- a/Simplified/NYPLReaderBookmark.swift
+++ b/Simplified/NYPLReaderBookmark.swift
@@ -55,8 +55,9 @@ final class NYPLReaderBookmark: NSObject {
       let idref = dictionary["idref"] as? String,
       let location = dictionary["location"] as? String,
       let time = dictionary["time"] as? String {
-        let annotationID = dictionary["annotationId"] as? String
-        if (annotationID?.count == 0) {
+        if let annotationID = dictionary["annotationId"] as? String, !annotationID.isEmpty {
+          self.annotationId = annotationID
+        } else {
           self.annotationId = nil
         }
         self.contentCFI = contentCFI

--- a/Simplified/NYPLReaderTOCViewController.m
+++ b/Simplified/NYPLReaderTOCViewController.m
@@ -263,9 +263,11 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       if (self.bookmarks.count == 0 || self.bookmarks == nil) {
         self.tableView.hidden = YES;
       }
-      self.refreshControl = [[UIRefreshControl alloc] init];
-      [self.refreshControl addTarget:self action:@selector(userDidRefresh:) forControlEvents:UIControlEventValueChanged];
-      [self.tableView addSubview:self.refreshControl];
+      if ([NYPLAnnotations syncIsPossibleAndPermitted]) {
+        self.refreshControl = [[UIRefreshControl alloc] init];
+        [self.refreshControl addTarget:self action:@selector(userDidRefresh:) forControlEvents:UIControlEventValueChanged];
+        [self.tableView addSubview:self.refreshControl];
+      }
       break;
     default:
       break;

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -1596,7 +1596,7 @@ replacementString:(NSString *)string
 
 - (BOOL)syncButtonShouldBeVisible
 {
-  //Only works on current active library account for now
+  // Only supported for now on current active library account
   return ((self.selectedAccount.supportsSimplyESync) &&
           ([self.selectedAccount getLicenseURL:URLTypeAnnotations] &&
            [self.selectedNYPLAccount hasBarcodeAndPIN]) &&

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -484,7 +484,8 @@ CGFloat const verticalMarginPadding = 2.0;
 
        NYPLXML *loansXML = [NYPLXML XMLWithData:data];
        NYPLOPDSFeed *loansFeed = [[NYPLOPDSFeed alloc] initWithXML:loansXML];
-       
+
+       [[NYPLAccount sharedAccount:self.selectedAccountType] setAuthorizationIdentifier:loansFeed.authorizationIdentifier];
        if (loansFeed.licensor) {
          [self.selectedNYPLAccount setLicensor:loansFeed.licensor];
        } else {


### PR DESCRIPTION
2 new commits to resolve #678 

In a typical user session inside SimplyE Settings, if a user picks a non-active library account (to sign in or change settings), there will likely be several scattered calls to NYPLAccount, and a single call to the singleton "sharedAccount" will rewrite all the global variables and start creating havok with keychain credentials and other values stored in the keychain.

It's too fragile to rely on developer knowledge of this fact, so the class should ultimately be reworked for safety.

The most immediate issue was that credentials would overwrite the current active account creds. So this has been fixed in addition to showing the credentials when re-visiting the particular detail page.