### PR TITLE
Start to integrate Audiobook Player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ DerivedData
 Build
 adobe-rmsdk
 Simplified/APIKeys.swift
+AudioEngine.json
+Carthage/

--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
-git "file:///Users/deansilfen/Projects/NYPLAudiobookToolkit" ~> 1.0.3
-git "file:///Users/deansilfen/Projects/NYPLAEToolkit" ~> 0.0.4
+github "NYPL-Simplified/NYPLAudiobookToolkit" ~> 1.0.4
+github "NYPL-Simplified/NYPLAEToolkit" ~> 0.0.6
 github "PureLayout/PureLayout" "v3.0.2"
 binary "AudioEngine.json" ~> 6.1.13
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,5 @@
+git "file:///Users/deansilfen/Projects/NYPLAudiobookToolkit" ~> 1.0.2
+git "file:///Users/deansilfen/Projects/NYPLAEToolkit" ~> 0.0.3
+github "PureLayout/PureLayout" "v3.0.2"
+binary "AudioEngine.json" ~> 6.1.13
+

--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
-github "NYPL-Simplified/NYPLAudiobookToolkit" ~> 1.0.5
-github "NYPL-Simplified/NYPLAEToolkit" ~> 0.0.9
+github "NYPL-Simplified/NYPLAudiobookToolkit" ~> 1.0.6
+github "NYPL-Simplified/NYPLAEToolkit" ~> 0.0.10
 github "PureLayout/PureLayout" "v3.0.2"
 binary "AudioEngine.json" ~> 6.1.13
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
-git "file:///Users/deansilfen/Projects/NYPLAudiobookToolkit" ~> 1.0.2
-git "file:///Users/deansilfen/Projects/NYPLAEToolkit" ~> 0.0.3
+git "file:///Users/deansilfen/Projects/NYPLAudiobookToolkit" ~> 1.0.3
+git "file:///Users/deansilfen/Projects/NYPLAEToolkit" ~> 0.0.4
 github "PureLayout/PureLayout" "v3.0.2"
 binary "AudioEngine.json" ~> 6.1.13
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,5 @@
 github "NYPL-Simplified/NYPLAudiobookToolkit" ~> 1.0.5
-github "NYPL-Simplified/NYPLAEToolkit" ~> 0.0.7
+github "NYPL-Simplified/NYPLAEToolkit" ~> 0.0.9
 github "PureLayout/PureLayout" "v3.0.2"
 binary "AudioEngine.json" ~> 6.1.13
+

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,4 @@
+binary "file:///Users/deansilfen/Projects/Simplified-iOS/AudioEngine.json" "6.1.13"
+git "file:///Users/deansilfen/Projects/NYPLAEToolkit" "0.0.3-alpha"
+git "file:///Users/deansilfen/Projects/NYPLAudiobookToolkit" "1.0.2-alpha"
+github "PureLayout/PureLayout" "v3.0.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 binary "AudioEngine.json" "6.1.13"
-github "NYPL-Simplified/NYPLAEToolkit" "0.0.7"
+github "NYPL-Simplified/NYPLAEToolkit" "0.0.9"
 github "NYPL-Simplified/NYPLAudiobookToolkit" "1.0.5"
 github "PureLayout/PureLayout" "v3.0.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 binary "file:///Users/deansilfen/Projects/Simplified-iOS/AudioEngine.json" "6.1.13"
-git "file:///Users/deansilfen/Projects/NYPLAEToolkit" "0.0.3-alpha"
-git "file:///Users/deansilfen/Projects/NYPLAudiobookToolkit" "1.0.2-alpha"
+git "file:///Users/deansilfen/Projects/NYPLAEToolkit" "0.0.4-alpha"
+git "file:///Users/deansilfen/Projects/NYPLAudiobookToolkit" "1.0.3-alpha"
 github "PureLayout/PureLayout" "v3.0.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 binary "file:///Users/deansilfen/Projects/Simplified-iOS/AudioEngine.json" "6.1.13"
