### PR TITLE
Update rounded button view to show time remaining

### DIFF
--- a/Simplified/NYPLBookButtonsView.m
+++ b/Simplified/NYPLBookButtonsView.m
@@ -280,10 +280,14 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
          }
        }
        unlimited:nil
-       reserved:nil
+       reserved:^(NYPLOPDSAcquisitionAvailabilityReserved * _Nonnull reserved) {
+         if (button == self.deleteButton && reserved.until && [reserved.until timeIntervalSinceNow] > 0) {
+           button.type = NYPLRoundedButtonTypeClock;
+           button.endDate = reserved.until;
+         }
+       }
        ready:nil];
     }
-
     [visibleButtons addObject:button];
   }
   for (NYPLRoundedButton *button in @[self.downloadButton, self.deleteButton, self.readButton]) {


### PR DESCRIPTION
Before:
![screen shot 2018-04-11 at 2 36 51 pm](https://user-images.githubusercontent.com/5833968/38636314-cc3ff000-3d95-11e8-87ae-bd009f63d9d4.png)


After:
![screen shot 2018-04-11 at 2 34 31 pm](https://user-images.githubusercontent.com/5833968/38636261-ad2b1bc2-3d95-11e8-9579-648eb5141844.png)

Closes #940 

Note:

The "Remove" button on the the book detail page is still missing the clock, but I think thats okay because the red warning text shows when it will become available for checkout:

<img width="216" alt="screen shot 2018-04-11 at 2 38 44 pm" src="https://user-images.githubusercontent.com/5833968/38636395-0dc707c0-3d96-11e8-9f7e-208778b149af.png">
