### PR TITLE
Rework account switch; pull accounts from Settings

### DIFF
--- a/Simplified/NYPLAccount.m
+++ b/Simplified/NYPLAccount.m
@@ -21,7 +21,7 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
 
 + (instancetype)sharedAccount
 {
-  NSInteger library = [[NYPLSettings sharedSettings] currentAccountIdentifier];
+  NSInteger library = [AccountsManager shared].currentAccount.id;
   return [self sharedAccount:library];
 }
 

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -127,7 +127,7 @@ CGFloat const marginPadding = 2.0;
   self.view.backgroundColor = [NYPLConfiguration backgroundColor];
   self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
 
-  self.currentAccount = [[NYPLSettings sharedSettings] currentAccount];
+  self.currentAccount = [AccountsManager shared].currentAccount;
   
   self.usernameTextField = [[UITextField alloc] initWithFrame:CGRectZero];
   self.usernameTextField.delegate = self;

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -606,7 +606,7 @@ static NSString *const RecordsKey = @"records";
 
 - (void)reset:(NSInteger)account
 {
-  if ([[NYPLSettings sharedSettings] currentAccountIdentifier] == account)
+  if ([AccountsManager shared].currentAccount.id == account)
   {
     [self reset];
   }

--- a/Simplified/NYPLConfiguration.m
+++ b/Simplified/NYPLConfiguration.m
@@ -99,7 +99,8 @@
 
 + (UIColor *)mainColor
 {
-  Account *const account = [[NYPLSettings sharedSettings] currentAccount];
+  Account *const account = [AccountsManager shared].currentAccount;
+
   if (account.mainColor) {
     return [NYPLAppTheme themeColorFromStringWithName:account.mainColor];
   } else {

--- a/Simplified/NYPLDirectoryManager.swift
+++ b/Simplified/NYPLDirectoryManager.swift
@@ -5,7 +5,7 @@ import Foundation
 final class DirectoryManager : NSObject {
   
   class func current() -> URL? {
-    return directory(NYPLSettings.shared().currentAccountIdentifier)
+    return directory(AccountsManager.shared.currentAccount.id)
   }
   
   class func directory(_ account: Int) -> URL? {

--- a/Simplified/NYPLHoldsNavigationController.m
+++ b/Simplified/NYPLHoldsNavigationController.m
@@ -52,7 +52,7 @@
   
   NYPLHoldsViewController *viewController = (NYPLHoldsViewController *)self.visibleViewController;
   
-  viewController.navigationItem.title = [[NYPLSettings sharedSettings] currentAccount].name;
+  viewController.navigationItem.title = [AccountsManager shared].currentAccount.name;
 }
 
 - (void)currentAccountChanged
@@ -93,12 +93,12 @@
                          completion:nil];
       } else {
         [[NYPLBookRegistry sharedRegistry] save];
-        [[NYPLSettings sharedSettings] setCurrentAccountIdentifier:account.id];
+        [AccountsManager shared].currentAccount = account;
         [self reloadSelected];
       }
     #else
       [[NYPLBookRegistry sharedRegistry] save];
-      [[NYPLSettings sharedSettings] setCurrentAccountIdentifier:account.id];
+      [AccountsManager shared].currentAccount = account;
       [self reloadSelected];
     #endif
     }]];
@@ -124,7 +124,7 @@
   [catalog reloadSelectedLibraryAccount];
   
   NYPLHoldsViewController *viewController = (NYPLHoldsViewController *)self.visibleViewController;
-  viewController.navigationItem.title = [[NYPLSettings sharedSettings] currentAccount].name;
+  viewController.navigationItem.title = [AccountsManager shared].currentAccount.name;
 }
 
 @end

--- a/Simplified/NYPLHoldsViewController.m
+++ b/Simplified/NYPLHoldsViewController.m
@@ -242,7 +242,7 @@ didSelectItemAtIndexPath:(NSIndexPath *const)indexPath
 {
   [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncBeganNotification object:nil];
   
-  Account *account = [[NYPLSettings sharedSettings] currentAccount];
+  Account *const account = [AccountsManager shared].currentAccount;
   
   if (account.needsAuth)
   {

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -768,7 +768,7 @@ didDismissWithButtonIndex:(NSInteger const)buttonIndex
 
 - (void)reset:(NSInteger)account
 {
-  if ([[NYPLSettings sharedSettings] currentAccountIdentifier] == account)
+  if ([AccountsManager shared].currentAccount.id == account)
   {
     [self reset];
   }

--- a/Simplified/NYPLMyBooksNavigationController.m
+++ b/Simplified/NYPLMyBooksNavigationController.m
@@ -54,7 +54,7 @@
     
   NYPLMyBooksViewController *viewController = (NYPLMyBooksViewController *)self.visibleViewController;
   
-  viewController.navigationItem.title = [[NYPLSettings sharedSettings] currentAccount].name;
+  viewController.navigationItem.title = [AccountsManager shared].currentAccount.name;
     
 }
 
@@ -96,12 +96,12 @@
                          completion:nil];
       } else {
         [[NYPLBookRegistry sharedRegistry] save];
-        [[NYPLSettings sharedSettings] setCurrentAccountIdentifier:account.id];
+        [AccountsManager shared].currentAccount = account;
         [self reloadSelected];
       }
     #else
       [[NYPLBookRegistry sharedRegistry] save];
