### PR TITLE
Update numberOfLines to 0 for UILabel

### DIFF
--- a/Simplified/NYPLBookDetailNormalView.m
+++ b/Simplified/NYPLBookDetailNormalView.m
@@ -33,7 +33,7 @@ typedef NS_ENUM (NSInteger, NYPLProblemReportButtonState) {
   self.messageLabel = [[UILabel alloc] init];
   self.messageLabel.font = [UIFont customFontForTextStyle:UIFontTextStyleBody];
   self.messageLabel.textColor = [NYPLConfiguration backgroundColor];
-  self.messageLabel.numberOfLines = 2;
+  self.messageLabel.numberOfLines = 0;
   self.messageLabel.textAlignment = NSTextAlignmentCenter;
   [self addSubview:self.messageLabel];
   [self.messageLabel autoCenterInSuperview];


### PR DESCRIPTION
This indicates that the number of lines should fit the text

closes #936 

on 4 inch phones
<img width="216" alt="screen shot 2018-03-14 at 3 51 21 pm" src="https://user-images.githubusercontent.com/5833968/37427452-ec43cf22-279f-11e8-8621-9d547c499ea9.png">

on 5.5 inch phones
<img width="310" alt="screen shot 2018-03-14 at 3 54 51 pm" src="https://user-images.githubusercontent.com/5833968/37427511-0a335d18-27a0-11e8-89b6-206e3996a159.png">
