### PR TITLE
When the app enters the background, dismiss a Reader if it's open. Try...

### DIFF
--- a/Simplified/NYPLAppDelegate.m
+++ b/Simplified/NYPLAppDelegate.m
@@ -123,7 +123,6 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))backgroundF
 
   [tbc setSelectedIndex:0];
 
-  // Presentation logic should match 'presentFromViewController:' in NYPLBookDetailViewController
   UINavigationController *navFormSheet = (UINavigationController *) tbc.selectedViewController.presentedViewController;
   if (tbc.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
     [tbc.selectedViewController pushViewController:bookDetailVC animated:YES];
@@ -144,8 +143,17 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))backgroundF
   [[NYPLReaderSettings sharedSettings] save];
 }
 
+- (void)applicationWillEnterForeground:(__unused UIApplication *)application
+{
+  // https://jira.nypl.org/browse/SIMPLY-1298
+  [[NYPLRootTabBarController sharedController] reapplyReaderViewControllerIfNeeded];
+}
+
 - (void)applicationDidEnterBackground:(__unused UIApplication *)application
 {
+  // https://jira.nypl.org/browse/SIMPLY-1298
+  [[NYPLRootTabBarController sharedController] dismissReaderViewControllerIfNeeded];
+
   [self.audiobookLifecycleManager didEnterBackground];
 }
 

--- a/Simplified/NYPLReaderViewController.h
+++ b/Simplified/NYPLReaderViewController.h
@@ -5,6 +5,8 @@
 - (id)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (id)initWithNibName:(NSString *)nibName bundle:(NSBundle *)nibBundle NS_UNAVAILABLE;
 
+@property (nonatomic, readonly) NSString *bookIdentifier;
+
 // designated initializer
 // |bookIdentifier| must not be nil. The book associated with the identifier given will be marked
 // as used in the book registry.

--- a/Simplified/NYPLRootTabBarController.h
+++ b/Simplified/NYPLRootTabBarController.h
@@ -7,16 +7,25 @@
 
 + (instancetype)sharedController;
 
-// This method will present a view controller from the receiver, or from the controller currently
-// being presented from the receiver, or from the controller being presented by that one, and so on,
-// such that no duplicate presenting errors occur.
+/// This method will present a view controller from the receiver, or from the
+/// controller currently being presented from the receiver, or from the
+/// controller being presented by that one, and so on, such that no duplicate
+/// presenting errors occur.
 - (void)safelyPresentViewController:(UIViewController *)viewController
                            animated:(BOOL)animated
                          completion:(void (^)(void))completion;
 
-// Pushes a view controller onto the navigation controller currently selected by the underlying tab
-// bar controller.
+/// Pushes a view controller onto the navigation controller currently selected
+/// by the underlying tab bar controller.
 - (void)pushViewController:(UIViewController *const)viewController
                   animated:(BOOL const)animated;
+
+/// Dismisses NYPLReaderViewController if it's on the top of the
+/// UINavigationController stack.
+- (void)dismissReaderViewControllerIfNeeded;
+
+/// Adds NYPLReaderViewController back to the stack if it was dismissed with
+/// `dismissReaderViewControllerIfNeeded`
+- (void)reapplyReaderViewControllerIfNeeded;
 
 @end


### PR DESCRIPTION
...and reapply it when the user returns to the foreground. This should only
apply when the app is suspended, not terminated. Attempt to work around
known issue of Readium locking up the UI when in a suspended state.