### PR TITLE
Email/Keyboard Support Per Library

### DIFF
--- a/Simplified/Accounts.swift
+++ b/Simplified/Accounts.swift
@@ -82,8 +82,8 @@ let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
   let subtitle:String?
   let needsAuth:Bool
   let authPasscodeLength:UInt
-  let patronIDKeyboard:PatronIDKeyboard
-  let pinKeyboard:PINKeyboard
+  let patronIDKeyboard:LoginKeyboard
+  let pinKeyboard:LoginKeyboard
   let supportsSimplyESync:Bool
   let supportsBarcodeScanner:Bool
   let supportsBarcodeDisplay:Bool
@@ -147,8 +147,8 @@ let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
     cardCreatorUrl = json["cardCreatorUrl"] as? String
     supportEmail = json["supportEmail"] as? String
     mainColor = json["mainColor"] as? String
-    patronIDKeyboard = PatronIDKeyboard(json["loginKeyboard"] as? String) ?? .standard
-    pinKeyboard = PINKeyboard(json["pinKeyboard"] as? String) ?? .standard
+    patronIDKeyboard = LoginKeyboard(json["loginKeyboard"] as? String) ?? .standard
+    pinKeyboard = LoginKeyboard(json["pinKeyboard"] as? String) ?? .standard
     inProduction = json["inProduction"] as! Bool
 
     let logoString = json["logo"] as? String
@@ -256,26 +256,7 @@ let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
   case annotations
 }
 