-git "file:///Users/deansilfen/Projects/NYPLAEToolkit" "0.0.4-alpha"
-git "file:///Users/deansilfen/Projects/NYPLAudiobookToolkit" "1.0.3-alpha"
+git "file:///Users/deansilfen/Projects/NYPLAEToolkit" "0.0.5-alpha"
+git "file:///Users/deansilfen/Projects/NYPLAudiobookToolkit" "1.0.4-alpha"
 github "PureLayout/PureLayout" "v3.0.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 binary "AudioEngine.json" "6.1.13"
-github "NYPL-Simplified/NYPLAEToolkit" "0.0.9"
-github "NYPL-Simplified/NYPLAudiobookToolkit" "1.0.5"
+github "NYPL-Simplified/NYPLAEToolkit" "0.0.10"
+github "NYPL-Simplified/NYPLAudiobookToolkit" "1.0.6"
 github "PureLayout/PureLayout" "v3.0.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "file:///Users/deansilfen/Projects/Simplified-iOS/AudioEngine.json" "6.1.13"
-git "file:///Users/deansilfen/Projects/NYPLAEToolkit" "0.0.5-alpha"
-git "file:///Users/deansilfen/Projects/NYPLAudiobookToolkit" "1.0.4-alpha"
+binary "AudioEngine.json" "6.1.13"
+github "NYPL-Simplified/NYPLAEToolkit" "0.0.6"
+github "NYPL-Simplified/NYPLAudiobookToolkit" "1.0.4-alpha"
 github "PureLayout/PureLayout" "v3.0.2"

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -147,6 +147,12 @@
 		5A6929241B95C8B400FB4C10 /* readium-shared-js_all.js.bundles.js in Resources */ = {isa = PBXBuildFile; fileRef = 5A6929231B95C8B400FB4C10 /* readium-shared-js_all.js.bundles.js */; };
 		5A6929251B95C93B00FB4C10 /* readium-shared-js_all.js.map in Resources */ = {isa = PBXBuildFile; fileRef = 5A69291D1B95C8AD00FB4C10 /* readium-shared-js_all.js.map */; };
 		5AEA9E011B947419009F71DB /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 119503EA1993F91E009FB788 /* libc++.dylib */; };
+		7B5FC68820A4DAD00075BDC7 /* AudioEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5FC68120A4DACC0075BDC7 /* AudioEngine.framework */; };
+		7B5FC68920A4DAD00075BDC7 /* AudioEngine.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5FC68120A4DACC0075BDC7 /* AudioEngine.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7B5FC68A20A4DAD00075BDC7 /* NYPLAEToolkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5FC68620A4DACC0075BDC7 /* NYPLAEToolkit.framework */; };
+		7B5FC68B20A4DAD00075BDC7 /* NYPLAEToolkit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5FC68620A4DACC0075BDC7 /* NYPLAEToolkit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7B5FC68C20A4DAD00075BDC7 /* NYPLAudiobookToolkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5FC68720A4DACE0075BDC7 /* NYPLAudiobookToolkit.framework */; };
+		7B5FC68D20A4DAD00075BDC7 /* NYPLAudiobookToolkit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5FC68720A4DACE0075BDC7 /* NYPLAudiobookToolkit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		841B55431B740F2700FAC1AF /* NYPLSettingsEULAViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 841B55421B740F2700FAC1AF /* NYPLSettingsEULAViewController.m */; };
 		84B7A3461B84E8FE00584FB2 /* OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3431B84E8FE00584FB2 /* OFL.txt */; };
 		84B7A3471B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3441B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf */; };
@@ -236,6 +242,22 @@
 			remoteInfo = RDServices;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		7B5FC68E20A4DAD00075BDC7 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				7B5FC68D20A4DAD00075BDC7 /* NYPLAudiobookToolkit.framework in Embed Frameworks */,
