### PR TITLE
Report A Problem Layout Supports Dynamic Text #1469

### DIFF
--- a/Simplified/NYPLProblemReportViewController.m
+++ b/Simplified/NYPLProblemReportViewController.m
@@ -14,6 +14,7 @@
 #import "SimplyE-Swift.h"
 
 static NSArray *s_problems = nil;
+static NSInteger EstimatedRowHeight = 44;
 
 @interface NYPLProblemReportViewController () <UITableViewDataSource, UITableViewDelegate>
 @property (nonatomic, strong) IBOutlet UITableView *problemDescriptionTable;
@@ -143,11 +144,6 @@ static NSArray *s_problems = nil;
   return cell;
 }
 
-- (CGFloat)tableView:(__unused UITableView *)tableView heightForRowAtIndexPath:(__unused NSIndexPath *)indexPath
-{
-  return 44;
-}
-
 #pragma mark UITableViewDelegate
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
@@ -170,6 +166,16 @@ static NSArray *s_problems = nil;
 {
   UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
   cell.accessoryType = UITableViewCellAccessoryNone;
+}
+
+- (CGFloat)tableView:(__unused UITableView *)tableView heightForRowAtIndexPath:(__unused NSIndexPath *)indexPath
+{
+  return UITableViewAutomaticDimension;
+}
+
+- (CGFloat)tableView:(__unused UITableView *)tableView estimatedHeightForRowAtIndexPath:(__unused NSIndexPath *)indexPath
+{
+  return EstimatedRowHeight;
 }
 
 @end


### PR DESCRIPTION
This PR address JIRA issue: https://jira.nypl.org/browse/SIMPLY-1469
where the table rows on the Report A Problem screen failed to adjust to larger font sizes or dynamic text.

For example, on the iPhone SE simulator (iOS 12.1), the Report A Problem screen looked like this **before** the fix:
![iphonese12 1_problems](https://user-images.githubusercontent.com/1022275/51698854-924dc000-1fc8-11e9-8c1d-82d367df5c4f.png)


The Report A Problem screen looks like this now (same simulator), **after** the fix:
![iphonese11 3_problemsfixed](https://user-images.githubusercontent.com/1022275/51698913-ba3d2380-1fc8-11e9-92da-edc42a27ca19.png)

This PR has been tested on iOS 12.1 and 11.3
