### PR TITLE
Notifications refinements

### DIFF
--- a/Simplified/NYPLBookRegistry.h
+++ b/Simplified/NYPLBookRegistry.h
@@ -57,11 +57,6 @@ static NSString *const NYPLBookProcessingDidChangeNotification =
 // completion.
 - (void)syncWithStandardAlertsOnCompletion;
 
-// This method should be called when the user expects an up-to-date book registry. For example,
-// when the user first visits My Books or Holds. The method will only run once for each app
-// launch so as to not interfere with a system-initiated background fetch.
-- (void)syncOnceIfNeeded;
-
 // Adds a book to the book registry until it is manually removed. It allows the application to
 // present information about obtained books when offline. Attempting to add a book already present
 // will overwrite the existing book as if |updateBook:| were called. The location may be nil. The

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -21,7 +21,6 @@
 @property (nonatomic) BOOL delaySync;
 @property (nonatomic, copy) void (^delayedSyncBlock)(void);
 @property (nonatomic) NSMutableSet *processingIdentifiers;
-@property (nonatomic) BOOL hasSynced;
 
 @end
 
@@ -60,8 +59,6 @@ static NSString *const RecordsKey = @"records";
   self.identifiersToRecords = [NSMutableDictionary dictionary];
   self.processingIdentifiers = [NSMutableSet set];
   self.shouldBroadcast = YES;
-  self.hasSynced = NO;
-  
   return self;
 }
 
@@ -377,19 +374,6 @@ static NSString *const RecordsKey = @"records";
       [alert presentFromViewControllerOrNil:nil animated:YES completion:nil];
     }
   }];
-}
-
-- (void)syncOnceIfNeeded {
-  @synchronized (self) {
-    if (self.hasSynced == NO) {
-      self.hasSynced = YES;
-      [self syncWithCompletionHandler:^(BOOL success) {
-        if (success) {
-          [self save];
-        }
-      }];
-    }
-  }
 }
 
 - (void)addBook:(NYPLBook *const)book

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -60,7 +60,7 @@ static NSString *const RecordsKey = @"records";
   self.identifiersToRecords = [NSMutableDictionary dictionary];
   self.processingIdentifiers = [NSMutableSet set];
   self.shouldBroadcast = YES;
-  self.hasSynced = YES;
+  self.hasSynced = NO;
   
   return self;
 }

--- a/Simplified/NYPLCatalogFeedViewController.m
+++ b/Simplified/NYPLCatalogFeedViewController.m
@@ -101,8 +101,7 @@
     [self syncBookRegistryForNewFeed];
   } else {
     /// Performs with a delay because on a fresh launch, the application state takes
-    /// a moment to accurately update. Posts the notification to keep the switching
-    /// UI disabled while the sync occurs.
+    /// a moment to accurately update.
     [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncBeganNotification object:nil];
     [self performSelector:@selector(syncBookRegistryForNewFeed) withObject:self afterDelay:2.0];
   }
@@ -118,14 +117,16 @@
   [self.navigationController setNavigationBarHidden:NO];
 }
 
-/// Syncs should not occur when the app is not Active. Background Fetch
-/// operations are handled elsewhere.
+/// Only sync the book registry for a new feed if the app is in the active state.
 - (void)syncBookRegistryForNewFeed {
-  [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL success) {
-    if (success) {
-      [[NYPLBookRegistry sharedRegistry] save];
-    }
-  }];
+  UIApplicationState applicationState = [[UIApplication sharedApplication] applicationState];
+  if (applicationState == UIApplicationStateActive) {
+    [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL success) {
+      if (success) {
+        [[NYPLBookRegistry sharedRegistry] save];
+      }
+    }];
+  }
 }
 
 @end

--- a/Simplified/NYPLCatalogNavigationController.h
+++ b/Simplified/NYPLCatalogNavigationController.h
@@ -11,5 +11,5 @@
 
 // designated initializer
 - (instancetype)init;
-- (void)reloadSelectedLibraryAccount;
+- (void)updateFeedForCurrentAccount;
 @end

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -125,7 +125,7 @@
       } else {
         [[NYPLBookRegistry sharedRegistry] save];
         [AccountsManager shared].currentAccount = account;
-        [self reloadSelectedLibraryAccount];
+        [self updateFeedForCurrentAccount];
       }
     #else
       [[NYPLBookRegistry sharedRegistry] save];
@@ -154,20 +154,13 @@
 }
 
 
