### PR TITLE
Integrate PDF Reader, No Local Data Save

### DIFF
--- a/Simplified/Accounts.json
+++ b/Simplified/Accounts.json
@@ -52,6 +52,21 @@
  "mainColor" : "#497049"
  },
  {
+ "id" : 100,
+ "pathComponent" : "100",
+ "name" : "Open Textbook Library",
+ "subtitle" : "Textbooks free to download and read without a library card.",
+ "logo" : "LibraryLogoMagic",
+ "needsAuth" : false,
+ "supportsSimplyESync" : false,
+ "supportsBarcodeScanner" : false,
+ "supportsBarcodeDisplay" : false,
+ "supportsCardCreator" : false,
+ "supportsReservations" : false,
+ "catalogUrl" : "http://open.minitex.org/textbooks",
+ "mainColor" : "#497049"
+ },
+ {
  "id" : 7,
  "pathComponent" : "7",
  "name" : "Alameda County Library",


### PR DESCRIPTION
We just want to render a PDF book in the PDF render. The bookmark and annotation features will still work, but no data of any kind will be saved locally: last page read, bookmarks, or annotations; and there will be no server syncing of data at this point either. Using the OpenTextbooks feed for the source of PDF books for this PR.