### PR TITLE
Notifications Refinements

### DIFF
--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -1015,7 +1015,6 @@ completionHandler:(void (^)(void))handler
         if (success) {
           [[NYPLBookRegistry sharedRegistry] save];
         }
-        [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
       }];
 
     } else {

--- a/Simplified/NYPLAppDelegate.m
+++ b/Simplified/NYPLAppDelegate.m
@@ -35,7 +35,7 @@
 
 @implementation NYPLAppDelegate
 
-const NSTimeInterval MinimumBackgroundFetchInterval = 60 * 60 * 6;
+const NSTimeInterval MinimumBackgroundFetchInterval = 60 * 60 * 12;
 
 #pragma mark UIApplicationDelegate
 
@@ -78,7 +78,6 @@ didFinishLaunchingWithOptions:(__attribute__((unused)) NSDictionary *)launchOpti
 performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))backgroundFetchHandler
 {
   UIBackgroundTaskIdentifier bgTask = [application beginBackgroundTaskWithExpirationHandler:^{
-    NYPLLOG(@"Error: Background fetch expired before completion.");
     backgroundFetchHandler(UIBackgroundFetchResultFailed);
   }];
 

--- a/Simplified/NYPLAppDelegate.m
+++ b/Simplified/NYPLAppDelegate.m
@@ -87,7 +87,6 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))backgroundF
     if (success) {
       [[NYPLBookRegistry sharedRegistry] save];
     }
-    [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
   } backgroundFetchHandler:^(UIBackgroundFetchResult result) {
     backgroundFetchHandler(result);
     [application endBackgroundTask:bgTask];

--- a/Simplified/NYPLBookRegistry.h
+++ b/Simplified/NYPLBookRegistry.h
@@ -57,6 +57,11 @@ static NSString *const NYPLBookProcessingDidChangeNotification =
 // completion.
 - (void)syncWithStandardAlertsOnCompletion;
 
+// This method should be called when the user expects an up-to-date book registry. For example,
+// when the user first visits My Books or Holds. The method will only run once for each app
+// launch so as to not interfere with a system-initiated background fetch.
+- (void)syncOnceIfNeeded;
+
 // Adds a book to the book registry until it is manually removed. It allows the application to
 // present information about obtained books when offline. Attempting to add a book already present
 // will overwrite the existing book as if |updateBook:| were called. The location may be nil. The

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -264,7 +264,6 @@ static NSString *const RecordsKey = @"records";
 
 - (void)syncWithCompletionHandler:(void (^)(BOOL success))handler
 {
-  [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncBeganNotification object:nil];
   [self syncWithCompletionHandler:handler backgroundFetchHandler:nil];
 }
 
@@ -272,6 +271,9 @@ static NSString *const RecordsKey = @"records";
             backgroundFetchHandler:(void (^)(UIBackgroundFetchResult))fetchHandler
 {
   @synchronized(self) {
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncBeganNotification object:nil];
+
     if(self.syncing) {
       [[NSOperationQueue mainQueue] addOperationWithBlock:^{
         if(fetchHandler) fetchHandler(UIBackgroundFetchResultNoData);
@@ -281,6 +283,7 @@ static NSString *const RecordsKey = @"records";
       [[NSOperationQueue mainQueue] addOperationWithBlock:^{
         if(handler) handler(NO);
         if(fetchHandler) fetchHandler(UIBackgroundFetchResultNoData);
+        [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
       }];
       return;
     } else {
@@ -301,6 +304,7 @@ static NSString *const RecordsKey = @"records";
         addOperationWithBlock:^{
           if(handler) handler(NO);
           if(fetchHandler) fetchHandler(UIBackgroundFetchResultFailed);
+          [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
         }];
        return;
      }
@@ -356,6 +360,7 @@ static NSString *const RecordsKey = @"records";
           [NYPLUserNotifications updateAppIconBadgeWithHeldBooks:[self heldBooks]];
           if(handler) handler(YES);
           if(fetchHandler) fetchHandler(UIBackgroundFetchResultNewData);
+          [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
         }];
      };
      
@@ -378,7 +383,6 @@ static NSString *const RecordsKey = @"records";
                                   message:NSLocalizedString(@"CheckConnection", nil)];
       [alert presentFromViewControllerOrNil:nil animated:YES completion:nil];
     }
-    [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
   }];
 }
 

--- a/Simplified/NYPLCatalogFeedViewController.m
+++ b/Simplified/NYPLCatalogFeedViewController.m
@@ -104,6 +104,7 @@
 {
   [super viewWillAppear:animated];
   [self.navigationController setNavigationBarHidden:NO];
+  [[NYPLBookRegistry sharedRegistry] syncOnceIfNeeded];
 }
 
 @end

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -166,7 +166,6 @@
     if (success) {
       [[NYPLBookRegistry sharedRegistry] save];
     }
