### PR TITLE
Gracefully handle books the app does not support

### DIFF
--- a/Simplified/NYPLBookButtonsView.h
+++ b/Simplified/NYPLBookButtonsView.h
@@ -15,7 +15,8 @@ typedef NS_ENUM(NSInteger, NYPLBookButtonsState) {
   NYPLBookButtonsStateDownloadSuccessful,
   NYPLBookButtonsStateUsed,
   NYPLBookButtonsStateDownloadInProgress,
-  NYPLBookButtonsStateDownloadFailed
+  NYPLBookButtonsStateDownloadFailed,
+  NYPLBookButtonsStateUnsupported
 };
 
 /// @param availability A non-nil @c NYPLOPDSAcquisitionAvailability.

--- a/Simplified/NYPLBookButtonsView.m
+++ b/Simplified/NYPLBookButtonsView.m
@@ -227,6 +227,11 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
       }
       break;
     }
+    case NYPLBookButtonsStateUnsupported:
+      // The app should never show books it cannot support, but if it mistakenly does,
+      // no actions will be available.
+      visibleButtonInfo = @[];
+      break;
   }
   
   NSMutableArray *visibleButtons = [NSMutableArray array];
@@ -335,6 +340,8 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
                  self.book.title];
       confirmButtonTitle = NSLocalizedString(@"BookButtonsViewRemoveHoldConfirm", nil);
       break;
+    case NYPLBookStateUnsupported:
+      @throw NSInternalInconsistencyException;
   }
   
   UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title

--- a/Simplified/NYPLBookCell.m
+++ b/Simplified/NYPLBookCell.m
@@ -125,6 +125,15 @@ NYPLBookCell *NYPLBookCellDequeue(UICollectionView *const collectionView,
       cell.state = NYPLBookButtonsStateUsed;
       return cell;
     }
+    case NYPLBookStateUnsupported: {
+      NYPLBookNormalCell *const cell = [collectionView
+                                        dequeueReusableCellWithReuseIdentifier:reuseIdentifierNormal
+                                        forIndexPath:indexPath];
+      cell.book = book;
+      cell.delegate = [NYPLBookCellDelegate sharedDelegate];
+      cell.state = NYPLBookButtonsStateUnsupported;
+      return cell;
+    }
   }
 }
 

--- a/Simplified/NYPLBookDetailButtonsView.m
+++ b/Simplified/NYPLBookDetailButtonsView.m
@@ -207,15 +207,15 @@
                                 HintKey: hint}];
       }
       break;
+    }
     case NYPLBookButtonsStateDownloadInProgress:
+    {
+      if (self.showReturnButtonIfApplicable)
       {
-        if (self.showReturnButtonIfApplicable)
-        {
-          visibleButtonInfo = @[@{ButtonKey: self.cancelButton,
-                                  TitleKey: NSLocalizedString(@"Cancel", nil),
-                                  HintKey: [NSString stringWithFormat:NSLocalizedString(@"Cancels the download for the current book: %@", nil), self.book.title],
-                                  AddIndicatorKey: @(NO)}];
-        }
+        visibleButtonInfo = @[@{ButtonKey: self.cancelButton,
+                                TitleKey: NSLocalizedString(@"Cancel", nil),
+                                HintKey: [NSString stringWithFormat:NSLocalizedString(@"Cancels the download for the current book: %@", nil), self.book.title],
+                                AddIndicatorKey: @(NO)}];
       }
       break;
     }
@@ -232,7 +232,12 @@
                                 HintKey: [NSString stringWithFormat:NSLocalizedString(@"Cancels the failed download for this book: %@", nil), self.book.title],
                                 AddIndicatorKey: @(NO)}];
       }
+      break;
     }
+    case NYPLBookButtonsStateUnsupported:
+      // The app should never show books it cannot support, but if it mistakenly does,
+      // no actions will be available.
+      visibleButtonInfo = @[];
       break;
   }
 
@@ -341,6 +346,8 @@
                  self.book.title];
       confirmButtonTitle = NSLocalizedString(@"BookButtonsViewRemoveHoldConfirm", nil);
       break;
+    case NYPLBookStateUnsupported:
+      @throw NSInternalInconsistencyException;
   }
   
   UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title

--- a/Simplified/NYPLBookDetailView.m
+++ b/Simplified/NYPLBookDetailView.m
@@ -577,6 +577,14 @@ navigationType:(__attribute__((unused)) UIWebViewNavigationType)navigationType
       self.normalView.state = NYPLBookButtonsStateUsed;
       self.buttonsView.state = NYPLBookButtonsStateUsed;
       break;
