### PR TITLE
Hold positions are not always lower than total copies

### DIFF
--- a/Simplified/NYPLOPDSAcquisitionAvailability.m
+++ b/Simplified/NYPLOPDSAcquisitionAvailability.m
@@ -129,8 +129,8 @@ NYPLOPDSAcquisitionAvailabilityWithLinkXML(NYPLXML *const _Nonnull linkXML)
 
   if ([statusString isEqual:@"reserved"]) {
     return [[NYPLOPDSAcquisitionAvailabilityReserved alloc]
-            initWithHoldPosition:MIN(holdPosition, copiesTotal)
-            copiesTotal:MAX(holdPosition, copiesTotal)
+            initWithHoldPosition:holdPosition
+            copiesTotal:copiesTotal
             since:since
             until:until];
   }
@@ -206,8 +206,8 @@ NYPLOPDSAcquisitionAvailabilityWithDictionary(NSDictionary *_Nonnull dictionary)
     NSDate *const until = untilString ? [NSDate dateWithRFC3339String:untilString] : nil;
 
     return [[NYPLOPDSAcquisitionAvailabilityReserved alloc]
-            initWithHoldPosition:MAX(0, MIN([holdPositionNumber integerValue], [copiesTotalNumber integerValue]))
-            copiesTotal:MAX(0, MAX([holdPositionNumber integerValue], [copiesTotalNumber integerValue]))
+            initWithHoldPosition:MAX(0, [holdPositionNumber integerValue])
+            copiesTotal:MAX(0, [copiesTotalNumber integerValue])
             since:since
             until:until];
   } else if ([caseString isEqual:readyCase]) {


### PR DESCRIPTION
It is possible to hold a reservation for a book without an available license.
Prior to this commit, we were always chosing with lower number as the hold
position and the higher number as the total copies.

closes #922

It looks like the only place these values are read off `NYPLOPDSAcquisitionAvailability` are in `NYPLBookDetailNormalView` which is where the string is.

<img width="310" alt="screen shot 2018-03-14 at 1 59 07 pm" src="https://user-images.githubusercontent.com/5833968/37421524-e012b250-278f-11e8-9177-59f1e9f8dff0.png">