-    [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
   }];
   
   [[NSNotificationCenter defaultCenter]

--- a/Simplified/NYPLHoldsViewController.m
+++ b/Simplified/NYPLHoldsViewController.m
@@ -116,6 +116,9 @@
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
+
+  [[NYPLBookRegistry sharedRegistry] syncOnceIfNeeded];
+
   if([NYPLBookRegistry sharedRegistry].syncing == NO) {
     [self.refreshControl endRefreshing];
     if (self.collectionView.numberOfSections == 0) {

--- a/Simplified/NYPLMyBooksViewController.m
+++ b/Simplified/NYPLMyBooksViewController.m
@@ -164,6 +164,9 @@ typedef NS_ENUM(NSInteger, FacetSort) {
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
+
+  [[NYPLBookRegistry sharedRegistry] syncOnceIfNeeded];
+
   if([NYPLBookRegistry sharedRegistry].syncing == NO) {
     [self.refreshControl endRefreshing];
     [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -625,7 +625,6 @@ double const requestTimeoutInterval = 25.0;
           if (success) {
             [[NYPLBookRegistry sharedRegistry] save];
           }
-          [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
         }];
       }
     } else {

--- a/Simplified/NYPLUserNotifications.swift
+++ b/Simplified/NYPLUserNotifications.swift
@@ -68,9 +68,9 @@ let DefaultActionIdentifier = "UNNotificationDefaultActionIdentifier"
                                                                unlimited: nil,
                                                                reserved: nil,
                                                                ready: { _ in readyBooks += 1 })
-      if UIApplication.shared.applicationIconBadgeNumber != readyBooks {
-        UIApplication.shared.applicationIconBadgeNumber = readyBooks
-      }
+    }
+    if UIApplication.shared.applicationIconBadgeNumber != readyBooks {
+      UIApplication.shared.applicationIconBadgeNumber = readyBooks
     }
   }
 

--- a/Simplified/NYPLUserNotifications.swift
+++ b/Simplified/NYPLUserNotifications.swift
@@ -5,8 +5,8 @@ let CheckOutActionIdentifier = "NYPLCheckOutNotificationAction"
 let DefaultActionIdentifier = "UNNotificationDefaultActionIdentifier"
 
 @available (iOS 10.0, *)
-@objcMembers class NYPLUserNotifications: NSObject {
-
+@objcMembers class NYPLUserNotifications: NSObject
+{
   let unCenter = UNUserNotificationCenter.current()
 
   /// If a user has not yet been presented with Notifications authorization,
@@ -118,8 +118,8 @@ let DefaultActionIdentifier = "UNNotificationDefaultActionIdentifier"
 }
 
 @available (iOS 10.0, *)
-extension NYPLUserNotifications: UNUserNotificationCenterDelegate {
-
+extension NYPLUserNotifications: UNUserNotificationCenterDelegate
+{
   func userNotificationCenter(_ center: UNUserNotificationCenter,
                               willPresent notification: UNNotification,
                               withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void)
@@ -158,7 +158,7 @@ extension NYPLUserNotifications: UNUserNotificationCenterDelegate {
 
       // Asynchronous network task in the background app state.
       let bgTask = UIApplication.shared.beginBackgroundTask {
-        Log.error(#file, "Background task expired before borrow action completed.")
+        Log.error(#file, "Background task expired before borrow action could complete.")
         completionHandler()
       }
       downloadCenter.startBorrow(for: book, attemptDownload: false) {

--- a/Simplified/NYPLUserNotifications.swift
+++ b/Simplified/NYPLUserNotifications.swift
@@ -142,7 +142,8 @@ extension NYPLUserNotifications: UNUserNotificationCenterDelegate {
         }
       }
       completionHandler()
-    } else if response.actionIdentifier == CheckOutActionIdentifier {
+    }
+    else if response.actionIdentifier == CheckOutActionIdentifier {
       Log.debug(#file, "'Check Out' Notification Action.")
       let userInfo = response.notification.request.content.userInfo
       guard let bookID = userInfo["bookID"] as? String else {
@@ -154,9 +155,15 @@ extension NYPLUserNotifications: UNUserNotificationCenterDelegate {
           Log.error(#file, "Problem creating book or download center singleton. BookID: \(bookID)")
           return
       }
-      downloadCenter.startBorrow(for: book, attemptDownload: false) {
-        Log.debug(#file, "Borrow has completed.")
+
+      // Asynchronous network task in the background app state.
+      let bgTask = UIApplication.shared.beginBackgroundTask {
+        Log.error(#file, "Background task expired before borrow action completed.")
         completionHandler()
+      }
+      downloadCenter.startBorrow(for: book, attemptDownload: false) {
+        completionHandler()
+        UIApplication.shared.endBackgroundTask(bgTask)
       }
     }
   }


### PR DESCRIPTION
Cleaned up unnecessary syncs performed from the book registry.
Now only syncs once when the app launches into the foreground/active state.
Utilize background tasks for notifications-related delegates.