### PR TITLE
3D Touch - Nil Casting Crash Fix

### DIFF
--- a/Simplified/NYPLCatalogGroupedFeedViewController.m
+++ b/Simplified/NYPLCatalogGroupedFeedViewController.m
@@ -301,7 +301,7 @@ viewForHeaderInSection:(NSInteger const)section
 {
   NSIndexPath *indexPath = [self.tableView indexPathForRowAtPoint:location];
   UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:indexPath];
-  if (!cell || ![cell isKindOfClass:[NYPLCatalogLaneCell class]]) {
+  if (![cell isKindOfClass:[NYPLCatalogLaneCell class]]) {
     return nil;
   }
   UIViewController *vc = [[UIViewController alloc] init];

--- a/Simplified/NYPLCatalogUngroupedFeedViewController.m
+++ b/Simplified/NYPLCatalogUngroupedFeedViewController.m
@@ -285,11 +285,14 @@ didSelectFacetAtIndexPath:(NSIndexPath *const)indexPath
 {
   CGPoint referencePoint = [self.collectionView convertPoint:location fromView:self.view];
   NSIndexPath *indexPath = [self.collectionView indexPathForItemAtPoint:referencePoint];
-  NYPLBookNormalCell *cell = (NYPLBookNormalCell *)[self.collectionView cellForItemAtIndexPath:indexPath];
-  
+  UICollectionViewCell *cell = [self.collectionView cellForItemAtIndexPath:indexPath];
+  if (!cell || ![cell isKindOfClass:[NYPLBookNormalCell class]]) {
+    return nil;
+  }
+  NYPLBookNormalCell *bookCell = (NYPLBookNormalCell *) cell;
   UIViewController *vc = [[UIViewController alloc] init];
   vc.view.tag = indexPath.row;
-  UIImageView *imView = [[UIImageView alloc] initWithImage:cell.cover.image];
+  UIImageView *imView = [[UIImageView alloc] initWithImage:bookCell.cover.image];
   imView.contentMode = UIViewContentModeScaleAspectFill;
   [vc.view addSubview:imView];
   [imView autoPinEdgesToSuperviewEdges];

--- a/Simplified/NYPLCatalogUngroupedFeedViewController.m
+++ b/Simplified/NYPLCatalogUngroupedFeedViewController.m
@@ -286,7 +286,7 @@ didSelectFacetAtIndexPath:(NSIndexPath *const)indexPath
   CGPoint referencePoint = [self.collectionView convertPoint:location fromView:self.view];
   NSIndexPath *indexPath = [self.collectionView indexPathForItemAtPoint:referencePoint];
   UICollectionViewCell *cell = [self.collectionView cellForItemAtIndexPath:indexPath];
-  if (!cell || ![cell isKindOfClass:[NYPLBookNormalCell class]]) {
+  if (![cell isKindOfClass:[NYPLBookNormalCell class]]) {
     return nil;
   }
   NYPLBookNormalCell *bookCell = (NYPLBookNormalCell *) cell;


### PR DESCRIPTION
Protect against nil when trying to cast a collection view cell.

Missed this when updating the GroupedFeedViewController for the same issue before.

Fixes #871 