### PR TITLE
Fixed logic in WebViewDelegate to show html content

### DIFF
--- a/Simplified/BundledHTMLViewController.swift
+++ b/Simplified/BundledHTMLViewController.swift
@@ -51,13 +51,21 @@ import WebKit
                  decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void)
     {
-      if navigationAction.navigationType == .linkActivated {
-        if let url = navigationAction.request.url {
-          UIApplication.shared.openURL(url)
-          decisionHandler(.allow)
+      if navigationAction.navigationType == .linkActivated,
+        let url = navigationAction.request.url {
+        if !UIApplication.shared.canOpenURL(url) {
+          decisionHandler(.cancel)
+        } else {
+          if #available(iOS 10.0, *) {
+            UIApplication.shared.open(url)
+          } else {
+            UIApplication.shared.openURL(url)
+          }
+          decisionHandler(.cancel)
         }
+      } else {
+        decisionHandler(.allow)
       }
-      decisionHandler(.cancel)
     }
   }
 }


### PR DESCRIPTION
This fixes a bug where HTML content wasn't shown properly because of the incorrect filtering of links in the NavigationDelegate for the view.  Links in the content will still open in the devices web browser and not in the application.  This replicates the logic that is used in RemoteHTMLViewController.swift.  In other words, the Software Licenses page will show properly.

Alternatives are to render software-licenses.html from an online source and not bundle it with the app.