-- (void) reloadSelectedLibraryAccount {
+- (void) updateFeedForCurrentAccount {
   
   Account *account = [[AccountsManager sharedInstance] currentAccount];
   
   [[NYPLSettings sharedSettings] setAccountMainFeedURL:[NSURL URLWithString:account.catalogUrl]];
   [UIApplication sharedApplication].delegate.window.tintColor = [NYPLConfiguration mainColor];
 
-  [[NYPLBookRegistry sharedRegistry] justLoad];
-  [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL __unused success) {
-    if (success) {
-      [[NYPLBookRegistry sharedRegistry] save];
-    }
-  }];
-  
   [[NSNotificationCenter defaultCenter]
    postNotificationName:NYPLCurrentAccountDidChangeNotification
    object:nil];
@@ -181,8 +174,6 @@
     Account *account = [[AccountsManager sharedInstance] currentAccount];
     [[NYPLSettings sharedSettings] setAccountMainFeedURL:[NSURL URLWithString:account.catalogUrl]];
     [UIApplication sharedApplication].delegate.window.tintColor = [NYPLConfiguration mainColor];
-
-    [[NYPLBookRegistry sharedRegistry] justLoad];
 
     [[NSNotificationCenter defaultCenter]
      postNotificationName:NYPLCurrentAccountDidChangeNotification
@@ -208,13 +199,13 @@
       [[NYPLSettings sharedSettings] setUserHasSeenWelcomeScreen:YES];
     }
     
-    [self reloadSelectedLibraryAccount];
+    [self updateFeedForCurrentAccount];
     
     if (settings.acceptedEULABeforeMultiLibrary == NO) {
       NYPLWelcomeScreenViewController *welcomeScreenVC = [[NYPLWelcomeScreenViewController alloc] initWithCompletion:^(Account *const account) {
         [[NYPLBookRegistry sharedRegistry] save];
         [AccountsManager shared].currentAccount = account;
-        [self reloadSelectedLibraryAccount];
+        [self updateFeedForCurrentAccount];
         [[NYPLSettings sharedSettings] setUserHasSeenWelcomeScreen:YES];
         [self dismissViewControllerAnimated:YES completion:nil];
       }];

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -115,8 +115,15 @@
     }
 
     [alert addAction:[UIAlertAction actionWithTitle:account.name style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
+
+      BOOL workflowsInProgress;
     #if defined(FEATURE_DRM_CONNECTOR)
-      if([NYPLADEPT sharedInstance].workflowsInProgress) {
+      workflowsInProgress = ([NYPLADEPT sharedInstance].workflowsInProgress || [NYPLBookRegistry sharedRegistry].syncing == YES);
+    #else
+      workflowsInProgress = ([NYPLBookRegistry sharedRegistry].syncing == YES);
+    #endif
+
+      if(workflowsInProgress) {
         [self presentViewController:[NYPLAlertController
                                      alertWithTitle:@"PleaseWait"
                                      message:@"PleaseWaitMessage"]
@@ -127,11 +134,6 @@
         [AccountsManager shared].currentAccount = account;
         [self updateFeedForCurrentAccount];
       }
-    #else
-      [[NYPLBookRegistry sharedRegistry] save];
-      [AccountsManager shared].currentAccount = account;
-      [self reloadSelectedLibraryAccount];
-    #endif
     }]];
   }
   

--- a/Simplified/NYPLHoldsNavigationController.m
+++ b/Simplified/NYPLHoldsNavigationController.m
@@ -121,7 +121,7 @@
 
 - (void) reloadSelected {
   NYPLCatalogNavigationController * catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
-  [catalog reloadSelectedLibraryAccount];
+  [catalog updateFeedForCurrentAccount];
   
   NYPLHoldsViewController *viewController = (NYPLHoldsViewController *)self.visibleViewController;
   viewController.navigationItem.title = [AccountsManager shared].currentAccount.name;

--- a/Simplified/NYPLHoldsNavigationController.m
+++ b/Simplified/NYPLHoldsNavigationController.m
@@ -84,8 +84,15 @@
     }
     
     [alert addAction:[UIAlertAction actionWithTitle:account.name style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
+
+      BOOL workflowsInProgress;
     #if defined(FEATURE_DRM_CONNECTOR)
-      if([NYPLADEPT sharedInstance].workflowsInProgress) {
+      workflowsInProgress = ([NYPLADEPT sharedInstance].workflowsInProgress || [NYPLBookRegistry sharedRegistry].syncing == YES);
+    #else
+      workflowsInProgress = ([NYPLBookRegistry sharedRegistry].syncing == YES);
+    #endif
+
+      if(workflowsInProgress) {
         [self presentViewController:[NYPLAlertController
                                      alertWithTitle:@"PleaseWait"
                                      message:@"PleaseWaitMessage"]
@@ -96,11 +103,6 @@
         [AccountsManager shared].currentAccount = account;
         [self reloadSelected];
       }
-    #else
-      [[NYPLBookRegistry sharedRegistry] save];
-      [AccountsManager shared].currentAccount = account;
-      [self reloadSelected];
-    #endif
     }]];
   }
   

--- a/Simplified/NYPLHoldsViewController.m
+++ b/Simplified/NYPLHoldsViewController.m
@@ -121,10 +121,10 @@
     BOOL isSyncing = [NYPLBookRegistry sharedRegistry].syncing;
     if(!isSyncing) {
       [self.refreshControl endRefreshing];
-      [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
       if (self.collectionView.numberOfSections == 0) {
         self.collectionView.contentOffset = CGPointMake(0, -self.collectionView.contentInset.top);
       }
+      [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];\
     } else {
       self.navigationItem.leftBarButtonItem.enabled = NO;
     }

--- a/Simplified/NYPLHoldsViewController.m
+++ b/Simplified/NYPLHoldsViewController.m
@@ -117,15 +117,18 @@
 {
   [super viewWillAppear:animated];
 
-  [[NYPLBookRegistry sharedRegistry] syncOnceIfNeeded];
-
-  if([NYPLBookRegistry sharedRegistry].syncing == NO) {
-    [self.refreshControl endRefreshing];
-    if (self.collectionView.numberOfSections == 0) {
-      self.collectionView.contentOffset = CGPointMake(0, -self.collectionView.contentInset.top);
+  [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+    BOOL isSyncing = [NYPLBookRegistry sharedRegistry].syncing;
+    if(!isSyncing) {
+      [self.refreshControl endRefreshing];
+      [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
+      if (self.collectionView.numberOfSections == 0) {
+        self.collectionView.contentOffset = CGPointMake(0, -self.collectionView.contentInset.top);
+      }
+    } else {
+      self.navigationItem.leftBarButtonItem.enabled = NO;
     }
-    [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
-  }
+  }];
 }
 
 #pragma mark UICollectionViewDelegate

--- a/Simplified/NYPLMyBooksNavigationController.m
+++ b/Simplified/NYPLMyBooksNavigationController.m
@@ -87,8 +87,15 @@
     }
 
     [alert addAction:[UIAlertAction actionWithTitle:account.name style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
+
+      BOOL workflowsInProgress;
     #if defined(FEATURE_DRM_CONNECTOR)
-      if([NYPLADEPT sharedInstance].workflowsInProgress) {
+      workflowsInProgress = ([NYPLADEPT sharedInstance].workflowsInProgress || [NYPLBookRegistry sharedRegistry].syncing == YES);
+    #else
+      workflowsInProgress = ([NYPLBookRegistry sharedRegistry].syncing == YES);
+    #endif
+
+      if(workflowsInProgress) {
         [self presentViewController:[NYPLAlertController
                                      alertWithTitle:@"PleaseWait"
                                      message:@"PleaseWaitMessage"]
@@ -99,11 +106,6 @@
         [AccountsManager shared].currentAccount = account;
         [self reloadSelected];
       }
-    #else
-      [[NYPLBookRegistry sharedRegistry] save];
-      [AccountsManager shared].currentAccount = account;
-      [self reloadSelected];
-    #endif
     }]];
   }
   

--- a/Simplified/NYPLMyBooksNavigationController.m
+++ b/Simplified/NYPLMyBooksNavigationController.m
@@ -125,7 +125,7 @@
 
 - (void) reloadSelected {
   NYPLCatalogNavigationController * catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
-  [catalog reloadSelectedLibraryAccount];
+  [catalog updateFeedForCurrentAccount];
   
   NYPLMyBooksViewController *viewController = (NYPLMyBooksViewController *)self.visibleViewController;
   viewController.navigationItem.title =  [AccountsManager shared].currentAccount.name;

--- a/Simplified/NYPLMyBooksViewController.m
+++ b/Simplified/NYPLMyBooksViewController.m
@@ -165,12 +165,15 @@ typedef NS_ENUM(NSInteger, FacetSort) {
 {
   [super viewWillAppear:animated];
 
-  [[NYPLBookRegistry sharedRegistry] syncOnceIfNeeded];
-
-  if([NYPLBookRegistry sharedRegistry].syncing == NO) {
-    [self.refreshControl endRefreshing];
-    [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
-  }
+  [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+    BOOL isSyncing = [NYPLBookRegistry sharedRegistry].syncing;
+    if(!isSyncing) {
+      [self.refreshControl endRefreshing];
+      [[NSNotificationCenter defaultCenter] postNotificationName:NYPLSyncEndedNotification object:nil];
+    } else {
+      self.navigationItem.leftBarButtonItem.enabled = NO;
+    }
+  }];
   [self.navigationController setNavigationBarHidden:NO];
 }
 

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -323,7 +323,8 @@ double const requestTimeoutInterval = 25.0;
   
 #if defined(FEATURE_DRM_CONNECTOR)
   
-  if([NYPLADEPT sharedInstance].workflowsInProgress) {
+  if([NYPLADEPT sharedInstance].workflowsInProgress ||
+     [NYPLBookRegistry sharedRegistry].syncing == YES) {
     [self presentViewController:[NYPLAlertController
                                  alertWithTitle:@"SettingsAccountViewControllerCannotLogOutTitle"
                                  message:@"SettingsAccountViewControllerCannotLogOutMessage"]
@@ -369,14 +370,22 @@ double const requestTimeoutInterval = 25.0;
   [task resume];
   
 #else
-  
-  [[NYPLMyBooksDownloadCenter sharedDownloadCenter] reset:self.selectedAccountType];
-  [[NYPLBookRegistry sharedRegistry] reset:self.selectedAccountType];
-  [[NYPLAccount sharedAccount:self.selectedAccountType] removeAll];
-  [self setupTableData];
-  [self.tableView reloadData];
-  [self removeActivityTitle];
-  [[UIApplication sharedApplication] endIgnoringInteractionEvents];
+
+  if([NYPLBookRegistry sharedRegistry].syncing == YES) {
+    [self presentViewController:[NYPLAlertController
+                                 alertWithTitle:@"SettingsAccountViewControllerCannotLogOutTitle"
+                                 message:@"SettingsAccountViewControllerCannotLogOutMessage"]
+                       animated:YES
+                     completion:nil];
+  } else {
+    [[NYPLMyBooksDownloadCenter sharedDownloadCenter] reset:self.selectedAccountType];
+    [[NYPLBookRegistry sharedRegistry] reset:self.selectedAccountType];
+    [[NYPLAccount sharedAccount:self.selectedAccountType] removeAll];
+    [self setupTableData];
+    [self.tableView reloadData];
+    [self removeActivityTitle];
+    [[UIApplication sharedApplication] endIgnoringInteractionEvents];
+  }
 
 #endif
   

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -667,7 +667,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
             [[NYPLBookRegistry sharedRegistry] reset:self.selectedAccountType];
             NYPLCatalogNavigationController *catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
             [catalog popToRootViewControllerAnimated:NO];
-            [catalog reloadSelectedLibraryAccount];
+            [catalog updateFeedForCurrentAccount];
           }
         }];
       } else {
@@ -675,7 +675,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
         self.selectedAccount.userAboveAgeLimit = YES;
         NYPLCatalogNavigationController *catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
         [catalog popToRootViewControllerAnimated:NO];
-        [catalog reloadSelectedLibraryAccount];
+        [catalog updateFeedForCurrentAccount];
       }
       break;
     }

--- a/Simplified/NYPLUserNotifications.swift
+++ b/Simplified/NYPLUserNotifications.swift
@@ -11,7 +11,7 @@ let DefaultActionIdentifier = "UNNotificationDefaultActionIdentifier"
 
   /// If a user has not yet been presented with Notifications authorization,
   /// defer the presentation for later to maximize acceptance rate. Otherwise,
-  /// Apple documents authorization to be preformed at app-launch to corretly
+  /// Apple documents authorization to be preformed at app-launch to correctly
   /// enable the delegate.
   func authorizeIfNeeded()
   {


### PR DESCRIPTION
Clarified several sources of bugs:
- The default accessibility level of keychain items prevented credentials from being available for a loans request while in the background
- Sync requests from different view controllers were colliding with the background fetch attempt
- Sync logic is consolidated and made safer when switching library accounts