+    case NYPLBookStateUnsupported:
+      self.normalView.hidden = NO;
+      self.downloadFailedView.hidden = YES;
+      [self hideDownloadingView:YES];
+      self.buttonsView.hidden = NO;
+      self.normalView.state = NYPLBookButtonsStateUnsupported;
+      self.buttonsView.state = NYPLBookButtonsStateUnsupported;
+      break;
   }
 }
 

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -662,7 +662,12 @@ static NSString *const RecordsKey = @"records";
 
 - (NSArray *)myBooks
 {
-  return [self booksMatchingStateMask:~(NYPLBookStateHolding | NYPLBookStateUnregistered)];
+  return [self booksMatchingStateMask:
+          (NYPLBookStateDownloadNeeded
+           | NYPLBookStateDownloading
+           | NYPLBookStateDownloadFailed
+           | NYPLBookStateDownloadSuccessful
+           | NYPLBookStateUsed)];
 }
 
 - (NSArray *)booksMatchingStateMask:(NSUInteger)mask

--- a/Simplified/NYPLBookRegistryRecord.m
+++ b/Simplified/NYPLBookRegistryRecord.m
@@ -47,6 +47,18 @@ static NSString *const BookmarksKey = @"bookmarks";
     self.bookmarks = [[NSMutableArray alloc] init];
   }
 
+  if (!book.defaultAcquisition) {
+    // Since the book has no default acqusition, there is no reliable way to
+    // determine if the book is on hold (although it may be), nor is there any
+    // way to download the book if it is available. As such, we give the book a
+    // special "unsupported" state which will allow other parts of the app to
+    // ignore it as appropriate. Unsupported books should generally only appear
+    // when a user has checked out a book in an unsupported format using another
+    // app.
+    self.state = NYPLBookStateUnsupported;
+    return self;
+  }
+
   // FIXME: The logic below is confusing at best. Upon initial inspection, it's
   // unclear why `book.state` needs to be "fixed" in this initializer. If said
   // fixing is appropriate, a rationale should be added here.

--- a/Simplified/NYPLBookState.h
+++ b/Simplified/NYPLBookState.h
@@ -1,11 +1,12 @@
-typedef NS_ENUM(NSInteger, NYPLBookState) {
+typedef NS_OPTIONS(NSUInteger, NYPLBookState) {
   NYPLBookStateUnregistered       = 1 << 0,
   NYPLBookStateDownloadNeeded     = 1 << 1,
   NYPLBookStateDownloading        = 1 << 2,
   NYPLBookStateDownloadFailed     = 1 << 3,
   NYPLBookStateDownloadSuccessful = 1 << 4,
   NYPLBookStateHolding            = 1 << 5,
-  NYPLBookStateUsed               = 1 << 6
+  NYPLBookStateUsed               = 1 << 6,
+  NYPLBookStateUnsupported        = 1 << 7
 };
 
 NYPLBookState NYPLBookStateFromString(NSString *string);

--- a/Simplified/NYPLBookState.m
+++ b/Simplified/NYPLBookState.m
@@ -7,6 +7,7 @@ static NSString *const DownloadSuccessful = @"download-successful";
 static NSString *const Unregistered = @"unregistered";
 static NSString *const Holding = @"holding";
 static NSString *const Used = @"used";
+static NSString *const Unsupported = @"unsupported";
 
 NYPLBookState NYPLBookStateFromString(NSString *const string)
 {
@@ -17,6 +18,7 @@ NYPLBookState NYPLBookStateFromString(NSString *const string)
   if([string isEqualToString:Unregistered]) return NYPLBookStateUnregistered;
   if([string isEqualToString:Holding]) return NYPLBookStateHolding;
   if([string isEqualToString:Used]) return NYPLBookStateUsed;
+  if([string isEqualToString:Unsupported]) return NYPLBookStateUnsupported;
   
   @throw NSInvalidArgumentException;
 }
@@ -38,5 +40,7 @@ NSString *NYPLBookStateToString(NYPLBookState state)
       return Holding;
     case NYPLBookStateUsed:
       return Used;
+    case NYPLBookStateUnsupported:
+      return Unsupported;
   }
 }

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -580,6 +580,8 @@ didDismissWithButtonIndex:(NSInteger const)buttonIndex
     case NYPLBookStateDownloadSuccessful:
       // fallthrough
     case NYPLBookStateUsed:
+      // fallthrough
+    case NYPLBookStateUnsupported:
       NYPLLOG(@"Ignoring nonsensical download request.");
       return;
   }


### PR DESCRIPTION
This change allows the app to represent books it does not support due to content type, required DRM technologies, et cetera. By representing unsupported books explicitly, the app can hide them from the user as appropriate.

Closes #923