### PR TITLE
Display Helpful Error Msg When Borrowing Already Checked Out Book #1613

### DIFF
--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -609,7 +609,7 @@ didDismissWithButtonIndex:(NSInteger const)buttonIndex
         // create an alert to display for error, feed, or feed count conditions
         NYPLAlertController *alert = [NYPLAlertController alertWithTitle:@"BorrowFailed" message:@"BorrowCouldNotBeCompletedFormat", book.title];
 
-        // display different message for special type of error or just add document message for generic error
+        // set different message for special type of error or just add document message for generic error
         if (error) {
           if([error[@"type"] isEqualToString:NYPLProblemDocumentTypeLoanAlreadyExists]) {
             alert = [NYPLAlertController alertWithTitle:@"BorrowFailed"
@@ -621,6 +621,7 @@ didDismissWithButtonIndex:(NSInteger const)buttonIndex
           }
         }
 
+        // display the alert
         [alert presentFromViewControllerOrNil:nil animated:YES completion:nil];
       }];
       return;

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -605,9 +605,20 @@ didDismissWithButtonIndex:(NSInteger const)buttonIndex
           borrowCompletion();
           return;
         }
-        NYPLAlertController *const alert = [NYPLAlertController alertWithTitle:@"BorrowFailed" message:@"BorrowCouldNotBeCompletedFormat", book.title];
-        if (error) [alert setProblemDocument:[NYPLProblemDocument problemDocumentWithDictionary:error] displayDocumentMessage:YES];
-        [alert presentFromViewControllerOrNil:nil animated:YES completion:nil];
+
+        if (error) {
+          NSString *message = @"BorrowCouldNotBeCompletedFormat";
+          BOOL displayDocumentMessage = YES;
+          if([error[@"type"] isEqualToString:NYPLProblemDocumentTypeLoanAlreadyExists]) {
+            message = NSLocalizedString(@"You have already checked out this loan. You may need to refresh your My Books list to download the title.",
+                                        comment: @"When book is already checked out on patron's other device(s), they will get this message");
+            displayDocumentMessage = NO;
+          }
+          NYPLAlertController *const alert = [NYPLAlertController alertWithTitle:@"BorrowFailed" message:message, book.title];
+          [alert setProblemDocument:[NYPLProblemDocument problemDocumentWithDictionary:error] displayDocumentMessage:displayDocumentMessage];
+          [alert presentFromViewControllerOrNil:nil animated:YES completion:nil];
+        }
+
       }];
       return;
     }

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -606,19 +606,22 @@ didDismissWithButtonIndex:(NSInteger const)buttonIndex
           return;
         }
 
+        // create an alert to display for error, feed, or feed count conditions
+        NYPLAlertController *alert = [NYPLAlertController alertWithTitle:@"BorrowFailed" message:@"BorrowCouldNotBeCompletedFormat", book.title];
+
+        // display different message for special type of error or just add document message for generic error
         if (error) {
-          NSString *message = @"BorrowCouldNotBeCompletedFormat";
-          BOOL displayDocumentMessage = YES;
           if([error[@"type"] isEqualToString:NYPLProblemDocumentTypeLoanAlreadyExists]) {
-            message = NSLocalizedString(@"You have already checked out this loan. You may need to refresh your My Books list to download the title.",
-                                        comment: @"When book is already checked out on patron's other device(s), they will get this message");
-            displayDocumentMessage = NO;
+            alert = [NYPLAlertController alertWithTitle:@"BorrowFailed"
+                                                message:NSLocalizedString(@"You have already checked out this loan. You may need to refresh your My Books list to download the title.",
+                                                  comment: @"When book is already checked out on patron's other device(s), they will get this message"),
+                                                book.title];
+          } else {
+            [alert setProblemDocument:[NYPLProblemDocument problemDocumentWithDictionary:error] displayDocumentMessage:YES];
           }
-          NYPLAlertController *const alert = [NYPLAlertController alertWithTitle:@"BorrowFailed" message:message, book.title];
-          [alert setProblemDocument:[NYPLProblemDocument problemDocumentWithDictionary:error] displayDocumentMessage:displayDocumentMessage];
-          [alert presentFromViewControllerOrNil:nil animated:YES completion:nil];
         }
 
+        [alert presentFromViewControllerOrNil:nil animated:YES completion:nil];
       }];
       return;
     }

--- a/Simplified/NYPLProblemDocument.h
+++ b/Simplified/NYPLProblemDocument.h
@@ -2,6 +2,8 @@
 
 static NSString *const NYPLProblemDocumentTypeNoActiveLoan =
   @"http://librarysimplified.org/terms/problem/no-active-loan";
+static NSString *const NYPLProblemDocumentTypeLoanAlreadyExists =
+  @"http://librarysimplified.org/terms/problem/loan-already-exists";
 
 @interface NYPLProblemDocument : NSObject
 


### PR DESCRIPTION
This PR addresses the issue raised in JIRA #1613: 
https://jira.nypl.org/browse/SIMPLY-1613

where, when a patron tries to check out a book from multiple devices, they will receive an unhelpful error message on the 2nd device.

I try to address this problem by displaying a more useful error message to the patron.

Screenshots for before and after the fix, are in the JIRA issue.