-      [[NYPLSettings sharedSettings] setCurrentAccountIdentifier:account.id];
+      [AccountsManager shared].currentAccount = account;
       [self reloadSelected];
     #endif
     }]];
@@ -128,7 +128,7 @@
   [catalog reloadSelectedLibraryAccount];
   
   NYPLMyBooksViewController *viewController = (NYPLMyBooksViewController *)self.visibleViewController;
-  viewController.navigationItem.title =  [[NYPLSettings sharedSettings] currentAccount].name;
+  viewController.navigationItem.title =  [AccountsManager shared].currentAccount.name;
 }
 
 @end

--- a/Simplified/NYPLMyBooksViewController.m
+++ b/Simplified/NYPLMyBooksViewController.m
@@ -365,7 +365,7 @@ OK:
   
   [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncBeganNotification object:nil];
 
-  Account *account = [[NYPLSettings sharedSettings] currentAccount];
+  Account *const account = [AccountsManager shared].currentAccount;
   
   if (account.needsAuth)
   {

--- a/Simplified/NYPLRemoteViewController.h
+++ b/Simplified/NYPLRemoteViewController.h
@@ -1,18 +1,20 @@
-// This class is designed to provide a simple way to implement view controllers that must retreive
-// some sort of network-available data before they can do anything. The idea is that an instance of
-// |NYPLRemoteViewController| can be told to load the data present at some URL. While the data is
-// downloading, it will display a progress indicator. Once the data has been retreived, the handler
-// function provided will be called. That handler then returns a new view controller that is
-// presented by the instance of |NYPLRemoteViewController|.
-//
-// The current left and right bar buttons of the presented view controller, as well as the current
-// title, will be displayed. Changes to said properties later on will not be shown, so be sure they
-// are all set before the handler returns. (Changes to the items already /within/ the left and right
-// sets of items will be correctly displayed, however.)
+/// This class is designed to provide a simple way to implement view controllers that must retreive
+/// some sort of network-available data before they can do anything. The idea is that an instance of
+/// |NYPLRemoteViewController| can be told to load the data present at some URL. While the data is
+/// downloading, it will display a progress indicator. Once the data has been retreived, the handler
+/// function provided will be called. That handler then returns a new view controller that is
+/// presented by the instance of |NYPLRemoteViewController|.
+///
+/// The current left and right bar buttons of the presented view controller, as well as the current
+/// title, will be displayed. Changes to said properties later on will not be shown, so be sure they
+/// are all set before the handler returns. (Changes to the items already /within/ the left and right
+/// sets of items will be correctly displayed, however.)
+///
+/// For more information, see Apple's documentation on view controller containers.
 
 @interface NYPLRemoteViewController : UIViewController
 
-// After changing this, you must call |load| to see the effect.
+/// After changing this, you must call |load| to see the effect.
 @property (atomic) NSURL *URL;
 
 + (id)new NS_UNAVAILABLE;
@@ -20,15 +22,15 @@
 - (id)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 
-// |handler| may not be nil. |handler| is strongly retained. |data| will never be nil as the handler
-// is only called if the data was downloaded successfully. The handler may return nil to indicate
-// that there is something wrong with the data.
+/// |handler| may not be nil. |handler| is strongly retained. |data| will never be nil as the handler
+/// is only called if the data was downloaded successfully. The handler may return nil to indicate
+/// that there is something wrong with the data.
 - (instancetype)initWithURL:(NSURL *)URL
           completionHandler:(UIViewController *(^)(NYPLRemoteViewController *remoteViewController,
                                                    NSData *data,
                                                    NSURLResponse *response))handler;
 
-// This may be called more than once to reload the data accessible at the previously provided URL.
+/// This may be called more than once to reload the data accessible at the previously provided URL.
 - (void)load;
 
 @end

--- a/Simplified/NYPLRemoteViewController.m
+++ b/Simplified/NYPLRemoteViewController.m
@@ -163,6 +163,8 @@
     [self addChildViewController:viewController];
     viewController.view.frame = self.view.bounds;
     [self.view addSubview:viewController.view];
+    // If `viewController` does not have its own bar button items or title, use whatever
+    // has been set on `self` by default.
     if(viewController.navigationItem.rightBarButtonItems) {
       self.navigationItem.rightBarButtonItems = viewController.navigationItem.rightBarButtonItems;
     }

--- a/Simplified/NYPLRootTabBarController.m
+++ b/Simplified/NYPLRootTabBarController.m
@@ -62,7 +62,7 @@
 
 - (void)setTabViewControllers
 {
-  Account *currentAccount = [[NYPLSettings sharedSettings] currentAccount];
+  Account *const currentAccount = [AccountsManager shared].currentAccount;
   if (currentAccount.supportsReservations) {
     self.viewControllers = @[self.catalogNavigationController,
                              self.myBooksNavigationController,

--- a/Simplified/NYPLSettings.h
+++ b/Simplified/NYPLSettings.h
@@ -26,8 +26,6 @@ static NSString *const NYPLUserAgreementURLString = @"http://www.librarysimplifi
 @property (atomic) BOOL userPresentedAgeCheck;
 @property (atomic) BOOL userHasSeenFirstTimeSyncMessage;
 @property (atomic) NYPLCardApplicationModel *currentCardApplication;
-@property (readonly) Account* currentAccount;
-@property (atomic) NSInteger currentAccountIdentifier;
 @property (atomic) NSArray* settingsAccountsList;
 
 // Leaving this set to |NYPLSettingsRenderingEngineAutomatic| (the default) is *highly* recommended.

--- a/Simplified/NYPLSettings.m
+++ b/Simplified/NYPLSettings.m
@@ -5,8 +5,6 @@
 #import "NYPLConfiguration.h"
 #import "SimplyE-Swift.h"
 
-static NSString *const currentAccountIdentifierKey = @"NYPLCurrentAccountIdentifier";
-
 static NSString *const customMainFeedURLKey = @"NYPLSettingsCustomMainFeedURL";
 
 static NSString *const accountMainFeedURLKey = @"NYPLSettingsAccountMainFeedURL";
@@ -69,15 +67,6 @@ static NSString *StringFromRenderingEngine(NYPLSettingsRenderingEngine const ren
   
   return sharedSettings;
 }
-- (Account*)currentAccount
-{
-  return [[AccountsManager sharedInstance] account:[[NYPLSettings sharedSettings] currentAccountIdentifier]];
-}
-
-- (NSInteger)currentAccountIdentifier
-{
-  return [[NSUserDefaults standardUserDefaults] integerForKey:currentAccountIdentifierKey];
-}
 
 - (NSURL *)customMainFeedURL
 {
@@ -109,12 +98,13 @@ static NSString *StringFromRenderingEngine(NYPLSettingsRenderingEngine const ren
   return [[NSUserDefaults standardUserDefaults] boolForKey:userSeenFirstTimeSyncMessageKey];
 }
 
+// FIXME: This should be in `AccountsManager`, not `NYPLSettings`.
 - (NSArray *) settingsAccountsList
 {
   NSArray *libraryAccounts = [[NSUserDefaults standardUserDefaults] arrayForKey:settingsLibraryAccountsKey];
   // If user has not selected any accounts yet, return the "currentAccount"
   if (!libraryAccounts) {
-    NSInteger currentLibrary = [self currentAccountIdentifier];
+    NSInteger currentLibrary = [AccountsManager shared].currentAccount.id;
     [self setSettingsAccountsList:@[@(currentLibrary), @2]];
     return [self settingsAccountsList];
   } else {
@@ -129,15 +119,6 @@ static NSString *StringFromRenderingEngine(NYPLSettingsRenderingEngine const ren
     return nil;
   
   return [NSKeyedUnarchiver unarchiveObjectWithData:currentCardApplicationSerialization];
-}
-- (void)setCurrentAccountIdentifier:(NSInteger)account
-{
-  [[NSUserDefaults standardUserDefaults] setInteger:account forKey:currentAccountIdentifierKey];
-  [[NSUserDefaults standardUserDefaults] synchronize];
-  
-  [[NSNotificationCenter defaultCenter]
-   postNotificationName:NYPLCurrentAccountDidChangeNotification
-   object:self];
 }
 
 - (void)setUserHasSeenWelcomeScreen:(BOOL)userPresentedScreen

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -454,7 +454,7 @@ double const requestTimeoutInterval = 25.0;
        NYPLLOG(@"***Successful DRM Deactivation***");
        // FIXME: NYPLDeviceManager should be updated once redesign of NYPLAccount is complete
        // Until then, only use on currently active library account
-       if (self.selectedAccountType == [[NYPLSettings sharedSettings] currentAccountIdentifier]) {
+       if (self.selectedAccountType == [AccountsManager shared].currentAccount) {
          NSURL *deviceManager =  [NSURL URLWithString: [self.selectedNYPLAccount licensor][@"deviceManager"]];
          if (deviceManager != nil) {
            [NYPLDeviceManager deleteDevice:[self.selectedNYPLAccount deviceID] url:deviceManager];
@@ -530,7 +530,7 @@ double const requestTimeoutInterval = 25.0;
           if (success) {
             // FIXME: NYPLDeviceManager should be updated once redesign of NYPLAccount is complete
             // Until then, only use on currently active library account
-            if (self.selectedAccountType == [[NYPLSettings sharedSettings] currentAccountIdentifier]) {
+            if (self.selectedAccountType == [AccountsManager shared].currentAccount.id) {
               NSURL *deviceManager = [NSURL URLWithString: [self.selectedNYPLAccount licensor][@"deviceManager"]];
               if (deviceManager != nil) {
                 [NYPLDeviceManager postDevice:deviceID url:deviceManager];
@@ -629,7 +629,7 @@ double const requestTimeoutInterval = 25.0;
     if(success) {
       [self.selectedNYPLAccount setBarcode:self.usernameTextField.text PIN:self.PINTextField.text];
 
-      if(self.selectedAccountType == [[NYPLSettings sharedSettings] currentAccountIdentifier]) {
+      if(self.selectedAccountType == [AccountsManager shared].currentAccount.id) {
         void (^handler)(void) = self.completionHandler;
         self.completionHandler = nil;
         if(handler) handler();
@@ -1610,7 +1610,7 @@ replacementString:(NSString *)string
   return ((self.selectedAccount.supportsSimplyESync) &&
           ([self.selectedAccount getLicenseURL:URLTypeAnnotations] &&
            [self.selectedNYPLAccount hasBarcodeAndPIN]) &&
-           (self.selectedAccountType == [[NYPLSettings sharedSettings] currentAccountIdentifier]));
+           (self.selectedAccountType == [AccountsManager shared].currentAccount.id));
 }
 
 - (void)didSelectCancel

--- a/Simplified/NYPLWelcomeScreen.swift
+++ b/Simplified/NYPLWelcomeScreen.swift
@@ -5,9 +5,9 @@ import PureLayout
 /// Welcome screen for a first-time user
 final class NYPLWelcomeScreenViewController: UIViewController {
   
-  var completion: ((Int) -> ())?
+  var completion: ((Account) -> ())?
   
-  required init(completion: ((Int) -> ())?) {
+  required init(completion: ((Account) -> ())?) {
     self.completion = completion
     super.init(nibName: nil, bundle: nil)
   }
@@ -157,7 +157,7 @@ final class NYPLWelcomeScreenViewController: UIViewController {
         } else {
           NYPLSettings.shared().settingsAccountsList = [2]
         }
-        self.completion?(acct.id)
+        self.completion?(acct)
       }
       self.navigationController?.pushViewController(listVC, animated: true)
     } else {
@@ -167,7 +167,7 @@ final class NYPLWelcomeScreenViewController: UIViewController {
         } else {
           NYPLSettings.shared().settingsAccountsList = [0, 2]
         }
-        self.completion?(acct.id)
+        self.completion?(acct)
       }
       self.navigationController?.pushViewController(listVC, animated: true)
     }
@@ -180,7 +180,7 @@ final class NYPLWelcomeScreenViewController: UIViewController {
     else {
       NYPLSettings.shared().settingsAccountsList = [2]
     }
-    completion?(2)
+    completion?(AccountsManager.shared.account(2)!)
   }
 }
 


### PR DESCRIPTION
Previously, switching an account would reuse the top-level view controller in Catalog. This caused various bugs such as the search button not being correctly set after changing libraries. This commit reworks account switching so that `NYPLCatalogNavigationController` throws away its view controllers and starts fresh with a new one, thus eliminating various problems.

In addition, this commit also moves much accounts-related functionality from `NYPLSettings` to its rightful place in `AccountsManager`.