+				7B5FC68B20A4DAD00075BDC7 /* NYPLAEToolkit.framework in Embed Frameworks */,
+				7B5FC68920A4DAD00075BDC7 /* AudioEngine.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0305005D1E8EF65100EA02C4 /* HelpStackThemeNYPL.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = HelpStackThemeNYPL.plist; sourceTree = "<group>"; };
@@ -501,6 +523,9 @@
 		5A69291D1B95C8AD00FB4C10 /* readium-shared-js_all.js.map */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; name = "readium-shared-js_all.js.map"; path = "readium-shared-js/build-output/_single-bundle/readium-shared-js_all.js.map"; sourceTree = SOURCE_ROOT; };
 		5A6929231B95C8B400FB4C10 /* readium-shared-js_all.js.bundles.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "readium-shared-js_all.js.bundles.js"; path = "readium-shared-js/build-output/_single-bundle/readium-shared-js_all.js.bundles.js"; sourceTree = SOURCE_ROOT; };
 		5A7048911B94A6700046FFF0 /* Adobe Content Filter.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "Adobe Content Filter.xcodeproj"; path = "adobe-content-filter/build/iOS/Adobe Content Filter.xcodeproj"; sourceTree = "<group>"; };
+		7B5FC68120A4DACC0075BDC7 /* AudioEngine.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioEngine.framework; path = Carthage/Build/iOS/AudioEngine.framework; sourceTree = "<group>"; };
+		7B5FC68620A4DACC0075BDC7 /* NYPLAEToolkit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NYPLAEToolkit.framework; path = Carthage/Build/iOS/NYPLAEToolkit.framework; sourceTree = "<group>"; };
+		7B5FC68720A4DACE0075BDC7 /* NYPLAudiobookToolkit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NYPLAudiobookToolkit.framework; path = Carthage/Build/iOS/NYPLAudiobookToolkit.framework; sourceTree = "<group>"; };
 		841B55411B740F2700FAC1AF /* NYPLSettingsEULAViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYPLSettingsEULAViewController.h; sourceTree = "<group>"; };
 		841B55421B740F2700FAC1AF /* NYPLSettingsEULAViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYPLSettingsEULAViewController.m; sourceTree = "<group>"; };
 		8499EE06365A73ACE6116D3C /* Pods-SimplyE.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplyE.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SimplyE/Pods-SimplyE.debug.xcconfig"; sourceTree = "<group>"; };
@@ -601,11 +626,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7B5FC68C20A4DAD00075BDC7 /* NYPLAudiobookToolkit.framework in Frameworks */,
 				03B092301E78871A00AD338D /* MediaPlayer.framework in Frameworks */,
 				03B092281E78859E00AD338D /* CoreMedia.framework in Frameworks */,
 				03B0922E1E7886ED00AD338D /* CoreVideo.framework in Frameworks */,
 				03B0922C1E7886C900AD338D /* AVFoundation.framework in Frameworks */,
 				03B0922A1E7885A600AD338D /* AudioToolbox.framework in Frameworks */,
+				7B5FC68820A4DAD00075BDC7 /* AudioEngine.framework in Frameworks */,
 				03B092261E7883C400AD338D /* libiconv.tbd in Frameworks */,
 				A823D813192BABA400B55DE2 /* CoreGraphics.framework in Frameworks */,
 				03B092241E78839D00AD338D /* QuartzCore.framework in Frameworks */,
@@ -624,6 +651,7 @@
 				08A352201BDE8E410040BF1D /* CFNetwork.framework in Frameworks */,
 				84FCD2611B7BA79200BFEDD9 /* CoreLocation.framework in Frameworks */,
 				A823D815192BABA400B55DE2 /* UIKit.framework in Frameworks */,
+				7B5FC68A20A4DAD00075BDC7 /* NYPLAEToolkit.framework in Frameworks */,
 				A823D811192BABA400B55DE2 /* Foundation.framework in Frameworks */,
 				1112A8431A3249B4002B8CC1 /* libTenPrintCover.a in Frameworks */,
 				119503E91993F919009FB788 /* libz.dylib in Frameworks */,
