### PR TITLE
Increase sync manager delay to 60s to reduce server requests,

### DIFF
--- a/Simplified/NYPLReadiumViewSyncManager.m
+++ b/Simplified/NYPLReadiumViewSyncManager.m
@@ -31,7 +31,7 @@ typedef NS_ENUM(NSInteger, NYPLReadPositionSyncStatus) {
 
 @implementation NYPLReadiumViewSyncManager
 
-const double RequestTimeInterval = 30;
+const double RequestTimeInterval = 60;
 
 - (instancetype) initWithBookID:(NSString *)bookID
                  annotationsURL:(NSURL *)URL


### PR DESCRIPTION
but keep probability of a bad UX low.

fixes #941 