### PR TITLE
Ignore ReaderClientCert.sig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ DerivedData
 .idea
 Build
 adobe-rmsdk
+ReaderClientCert.sig
 Simplified/APIKeys.swift
 AudioEngine.json
 Carthage


### PR DESCRIPTION
I'm surprised this was never done. Presumably we all had it in our personal ignore files.