### PR TITLE
Fix Launch Screen When Status Bar is Displayed #754 

### DIFF
--- a/Simplified/Simplified-Info.plist
+++ b/Simplified/Simplified-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIStatusBarHidden</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
This PR addresses the following issue: https://jira.nypl.org/browse/SIMPLY-754

where the launch screen layout breaks if the patron's device is displaying the status bar.

This is fixed by hiding the status bar when the launch screen appears. 

Then the status bar, if previously hidden, reappears after the launch screen is gone.

This fix does not affect the launch screen display if the status bar is not displayed.

Tested on iOS 9.3, 10.3.1, 11.3, and 12.1