@@ -953,6 +981,9 @@
 		A823D804192BABA400B55DE2 = {
 			isa = PBXGroup;
 			children = (
+				7B5FC68120A4DACC0075BDC7 /* AudioEngine.framework */,
+				7B5FC68620A4DACC0075BDC7 /* NYPLAEToolkit.framework */,
+				7B5FC68720A4DACE0075BDC7 /* NYPLAudiobookToolkit.framework */,
 				CAE35BBA1B86289500BF9BC5 /* Simplified.xcconfig */,
 				2D6AF74A1E7E341F005CEC90 /* Simplified+RMSDK.xcconfig */,
 				5A569A261B8351C6003B5B61 /* ADEPT.xcodeproj */,
@@ -1247,6 +1278,7 @@
 				FE8719C55955B22F68EDF819 /* Upload Bugsnag dSYM */,
 				8ED1E1320C2F37F0410DA796 /* [CP] Embed Pods Frameworks */,
 				7D35AB55AEA925FC3399FA2A /* [CP] Copy Pods Resources */,
+				7B5FC68E20A4DAD00075BDC7 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1896,6 +1928,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Simplified/Simplified-Prefix.pch";
@@ -1945,6 +1978,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Simplified/Simplified-Prefix.pch";

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		7B5FC68B20A4DAD00075BDC7 /* NYPLAEToolkit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5FC68620A4DACC0075BDC7 /* NYPLAEToolkit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7B5FC68C20A4DAD00075BDC7 /* NYPLAudiobookToolkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5FC68720A4DACE0075BDC7 /* NYPLAudiobookToolkit.framework */; };
 		7B5FC68D20A4DAD00075BDC7 /* NYPLAudiobookToolkit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B5FC68720A4DACE0075BDC7 /* NYPLAudiobookToolkit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7BF4971F20A62421004F46EF /* NYPLAudiobookController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF4971E20A62421004F46EF /* NYPLAudiobookController.swift */; };
 		841B55431B740F2700FAC1AF /* NYPLSettingsEULAViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 841B55421B740F2700FAC1AF /* NYPLSettingsEULAViewController.m */; };
 		84B7A3461B84E8FE00584FB2 /* OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3431B84E8FE00584FB2 /* OFL.txt */; };
 		84B7A3471B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3441B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf */; };
