### PR TITLE
SQLite.swift update + move off fork

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ target 'SimplyE' do
   pod 'HelpStack', :git => 'https://github.com/NYPL-Simplified/helpstack-ios'
   pod 'Bugsnag', '~> 5.14.2'
   pod 'NYPLCardCreator', :git => 'https://github.com/NYPL-Simplified/CardCreator-iOS.git'
-  pod 'SQLite.swift', :git => 'https://github.com/NYPL-Simplified/SQLite.swift', :branch => 'nypl-swift4-ios8-target'
+  pod 'SQLite.swift', '~> 0.11.4'
   pod 'ZXingObjC', '~> 3.2.1'
 
   target 'SimplyETests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,9 +44,9 @@ PODS:
   - NYPLCardCreator (1.0.0):
     - PureLayout (~> 3.0)
   - PureLayout (3.0.2)
-  - SQLite.swift (0.11.3):
-    - SQLite.swift/standard (= 0.11.3)
-  - SQLite.swift/standard (0.11.3)
+  - SQLite.swift (0.11.4):
+    - SQLite.swift/standard (= 0.11.4)
+  - SQLite.swift/standard (0.11.4)
   - ZXingObjC (3.2.2):
     - ZXingObjC/All (= 3.2.2)
   - ZXingObjC/All (3.2.2)
@@ -55,7 +55,7 @@ DEPENDENCIES:
   - Bugsnag (~> 5.14.2)
   - HelpStack (from `https://github.com/NYPL-Simplified/helpstack-ios`)
   - NYPLCardCreator (from `https://github.com/NYPL-Simplified/CardCreator-iOS.git`)
-  - SQLite.swift (from `https://github.com/NYPL-Simplified/SQLite.swift`, branch `nypl-swift4-ios8-target`)
+  - SQLite.swift (~> 0.11.4)
   - ZXingObjC (~> 3.2.1)
 
 EXTERNAL SOURCES:
@@ -63,9 +63,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/NYPL-Simplified/helpstack-ios
   NYPLCardCreator:
     :git: https://github.com/NYPL-Simplified/CardCreator-iOS.git
-  SQLite.swift:
-    :branch: nypl-swift4-ios8-target
-    :git: https://github.com/NYPL-Simplified/SQLite.swift
 
 CHECKOUT OPTIONS:
   HelpStack:
@@ -74,9 +71,6 @@ CHECKOUT OPTIONS:
   NYPLCardCreator:
     :commit: 0225028ae6ccad34eeb4e375bb02127c8a0bd5c1
     :git: https://github.com/NYPL-Simplified/CardCreator-iOS.git
-  SQLite.swift:
-    :commit: f080c1349e938882963c226a68b1bb671650cba9
-    :git: https://github.com/NYPL-Simplified/SQLite.swift
 
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
@@ -84,9 +78,9 @@ SPEC CHECKSUMS:
   HelpStack: a9067738597ef81835d84ac8bb75ee346e34f000
   NYPLCardCreator: e0f5034902008b4c8cdfb5edbffa2a51ec0b261d
   PureLayout: 4d550abe49a94f24c2808b9b95db9131685fe4cd
-  SQLite.swift: 0cb8585c21684b2290ec7792b3ca8089f68bdd29
+  SQLite.swift: 3e3bee21da701b5b9f87c4a672cb54f233505692
   ZXingObjC: 2c95a0dc52daac69b23ec78fad8fa2fec05f8981
 
-PODFILE CHECKSUM: 739be78f6ca5bc39060bc04db549cf27522155bf
+PODFILE CHECKSUM: 193afbcdbeb69b8ba52f8f24ede9ea901cb334d1
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
SQLiteSwift library: move off of forked repo and back to main author's library. Min deployment updated with 0.11.4.

Point update contains mostly stability fixes. Initial testing seems fine, and we can continue to monitor [this crash](https://github.com/NYPL-Simplified/Simplified-iOS/issues/897) for any changes.