### PR TITLE
Annotation server fixes

### DIFF
--- a/Simplified/NYPLReadiumViewSyncManager.m
+++ b/Simplified/NYPLReadiumViewSyncManager.m
@@ -320,9 +320,11 @@ const double RequestTimeInterval = 30;
 
 - (void)sendOffAnyQueuedRequest
 {
-  if (self.queuedReadingPosition) {
-    [NYPLAnnotations postReadingPositionForBook:self.bookID annotationsURL:nil cfi:self.queuedReadingPosition];
-    self.queuedReadingPosition = nil;
+  @synchronized(self) {
+    if (self.queuedReadingPosition) {
+      [NYPLAnnotations postReadingPositionForBook:self.bookID annotationsURL:nil cfi:self.queuedReadingPosition];
+      self.queuedReadingPosition = nil;
+    }
   }
 }
 


### PR DESCRIPTION
resolves #931 

Two Issues addressed:

1. It's likely that sporadic inconsistencies in network reachibility listeners sometimes cause multiple rapid requests to the offline queue, so there's been protection added to only process one call at a time and restricting curther calls until the attempted requests to finish.

2. If a user left a book they were reading, the last queued page position would immediately be requested to be sent off, but it was not correctly clearing that same bookmark on the 30 second rolling queue. So this would cause the same page position to be sent one more time unecessarily.


Further: There's a decent argument to be made for some kind of strategy to mitigate erratic or high frequency changes to the network reachibility notification mechanism, but without further research into the nature of this it's likely that the "true" value of reachability could be ignored to appease the _debouncing_ of the outgoing pings.