### PR TITLE
add objcMembers to fix swift 4/xcode 10 build errors

### DIFF
--- a/APIKeys.swift.example
+++ b/APIKeys.swift.example
@@ -2,7 +2,7 @@ import Foundation
 
 import HelpStack
 
-class APIKeys: NSObject {
+@objcMembers class APIKeys: NSObject {
 
   static let bugsnagID: String = ""
 


### PR DESCRIPTION
@objc inference was (thankfully) dropped in swift 4; now must be explicit. This fixes build errors I hit when doing a fresh checkout of the project.