### PR TITLE
Support smart invert colors

### DIFF
--- a/Simplified/NYPLBookDetailView.m
+++ b/Simplified/NYPLBookDetailView.m
@@ -217,8 +217,14 @@ static NSString *DetailHTMLTemplate = nil;
 
   self.coverImageView = [[UIImageView alloc] init];
   self.coverImageView.contentMode = UIViewContentModeScaleAspectFit;
+  if (@available(iOS 11.0, *)) {
+    self.coverImageView.accessibilityIgnoresInvertColors = YES;
+  }
   self.blurCoverImageView = [[UIImageView alloc] init];
   self.blurCoverImageView.contentMode = UIViewContentModeScaleAspectFit;
+  if (@available(iOS 11.0, *)) {
+    self.blurCoverImageView.accessibilityIgnoresInvertColors = YES;
+  }
   self.blurCoverImageView.alpha = 0.4f;
 
   [[NYPLBookRegistry sharedRegistry]

--- a/Simplified/NYPLBookNormalCell.m
+++ b/Simplified/NYPLBookNormalCell.m
@@ -74,6 +74,9 @@
   
   if(!self.cover) {
     self.cover = [[UIImageView alloc] init];
+    if (@available(iOS 11.0, *)) {
+      self.cover.accessibilityIgnoresInvertColors = YES;
+    }
     [self.contentView addSubview:self.cover];
   }
 

--- a/Simplified/NYPLCatalogLaneCell.m
+++ b/Simplified/NYPLCatalogLaneCell.m
@@ -51,6 +51,9 @@
     }
     [button setImage:(image ? image : [UIImage imageNamed:@"NoCover"])
             forState:UIControlStateNormal];
+    if (@available(iOS 11.0, *)) {
+      button.accessibilityIgnoresInvertColors = YES;
+    }
     [button addTarget:self
                action:@selector(didSelectBookButton:)
      forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
This prevents cover images from being inverted when using iOS 11's smart invert color feature.

**NOTE:** I was not able to test this change, although I'd be happy to do so if I could receive an up-to-date `Accounts.json`. I'm especially unsure about `blurCoverImageView`.