### PR TITLE
Remove Search Icon For Non-Searchable Catalogs #1008

### DIFF
--- a/Simplified/NYPLCatalogGroupedFeedViewController.m
+++ b/Simplified/NYPLCatalogGroupedFeedViewController.m
@@ -87,6 +87,12 @@ static CGFloat const sectionHeaderHeight = 50.0;
     self.navigationItem.rightBarButtonItem.enabled = NO;
     
     [self fetchOpenSearchDescription];
+  } else {
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc]
+                                              initWithTitle:@""
+                                              style:UIBarButtonItemStylePlain
+                                              target:nil
+                                              action:nil];
   }
   
   [self downloadImages];

--- a/Simplified/NYPLCatalogUngroupedFeedViewController.m
+++ b/Simplified/NYPLCatalogUngroupedFeedViewController.m
@@ -103,6 +103,12 @@ static const CGFloat kActivityIndicatorPadding = 20.0;
     self.navigationItem.rightBarButtonItem.enabled = NO;
     
     [self fetchOpenSearchDescription];
+  } else {
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc]
+                                              initWithTitle:@""
+                                              style:UIBarButtonItemStylePlain
+                                              target:nil
+                                              action:nil];
   }
   
   [self.collectionView reloadData];


### PR DESCRIPTION
This branch addresses JIRA issue: http://jira.nypl.org/browse/SIMPLY-1008

where the search icon (magnifying glass) appeared in the navigation bar of a feed that doesn't have search support. Before, the search icon would sometimes be visible for a non-searchable feed, but nothing would happen if the user clicked on that icon. This created a poor user experience.

Now, with this fix, the search icon is visible and activated for a searchable feed; and not visible and not activated for a non-searchable feed.