### PR TITLE
Filter only supported book formats in the catalog

### DIFF
--- a/Simplified/NYPLBook.m
+++ b/Simplified/NYPLBook.m
@@ -531,9 +531,7 @@ static NSString *const UpdatedKey = @"updated";
     }
   }
 
-  NYPLLOG(@"WARNING: Choosing arbitrary default acquisition.");
-
-  return self.acquisitions.firstObject;
+  return nil;
 }
 
 - (NYPLOPDSAcquisition *)defaultAcquisitionIfBorrow

--- a/Simplified/NYPLCatalogLane.m
+++ b/Simplified/NYPLCatalogLane.m
@@ -27,6 +27,13 @@
     if(![object isKindOfClass:[NYPLBook class]]) {
       @throw NSInvalidArgumentException;
     }
+
+    NYPLBook *const book = object;
+
+    if(!book.defaultAcquisition) {
+      // The application is not able to support this, so we ignore it.
+      continue;
+    }
   }
   
   self.books = books;

--- a/Simplified/NYPLCatalogUngroupedFeed.m
+++ b/Simplified/NYPLCatalogUngroupedFeed.m
@@ -61,12 +61,17 @@ handler:(void (^)(NYPLCatalogUngroupedFeed *category))handler
     @throw NSInvalidArgumentException;
   }
   
-  self.books = [NSMutableArray arrayWithCapacity:feed.entries.count];
+  self.books = [NSMutableArray array];
   
   for(NYPLOPDSEntry *const entry in feed.entries) {
     NYPLBook *book = [NYPLBook bookWithEntry:entry];
     if(!book) {
       NYPLLOG(@"Failed to create book from entry.");
+      continue;
+    }
+
+    if(!book.defaultAcquisition) {
+      // The application is not able to support this, so we ignore it.
       continue;
     }
     


### PR DESCRIPTION
Books that show up in My Books after the registry syncs will still appear even if the client does not support them. This seems like the safest option and it is consistent with the app's historical behavior.

Closes #917.

---

Filtering of books happens in the catalog portion of the app, not in the OPDS parsing portion as it did in older versions of the application. This is correct because the OPDS parser should be ignorant of application-level concerns.

Note that `[NYPLOPDSAcquisition defaultAcquisition]` now returns `nil` instead of choosing an arbitrary acquisition when the app does not support any of the acquisitions available. This behavior probably should have been in place already and it seems like a safe change. 