### PR TITLE
Truncate Long Titles on Recommendations Lane #1482

### DIFF
--- a/Simplified/NYPLBookDetailTableView.swift
+++ b/Simplified/NYPLBookDetailTableView.swift
@@ -261,7 +261,8 @@ private let standardCellHeight: CGFloat = 44.0
     headerButton.setTitle(catalogLanes[section].title, for: .normal)
     headerButton.setTitleColor(.black, for: .normal)
     headerButton.titleLabel?.font = UIFont.customBoldFont(forTextStyle: UIFont.TextStyle.caption1)
-    
+    headerButton.titleLabel?.lineBreakMode = NSLineBreakMode.byTruncatingTail;
+
     moreButton.addTarget(self, action: #selector(moreBooksTapped(sender:)), for: .touchUpInside)
     moreButton.tag = section
     moreButton.setTitle("More...", for: .normal)
@@ -272,6 +273,7 @@ private let standardCellHeight: CGFloat = 44.0
     container.addSubview(moreButton)
     headerButton.autoAlignAxis(toSuperviewAxis: .horizontal)
     headerButton.autoPinEdge(toSuperviewEdge: .leading, withInset: 20)
+    headerButton.widthAnchor.constraint(lessThanOrEqualTo: container.widthAnchor, multiplier: 0.75).isActive = true
     moreButton.autoAlignAxis(toSuperviewAxis: .horizontal)
     moreButton.autoPinEdge(toSuperviewMargin: .trailing)
     return container

--- a/Simplified/NYPLBookDetailTableView.swift
+++ b/Simplified/NYPLBookDetailTableView.swift
@@ -261,6 +261,8 @@ private let standardCellHeight: CGFloat = 44.0
     headerButton.setTitle(catalogLanes[section].title, for: .normal)
     headerButton.setTitleColor(.black, for: .normal)
     headerButton.titleLabel?.font = UIFont.customBoldFont(forTextStyle: UIFont.TextStyle.caption1)
+    headerButton.titleLabel?.textAlignment = NSTextAlignment.left
+    headerButton.titleLabel?.autoPinEdge(toSuperviewEdge: .left)
     headerButton.titleLabel?.lineBreakMode = NSLineBreakMode.byTruncatingTail;
 
     moreButton.addTarget(self, action: #selector(moreBooksTapped(sender:)), for: .touchUpInside)
@@ -268,12 +270,14 @@ private let standardCellHeight: CGFloat = 44.0
     moreButton.setTitle("More...", for: .normal)
     moreButton.setTitleColor(.black, for: .normal)
     moreButton.titleLabel?.font = UIFont.customFont(forTextStyle: UIFont.TextStyle.caption1)
+    moreButton.titleLabel?.textAlignment = NSTextAlignment.right
+    moreButton.titleLabel?.autoPinEdge(toSuperviewEdge: .right)
     
     container.addSubview(headerButton)
     container.addSubview(moreButton)
     headerButton.autoAlignAxis(toSuperviewAxis: .horizontal)
     headerButton.autoPinEdge(toSuperviewEdge: .leading, withInset: 20)
-    headerButton.widthAnchor.constraint(lessThanOrEqualTo: container.widthAnchor, multiplier: 0.75).isActive = true
+    headerButton.autoPinEdge(.trailing, to: .leading, of: moreButton, withOffset: -20)
     moreButton.autoAlignAxis(toSuperviewAxis: .horizontal)
     moreButton.autoPinEdge(toSuperviewMargin: .trailing)
     return container


### PR DESCRIPTION
This PR addresses the JIRA issue: https://jira.nypl.org/browse/SIMPLY-1482

where long titles in the Recommendations lane of the Book Detail View would overlap with the "More..." link as shown here, in a before screenshot (on an iphone 5s simulator, the smallest simulator that I can run on Xcode 10.1 right now):

![simulator screen shot - iphone 5s - 2019-01-09 at 09 56 18](https://user-images.githubusercontent.com/1022275/50917138-0ea5a800-13fa-11e9-8b41-5ce6df7537c3.png)

I've fixed this so now long titles get truncated with "..." and no longer overlap with the "More..." link, as seen here in the after screenshot, also on an iphone 5s simulator:

![simulator screen shot - iphone 5s - 2019-01-09 at 09 58 37](https://user-images.githubusercontent.com/1022275/50917325-74922f80-13fa-11e9-88f9-15833b079253.png)