-@objc enum PatronIDKeyboard: Int {
-  case standard
-  case email
-  case numeric
-
-  init?(_ stringValue: String?) {
-    if stringValue == "Default" {
-      self = .standard
-    } else if stringValue == "Email address" {
-      self = .email
-    } else if stringValue == "Number pad" {
-      self = .numeric
-    } else {
-      Log.error(#file, "Invalid init parameter for PatronIDKeyboard: \(stringValue ?? "nil")")
-      return nil
-    }
-  }
-}
-
-@objc enum PINKeyboard: Int {
+@objc enum LoginKeyboard: Int {
   case standard
   case email
   case numeric

--- a/Simplified/Accounts.swift
+++ b/Simplified/Accounts.swift
@@ -81,9 +81,9 @@ let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
   let name:String
   let subtitle:String?
   let needsAuth:Bool
-  let pinRequired:Bool
   let authPasscodeLength:UInt
-  let authPasscodeAllowsLetters:Bool
+  let patronIDKeyboard:PatronIDKeyboard
+  let pinKeyboard:PINKeyboard
   let supportsSimplyESync:Bool
   let supportsBarcodeScanner:Bool
   let supportsBarcodeDisplay:Bool
@@ -147,7 +147,8 @@ let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
     cardCreatorUrl = json["cardCreatorUrl"] as? String
     supportEmail = json["supportEmail"] as? String
     mainColor = json["mainColor"] as? String
-    pinRequired = json["pinRequired"] as? Bool ?? true
+    patronIDKeyboard = PatronIDKeyboard(json["loginKeyboard"] as? String) ?? .standard
+    pinKeyboard = PINKeyboard(json["pinKeyboard"] as? String) ?? .standard
     inProduction = json["inProduction"] as! Bool
 
     let logoString = json["logo"] as? String
@@ -163,11 +164,6 @@ let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
       authPasscodeLength = length
     } else {
       authPasscodeLength = 0
-    }
-    if let allows = json["authPasscodeAllowsLetters"] as? Bool {
-      authPasscodeAllowsLetters = allows
-    } else {
-      authPasscodeAllowsLetters = true
     }
   }
 
@@ -258,4 +254,45 @@ let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
   case eula
   case privacyPolicy
   case annotations
+}
+
+@objc enum PatronIDKeyboard: Int {
+  case standard
+  case email
+  case numeric
+
+  init?(_ stringValue: String?) {
+    if stringValue == "Default" {
+      self = .standard
+    } else if stringValue == "Email address" {
+      self = .email
+    } else if stringValue == "Number pad" {
+      self = .numeric
+    } else {
+      Log.error(#file, "Invalid init parameter for PatronIDKeyboard: \(stringValue ?? "nil")")
+      return nil
+    }
+  }
+}
+
+@objc enum PINKeyboard: Int {
+  case standard
+  case email
+  case numeric
+  case none
+
+  init?(_ stringValue: String?) {
+    if stringValue == "Default" {
+      self = .standard
+    } else if stringValue == "Email address" {
+      self = .email
+    } else if stringValue == "Number pad" {
+      self = .numeric
+    } else if stringValue == "No input" {
+      self = .none
+    } else {
+      Log.error(#file, "Invalid init parameter for PatronPINKeyboard: \(stringValue ?? "nil")")
+      return nil
+    }
+  }
 }

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -134,15 +134,16 @@ CGFloat const marginPadding = 2.0;
   self.usernameTextField.placeholder = NSLocalizedString(@"BarcodeOrUsername", nil);
 
   switch (self.currentAccount.patronIDKeyboard) {
-    case PatronIDKeyboardStandard:
-    self.usernameTextField.keyboardType = UIKeyboardTypeASCIICapable;
-    break;
-    case PatronIDKeyboardEmail:
-    self.usernameTextField.keyboardType = UIKeyboardTypeEmailAddress;
-    break;
-    case PatronIDKeyboardNumeric:
-    self.usernameTextField.keyboardType = UIKeyboardTypeNumberPad;
-    break;
+    case LoginKeyboardStandard:
+    case LoginKeyboardNone:
+      self.usernameTextField.keyboardType = UIKeyboardTypeASCIICapable;
+      break;
+    case LoginKeyboardEmail:
+      self.usernameTextField.keyboardType = UIKeyboardTypeEmailAddress;
+      break;
+    case LoginKeyboardNumeric:
+      self.usernameTextField.keyboardType = UIKeyboardTypeNumberPad;
+      break;
   }
 
   self.usernameTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
@@ -156,16 +157,16 @@ CGFloat const marginPadding = 2.0;
   self.PINTextField.placeholder = NSLocalizedString(@"PIN", nil);
 
   switch (self.currentAccount.pinKeyboard) {
-    case PINKeyboardEmail:
-    self.PINTextField.keyboardType = UIKeyboardTypeEmailAddress;
-    break;
-    case PINKeyboardNumeric:
-    self.PINTextField.keyboardType = UIKeyboardTypeNumberPad;
-    break;
-    case PINKeyboardStandard:
-    case PINKeyboardNone:
-    self.PINTextField.keyboardType = UIKeyboardTypeASCIICapable;
-    break;
+    case LoginKeyboardStandard:
+    case LoginKeyboardNone:
+      self.PINTextField.keyboardType = UIKeyboardTypeASCIICapable;
+      break;
+    case LoginKeyboardEmail:
+      self.PINTextField.keyboardType = UIKeyboardTypeEmailAddress;
+      break;
+    case LoginKeyboardNumeric:
+      self.PINTextField.keyboardType = UIKeyboardTypeNumberPad;
+      break;
   }
 
   self.PINTextField.secureTextEntry = YES;
@@ -198,7 +199,7 @@ CGFloat const marginPadding = 2.0;
 - (void)setupTableData
 {
   NSArray *section0;
-  if (self.currentAccount.pinKeyboard != PINKeyboardNone) {
+  if (self.currentAccount.pinKeyboard != LoginKeyboardNone) {
     section0 = @[@(CellKindBarcode),
                  @(CellKindPIN),
                  @(CellKindLogInSignOut)];
@@ -519,7 +520,7 @@ replacementString:(NSString *)string
   }
   
   if(textField == self.usernameTextField &&
-     self.currentAccount.patronIDKeyboard != PatronIDKeyboardEmail) {
+     self.currentAccount.patronIDKeyboard != LoginKeyboardEmail) {
     // Barcodes are numeric and usernames are alphanumeric.
     if([string stringByTrimmingCharactersInSet:[NSCharacterSet alphanumericCharacterSet]].length > 0) {
       return NO;
@@ -534,7 +535,7 @@ replacementString:(NSString *)string
   if(textField == self.PINTextField) {
     
     NSCharacterSet *charSet = [NSCharacterSet decimalDigitCharacterSet];
-    bool alphanumericPin = self.currentAccount.pinKeyboard != PINKeyboardNumeric;
+    bool alphanumericPin = self.currentAccount.pinKeyboard != LoginKeyboardNumeric;
     bool containsNonNumericChar = [string stringByTrimmingCharactersInSet:charSet].length > 0;
     bool abovePinCharLimit = [textField.text stringByReplacingCharactersInRange:range withString:string].length > self.currentAccount.authPasscodeLength;
     
@@ -773,7 +774,7 @@ completionHandler:(void (^)(void))handler
                                  stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length;
     BOOL const pinHasText = [self.PINTextField.text
                              stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length;
-    BOOL const pinIsNotRequired = self.currentAccount.pinKeyboard == PINKeyboardNone;
+    BOOL const pinIsNotRequired = self.currentAccount.pinKeyboard == LoginKeyboardNone;
     if((barcodeHasText && pinHasText) || (barcodeHasText && pinIsNotRequired)) {
       self.logInSignOutCell.userInteractionEnabled = YES;
       self.logInSignOutCell.textLabel.textColor = [NYPLConfiguration mainColor];

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -200,37 +200,27 @@
   NYPLSettings *settings = [NYPLSettings sharedSettings];
   
   if (settings.userHasSeenWelcomeScreen == NO) {
-    
-    if (settings.acceptedEULABeforeMultiLibrary == YES) {
-      Account *nyplAccount = [[AccountsManager sharedInstance] account:0];
-      nyplAccount.eulaIsAccepted = YES;
-      [[NYPLSettings sharedSettings] setUserHasSeenWelcomeScreen:YES];
-    }
-    
     Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
     [[NYPLSettings sharedSettings] setAccountMainFeedURL:[NSURL URLWithString:currentAccount.catalogUrl]];
     [UIApplication sharedApplication].delegate.window.tintColor = [NYPLConfiguration mainColor];
     
-    if (settings.acceptedEULABeforeMultiLibrary == NO) {
-      NYPLWelcomeScreenViewController *welcomeScreenVC = [[NYPLWelcomeScreenViewController alloc] initWithCompletion:^(Account *const account) {
-        [[NYPLSettings sharedSettings] setUserHasSeenWelcomeScreen:YES];
-        [[NYPLBookRegistry sharedRegistry] save];
-        [AccountsManager shared].currentAccount = account;
-        [[NYPLSettings sharedSettings] setAccountMainFeedURL:[NSURL URLWithString:account.catalogUrl]];
-        [UIApplication sharedApplication].delegate.window.tintColor = [NYPLConfiguration mainColor];
-        [self dismissViewControllerAnimated:YES completion:nil];
-      }];
-      
-      UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:welcomeScreenVC];
-      
-      if([[NYPLRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
-        [navController setModalPresentationStyle:UIModalPresentationFormSheet];
-      }
-      [navController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
-      
-      NYPLRootTabBarController *vc = [NYPLRootTabBarController sharedController];
-      [vc safelyPresentViewController:navController animated:YES completion:nil];
+    NYPLWelcomeScreenViewController *welcomeScreenVC = [[NYPLWelcomeScreenViewController alloc] initWithCompletion:^(Account *const account) {
+      [[NYPLSettings sharedSettings] setUserHasSeenWelcomeScreen:YES];
+      [[NYPLBookRegistry sharedRegistry] save];
+      [AccountsManager sharedInstance].currentAccount = account;
+      [self updateFeedAndRegistryOnAccountChange];
+      [self dismissViewControllerAnimated:YES completion:nil];
+    }];
+
+    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:welcomeScreenVC];
+
+    if([[NYPLRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
+      [navController setModalPresentationStyle:UIModalPresentationFormSheet];
     }
+    [navController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
+
+    NYPLRootTabBarController *vc = [NYPLRootTabBarController sharedController];
+    [vc safelyPresentViewController:navController animated:YES completion:nil];
   }
 }
 

--- a/Simplified/NYPLReaderReadiumView.m
+++ b/Simplified/NYPLReaderReadiumView.m
@@ -736,7 +736,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 
   if (self.updateSettingsInProgress) {
     // Readium cannot maintain a CFI with rapid changes to Reader Settings.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
       self.updateSettingsInProgress = NO;
     });
   }

--- a/Simplified/NYPLSettings.h
+++ b/Simplified/NYPLSettings.h
@@ -21,7 +21,6 @@ static NSString *const NYPLUserAgreementURLString = @"http://www.librarysimplifi
 // Set to nil (the default) if no custom feed should be used.
 @property (atomic) NSURL *customMainFeedURL;
 @property (atomic) NSURL *accountMainFeedURL;
-@property (atomic) BOOL acceptedEULABeforeMultiLibrary;
 @property (atomic) BOOL userHasSeenWelcomeScreen;
 @property (atomic) BOOL userPresentedAgeCheck;
 @property (atomic) BOOL userHasSeenFirstTimeSyncMessage;

--- a/Simplified/NYPLSettings.m
+++ b/Simplified/NYPLSettings.m
@@ -78,11 +78,6 @@ static NSString *StringFromRenderingEngine(NYPLSettingsRenderingEngine const ren
   return [[NSUserDefaults standardUserDefaults] URLForKey:accountMainFeedURLKey];
 }
 
-- (BOOL)acceptedEULABeforeMultiLibrary
-{
-  return [[NSUserDefaults standardUserDefaults] boolForKey:legacyUserAcceptedEULAKey];
-}
-
 - (BOOL) userHasSeenWelcomeScreen
 {
   return [[NSUserDefaults standardUserDefaults] boolForKey:userHasSeenWelcomeScreenKey];
@@ -203,12 +198,6 @@ static NSString *StringFromRenderingEngine(NYPLSettingsRenderingEngine const ren
   [[NSNotificationCenter defaultCenter]
    postNotificationName:NYPLSettingsDidChangeNotification
    object:self];
-}
-
-- (void)setAcceptedEULABeforeMultiLibrary:(BOOL)acceptedEULA
-{
-  [[NSUserDefaults standardUserDefaults] setBool:acceptedEULA forKey:legacyUserAcceptedEULAKey];
-  [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 @end

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -161,15 +161,16 @@ double const requestTimeoutInterval = 25.0;
   self.usernameTextField.placeholder = NSLocalizedString(@"BarcodeOrUsername", nil);
 
   switch (self.selectedAccount.patronIDKeyboard) {
-    case PatronIDKeyboardStandard:
-    self.usernameTextField.keyboardType = UIKeyboardTypeASCIICapable;
-    break;
-    case PatronIDKeyboardEmail:
-    self.usernameTextField.keyboardType = UIKeyboardTypeEmailAddress;
-    break;
-    case PatronIDKeyboardNumeric:
-    self.usernameTextField.keyboardType = UIKeyboardTypeNumberPad;
-    break;
+    case LoginKeyboardStandard:
+    case LoginKeyboardNone:
+      self.usernameTextField.keyboardType = UIKeyboardTypeASCIICapable;
+      break;
+    case LoginKeyboardEmail:
+      self.usernameTextField.keyboardType = UIKeyboardTypeEmailAddress;
+      break;
+    case LoginKeyboardNumeric:
+      self.usernameTextField.keyboardType = UIKeyboardTypeNumberPad;
+      break;
   }
 
   self.usernameTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
@@ -188,16 +189,16 @@ double const requestTimeoutInterval = 25.0;
   self.PINTextField.placeholder = NSLocalizedString(@"PIN", nil);
 
   switch (self.selectedAccount.pinKeyboard) {
-    case PINKeyboardEmail:
-    self.PINTextField.keyboardType = UIKeyboardTypeEmailAddress;
-    break;
-    case PINKeyboardNumeric:
-    self.PINTextField.keyboardType = UIKeyboardTypeNumberPad;
-    break;
-    case PINKeyboardStandard:
-    case PINKeyboardNone:
-    self.PINTextField.keyboardType = UIKeyboardTypeASCIICapable;
-    break;
+    case LoginKeyboardStandard:
+    case LoginKeyboardNone:
+      self.PINTextField.keyboardType = UIKeyboardTypeASCIICapable;
+      break;
+    case LoginKeyboardEmail:
+      self.PINTextField.keyboardType = UIKeyboardTypeEmailAddress;
+      break;
+    case LoginKeyboardNumeric:
+      self.PINTextField.keyboardType = UIKeyboardTypeNumberPad;
+      break;
   }
 
   self.PINTextField.secureTextEntry = YES;
@@ -226,7 +227,7 @@ double const requestTimeoutInterval = 25.0;
   NSMutableArray *section0;
   if (!self.selectedAccount.needsAuth) {
     section0 = @[@(CellKindAgeCheck)].mutableCopy;
-  } else if (self.selectedAccount.pinKeyboard != PINKeyboardNone) {
+  } else if (self.selectedAccount.pinKeyboard != LoginKeyboardNone) {
     section0 = @[@(CellKindBarcode),
                  @(CellKindPIN),
                  @(CellKindLogInSignOut)].mutableCopy;
@@ -1232,7 +1233,7 @@ replacementString:(NSString *)string
   }
 
   if(textField == self.usernameTextField &&
-     self.selectedAccount.patronIDKeyboard != PatronIDKeyboardEmail) {
+     self.selectedAccount.patronIDKeyboard != LoginKeyboardEmail) {
     // Barcodes are numeric and usernames are alphanumeric.
     if([string stringByTrimmingCharactersInSet:[NSCharacterSet alphanumericCharacterSet]].length > 0) {
       return NO;
@@ -1247,7 +1248,7 @@ replacementString:(NSString *)string
   if(textField == self.PINTextField) {
     
     NSCharacterSet *charSet = [NSCharacterSet decimalDigitCharacterSet];
-    bool alphanumericPin = self.selectedAccount.pinKeyboard != PINKeyboardNumeric;
+    bool alphanumericPin = self.selectedAccount.pinKeyboard != LoginKeyboardNumeric;
     bool containsNonNumericChar = [string stringByTrimmingCharactersInSet:charSet].length > 0;
     bool abovePinCharLimit = [textField.text stringByReplacingCharactersInRange:range withString:string].length > self.selectedAccount.authPasscodeLength;
     
@@ -1389,7 +1390,7 @@ replacementString:(NSString *)string
                                  stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length;
     BOOL const pinHasText = [self.PINTextField.text
                              stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length;
-    BOOL const pinIsNotRequired = self.selectedAccount.pinKeyboard == PINKeyboardNone;
+    BOOL const pinIsNotRequired = self.selectedAccount.pinKeyboard == LoginKeyboardNone;
     if((barcodeHasText && pinHasText) || (barcodeHasText && pinIsNotRequired)) {
       self.logInSignOutCell.userInteractionEnabled = YES;
       self.logInSignOutCell.textLabel.textColor = [NYPLConfiguration mainColor];

--- a/Simplified/NYPLWelcomeScreen.swift
+++ b/Simplified/NYPLWelcomeScreen.swift
@@ -149,38 +149,20 @@ import PureLayout
       self.dismiss(animated: true, completion: nil)
       return
     }
-    // Existing User
-    if NYPLSettings.shared().acceptedEULABeforeMultiLibrary == false {
-      let listVC = NYPLWelcomeScreenAccountList { acct in
-        if (acct.id != 2) {
-          NYPLSettings.shared().settingsAccountsList = [acct.id, 2]
-        } else {
-          NYPLSettings.shared().settingsAccountsList = [2]
-        }
-        self.completion?(acct)
+    let listVC = NYPLWelcomeScreenAccountList { account in
+      if (account.id != 2) {
+        NYPLSettings.shared().settingsAccountsList = [account.id, 2]
+      } else {
+        NYPLSettings.shared().settingsAccountsList = [2]
       }
-      self.navigationController?.pushViewController(listVC, animated: true)
-    } else {
-      let listVC = NYPLWelcomeScreenAccountList { acct in
-        if (acct.id != 0 && acct.id != 2) {
-          NYPLSettings.shared().settingsAccountsList = [acct.id, 0, 2]
-        } else {
-          NYPLSettings.shared().settingsAccountsList = [0, 2]
-        }
-        self.completion?(acct)
-      }
-      self.navigationController?.pushViewController(listVC, animated: true)
+      self.completion?(account)
     }
+    self.navigationController?.pushViewController(listVC, animated: true)
   }
 
   func instantClassicsTapped() {
-    if NYPLSettings.shared().acceptedEULABeforeMultiLibrary == true {
-      NYPLSettings.shared().settingsAccountsList = [0,2]
-    }
-    else {
-      NYPLSettings.shared().settingsAccountsList = [2]
-    }
-    completion?(AccountsManager.shared.account(2)!)
+    NYPLSettings.shared().settingsAccountsList = [2]
+    self.completion?(AccountsManager.shared.account(2)!)
   }
 }
 


### PR DESCRIPTION
Removing deprecated SimplyE keys being used prior to 2.0(multi-library).
Support for email sign in + any type of keyboard specified by the registry for username and pin fields.
NOTE: Pin == NONE also implies "no pin required". No such implication exists for the username/patron ID field.

Also address issue that caused a new library selection, from a fresh install, to potentially not fully load in until the next app-open.