### PR TITLE
Offline queue sql fix #897

### DIFF
--- a/Simplified/NYPLAnnotations.swift
+++ b/Simplified/NYPLAnnotations.swift
@@ -682,6 +682,6 @@ final class NYPLAnnotations: NSObject {
   private class func addToOfflineQueue(_ bookID: String?, _ url: URL, _ parameters: [String:Any]) {
     let libraryID = AccountsManager.shared.currentAccount.id
     let parameterData = try? JSONSerialization.data(withJSONObject: parameters, options: [.prettyPrinted])
-    NetworkQueue.addRequest(libraryID, bookID, url, .POST, parameterData, headers)
+    NetworkQueue.shared.addRequest(libraryID, bookID, url, .POST, parameterData, headers)
   }
 }

--- a/Simplified/NYPLAppDelegate.m
+++ b/Simplified/NYPLAppDelegate.m
@@ -44,7 +44,8 @@ didFinishLaunchingWithOptions:(__attribute__((unused)) NSDictionary *)launchOpti
   
   // Initiallize Accounts from JSON file
   [AccountsManager sharedInstance];
-  
+  // Initialize Offline Requests Queue
+  [NetworkQueue shared];
   self.reachabilityManager = [NYPLReachability sharedReachability];
   
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];

--- a/Simplified/NYPLCirculationAnalytics.swift
+++ b/Simplified/NYPLCirculationAnalytics.swift
@@ -38,6 +38,6 @@ final class NYPLCirculationAnalytics : NSObject {
   private class func addToOfflineAnalyticsQueue(_ event: String, _ bookURL: URL) -> Void
   {
     let libraryID = AccountsManager.shared.currentAccount.id
-    NetworkQueue.addRequest(libraryID, nil, bookURL, .GET, nil, NYPLAnnotations.headers)
+    NetworkQueue.shared.addRequest(libraryID, nil, bookURL, .GET, nil, NYPLAnnotations.headers)
   }
 }

--- a/Simplified/NYPLReachability.h
+++ b/Simplified/NYPLReachability.h
@@ -19,4 +19,6 @@
 
 @property (nonatomic) ReachabilityManager *hostReachabilityManager;
 
+extern NSString *const NYPLReachabilityHostIsReachableNotification;
+
 @end

--- a/Simplified/NYPLReachability.m
+++ b/Simplified/NYPLReachability.m
@@ -11,6 +11,8 @@
 
 @implementation NYPLReachability
 
+NSString *const NYPLReachabilityHostIsReachableNotification = @"NYPLReachabilityHostIsReachableNotification";
+
 + (NYPLReachability *)sharedReachability
 {
   static NYPLReachability *sharedReachability;
@@ -58,7 +60,7 @@
     switch (netStatus) {
       case ReachableViaWiFi:
       case ReachableViaWWAN:
-        [NetworkQueue retryQueue];
+        [[NSNotificationCenter defaultCenter] postNotificationName:NYPLReachabilityHostIsReachableNotification object:self];
         NYPLLOG(@"Host Reachability changed: WIFI or 3G");
         break;
       default:

--- a/Simplified/SimplyE-Bridging-Header.h
+++ b/Simplified/SimplyE-Bridging-Header.h
@@ -28,3 +28,4 @@
 #import "NYPLBarcodeScanningViewController.h"
 #import "NYPLRootTabBarController.h"
 #import "NYPLZXingEncoder.h"
+#import "NYPLReachability.h"


### PR DESCRIPTION
Improves reliability and organization of NetworkQueue in a couple ways:

- Synchronizes an iterator on the sqlite table so that network requests and their completion blocks do not happen on different threads, which is likely to resolve #897 
- Turn NetworkQueue into a singleton instead of fully static class. NYPLReachability doesn't need to "know" about the queue. The instance is created on app launch in the app delegate.