### PR TITLE
Remove observation of Available Copies when creating OPDS Availability

### DIFF
--- a/Simplified/NYPLOPDSAcquisitionAvailability.m
+++ b/Simplified/NYPLOPDSAcquisitionAvailability.m
@@ -107,7 +107,7 @@ NYPLOPDSAcquisitionAvailabilityWithLinkXML(NYPLXML *const _Nonnull linkXML)
   NSString *const untilString = [linkXML firstChildWithName:availabilityName].attributes[untilAttribute];
   NSDate *const until = untilString ? [NSDate dateWithRFC3339String:untilString] : nil;
 
-  if ([statusString isEqual:@"unavailable"] || copiesAvailable == 0) {
+  if ([statusString isEqual:@"unavailable"]) {
     return [[NYPLOPDSAcquisitionAvailabilityUnavailable alloc]
             initWithCopiesHeld:MIN(copiesHeld, copiesTotal)
             copiesTotal:MAX(copiesHeld, copiesTotal)];


### PR DESCRIPTION
...to keep reserved and ready books correctly separated.

resolves #916

There may be larger implications to this change that still needs to be addressed, @winniequinn. As far as I can tell, a book entry currently on hold (reserved) would have a "copies available" tag set to equal 0. However, when setting the availability, the conditional would mistakenly set the acquisition to "unavailable".

Later down in execution, when trying to access books in the book registry, `NYPLBookRegistryRecord` would mistakenly set the "state" property of the record to `NYPLBookStateDownloadNeeded` which ends up putting everything in My Books and nothing in the Reservations tab.