@@ -526,6 +527,7 @@
 		7B5FC68120A4DACC0075BDC7 /* AudioEngine.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioEngine.framework; path = Carthage/Build/iOS/AudioEngine.framework; sourceTree = "<group>"; };
 		7B5FC68620A4DACC0075BDC7 /* NYPLAEToolkit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NYPLAEToolkit.framework; path = Carthage/Build/iOS/NYPLAEToolkit.framework; sourceTree = "<group>"; };
 		7B5FC68720A4DACE0075BDC7 /* NYPLAudiobookToolkit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NYPLAudiobookToolkit.framework; path = Carthage/Build/iOS/NYPLAudiobookToolkit.framework; sourceTree = "<group>"; };
+		7BF4971E20A62421004F46EF /* NYPLAudiobookController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAudiobookController.swift; sourceTree = "<group>"; };
 		841B55411B740F2700FAC1AF /* NYPLSettingsEULAViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYPLSettingsEULAViewController.h; sourceTree = "<group>"; };
 		841B55421B740F2700FAC1AF /* NYPLSettingsEULAViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYPLSettingsEULAViewController.m; sourceTree = "<group>"; };
 		8499EE06365A73ACE6116D3C /* Pods-SimplyE.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplyE.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SimplyE/Pods-SimplyE.debug.xcconfig"; sourceTree = "<group>"; };
@@ -948,6 +950,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		7BF4971D20A623E7004F46EF /* Audiobook */ = {
+			isa = PBXGroup;
+			children = (
+				7BF4971E20A62421004F46EF /* NYPLAudiobookController.swift */,
+			);
+			name = Audiobook;
+			sourceTree = "<group>";
+		};
 		84B7A3421B84E8FE00584FB2 /* OpenDyslexicFont */ = {
 			isa = PBXGroup;
 			children = (
@@ -1061,6 +1071,7 @@
 		A823D816192BABA400B55DE2 /* Simplified */ = {
 			isa = PBXGroup;
 			children = (
+				7BF4971D20A623E7004F46EF /* Audiobook */,
 				0345BFE31DBF010100398B6F /* Annotations */,
 				110AF8891961D66C004887C3 /* Additions */,
 				0345BFEE1DBF031B00398B6F /* CardCreator */,
@@ -1650,6 +1661,7 @@
 				111197281986B43B0014462F /* NYPLBookCellDelegate.m in Sources */,
 				111197391987F4070014462F /* NYPLBookDetailNormalView.m in Sources */,
 				111E757D1A801A6F00718AD7 /* NYPLSettingsPrimaryNavigationController.m in Sources */,
+				7BF4971F20A62421004F46EF /* NYPLAudiobookController.swift in Sources */,
 				11A16E69195B2BD3004147F4 /* NYPLCatalogUngroupedFeedViewController.m in Sources */,
 				D787E8441FB6B0290016D9D5 /* NYPLSettingsAdvancedViewController.swift in Sources */,
 				111E757A1A80165C00718AD7 /* NYPLSettingsSplitViewController.m in Sources */,

--- a/Simplified/NYPLAudiobookController.swift
+++ b/Simplified/NYPLAudiobookController.swift
@@ -1,0 +1,77 @@
+//
+//  NYPLAudiobookController.swift
+//  SimplyE
+//
+//  Created by Dean Silfen on 5/11/18.
+//  Copyright © 2018 NYPL Labs. All rights reserved.
+//
+
+import UIKit
+import NYPLAudiobookToolkit
+
+@objcMembers class NYPLAudiobookController: NSObject {
+  var manager: AudiobookManager?
+  let encoder: JSONEncoder
+  let decoder: JSONDecoder
+  func configurePlayhead() {
+    guard let manager = self.manager else {
+      return
+    }
+    let cachedPlayhead = FileManager.default.contents(atPath: pathFor(audiobookID: manager.audiobook.uniqueIdentifier)!)
+    guard let playheadData = cachedPlayhead else {
+      return
+    }
+    
+    
+    guard let location = try? decoder.decode(ChapterLocation.self, from: playheadData) else {
+      return
+    }
+    manager.audiobook.player.movePlayheadToLocation(location)
+  }
+  
+  init(json: String, encoder: JSONEncoder = JSONEncoder(), decoder: JSONDecoder = JSONDecoder()) {
+    self.encoder = encoder
+    self.decoder = decoder
+    guard let data = json.data(using: String.Encoding.utf8) else { return }
+    let possibleJson = try? JSONSerialization.jsonObject(with: data, options: [])
+    guard let unwrappedJSON = possibleJson as? [String: Any] else { return }
+    guard let JSONmetadata = unwrappedJSON["metadata"] as? [String: Any] else { return }
+    guard let title = JSONmetadata["title"] as? String else {
+      return
+    }
+    guard let authors = JSONmetadata["authors"] as? [String] else {
+      return
+    }
+    let metadata = AudiobookMetadata(
+      title: title,
+      authors: authors,
+      narrators: ["John Hodgeman"],
+      publishers: ["Findaway"],
+      published: Date(),
+      modified: Date(),
+      language: "en"
+    )
+    
+    guard let audiobook = AudiobookFactory.audiobook(unwrappedJSON) else { return }
+    self.manager = DefaultAudiobookManager(
+      metadata: metadata,
+      audiobook: audiobook
+    )
+  }
+  
+  func pathFor(audiobookID: String) -> String? {
+    let paths = NSSearchPathForDirectoriesInDomains(FileManager.SearchPathDirectory.documentDirectory, FileManager.SearchPathDomainMask.userDomainMask, true)
+    let documentsURL = NSURL(fileURLWithPath: paths.first!, isDirectory: true)
+    let fullURL = documentsURL.appendingPathComponent("\(audiobookID).playhead")
+    return fullURL?.path
+  }
+  
+  public func savePlayhead() {
+    guard let chapter = self.manager?.audiobook.player.currentChapterLocation else {
+      return
+    }
+    if let encodedChapter = try? encoder.encode(chapter) {
+      FileManager.default.createFile(atPath: pathFor(audiobookID: chapter.audiobookID)!, contents: encodedChapter, attributes: nil)
+    }
+  }
+}

--- a/Simplified/NYPLAudiobookController.swift
+++ b/Simplified/NYPLAudiobookController.swift
@@ -11,8 +11,8 @@ import NYPLAudiobookToolkit
 
 @objcMembers class NYPLAudiobookController: NSObject {
   var manager: AudiobookManager?
-  let encoder: JSONEncoder
-  let decoder: JSONDecoder
+  let encoder = JSONEncoder()
+  let decoder = JSONDecoder()
   func configurePlayhead() {
     guard let manager = self.manager else {
       return
@@ -29,9 +29,7 @@ import NYPLAudiobookToolkit
     manager.audiobook.player.movePlayheadToLocation(location)
   }
   
-  init(json: String, encoder: JSONEncoder = JSONEncoder(), decoder: JSONDecoder = JSONDecoder()) {
-    self.encoder = encoder
-    self.decoder = decoder
+  init(json: String) {
     guard let data = json.data(using: String.Encoding.utf8) else { return }
     let possibleJson = try? JSONSerialization.jsonObject(with: data, options: [])
     guard let unwrappedJSON = possibleJson as? [String: Any] else { return }

--- a/Simplified/NYPLAudiobookController.swift
+++ b/Simplified/NYPLAudiobookController.swift
@@ -10,6 +10,7 @@ import UIKit
 import NYPLAudiobookToolkit
 
 @objcMembers class NYPLAudiobookController: NSObject {
+  static let payload = "" // replace with string-ified audiobook manifest
   var manager: AudiobookManager?
   let encoder = JSONEncoder()
   let decoder = JSONDecoder()

--- a/Simplified/NYPLRootTabBarController.m
+++ b/Simplified/NYPLRootTabBarController.m
@@ -5,6 +5,7 @@
 #import "NYPLSettingsSplitViewController.h"
 #import "NYPLRootTabBarController.h"
 #import "SimplyE-Swift.h"
+#import <NYPLAudiobookToolkit/NYPLAudiobookToolkit-Swift.h>
 
 @interface NYPLRootTabBarController () <UITabBarControllerDelegate>
 
@@ -12,6 +13,8 @@
 @property (nonatomic) NYPLMyBooksNavigationController *myBooksNavigationController;
 @property (nonatomic) NYPLHoldsNavigationController *holdsNavigationController;
 @property (nonatomic) NYPLSettingsSplitViewController *settingsSplitViewController;
+@property (nonatomic) AudiobookPlayerViewController *playerViewController;
+@property (nonatomic) NYPLAudiobookController *audiobookController;
 
 @end
 
@@ -36,6 +39,8 @@
 
 - (instancetype)init
 {
+  self.audiobookController = [[NYPLAudiobookController alloc] initWithJson: NYPLAudiobookController.payload];
+  
   self = [super init];
   if(!self) return nil;
   

--- a/Simplified/NYPLRootTabBarController.m
+++ b/Simplified/NYPLRootTabBarController.m
@@ -40,7 +40,7 @@
 - (instancetype)init
 {
   self.audiobookController = [[NYPLAudiobookController alloc] initWithJson: NYPLAudiobookController.payload];
-  
+  self.playerViewController = [[AudiobookPlayerViewController alloc] initWithAudiobookManager:self.audiobookController.manager];
   self = [super init];
   if(!self) return nil;
   
@@ -72,7 +72,7 @@
     self.viewControllers = @[self.catalogNavigationController,
                              self.myBooksNavigationController,
                              self.holdsNavigationController,
-                             self.settingsSplitViewController];
+                             self.playerViewController];
   } else {
     self.viewControllers = @[self.catalogNavigationController,
                              self.myBooksNavigationController,


### PR DESCRIPTION
- [x] move all git references from local filesystem to GitHub 
- [ ] remove POC code from tab bar
- [ ] document how to build when NYPLAEToolkit is missing

Note:

To get this to work we must use the `HEAD` release of Carthage.

In version 0.29.0 (Great Groove) of Carthage, `binary` packages write to lock files with absolute file references. This breaks the portability of the lock file. This is fixed in `HEAD`, and should be included in the next release of Carthage.

https://github.com/Carthage/Carthage/issues/2382
https://github.com/Carthage/Carthage/pull/2383

To build Carthage dependencies:

```bash
$ carthage bootstrap --platform iOS --use-ssh
```