### PR TITLE
Address possibility of NSNull return from a Nullable variable.

### DIFF
--- a/Simplified/NYPLReaderReadiumView.m
+++ b/Simplified/NYPLReaderReadiumView.m
@@ -695,7 +695,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
     [self
      sequentiallyEvaluateJavaScript:@"ReadiumSDK.reader.bookmarkCurrentPage()"
      withCompletionHandler:^(id  _Nullable result, __unused NSError *_Nullable error) {
-       if(!result) {
+       if(!result || [result isKindOfClass:[NSNull class]]) {
          NYPLLOG(@"Readium failed to generate a CFI. This is a bug in Readium.");
          return;
        }


### PR DESCRIPTION
@winniequinn 
Quick inspection apprecated... Occassional crash from trying to send `rangeOfString` to `NSNull` on `result` on line 704.

fixes #986 