### PR TITLE
Don't show DRM PDFs

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1798,7 +1798,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1848,8 +1847,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1264,6 +1264,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				it,
 				de,
@@ -1847,7 +1848,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution: The New York Library Astor, Lenox, and Tilden Foundations (7262U6ST2R)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
@@ -1876,7 +1877,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
-				PROVISIONING_PROFILE_SPECIFIER = "SimplyE Distribution (2018)";
+				PROVISIONING_PROFILE_SPECIFIER = "SimplyE Distribution 2019";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplified/SimplyE-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;

--- a/Simplified/NYPLBook.m
+++ b/Simplified/NYPLBook.m
@@ -563,11 +563,11 @@ static NSString *const UpdatedKey = @"updated";
     [finalTypes addObject:path.types.lastObject];
   }
 
+  NYPLBookContentType defaultType = NYPLBookContentTypeUnsupported;
   if (finalTypes.count == 1) {
-    return NYPLBookContentTypeFromMIMEType(finalTypes.firstObject);
+    defaultType = NYPLBookContentTypeFromMIMEType(finalTypes.firstObject);
   } else if (finalTypes.count > 1) {
     // Defualt to epub if it exists, else assign a random supported type if one exists.
-    NYPLBookContentType defaultType = NYPLBookContentTypeUnsupported;
     for (NSString *const type in finalTypes) {
       NYPLBookContentType const contentType = NYPLBookContentTypeFromMIMEType(type);
       if (contentType != NYPLBookContentTypeUnsupported) {
@@ -577,11 +577,9 @@ static NSString *const UpdatedKey = @"updated";
         }
       }
     }
-    return defaultType;
   }
-
-  NYPLLOG(@"Invalid argument: No mime type in acquisition path/s");
-  @throw NSInvalidArgumentException;
+  
+  return defaultType;
 }
 
 @end

--- a/Simplified/NYPLBook.m
+++ b/Simplified/NYPLBook.m
@@ -564,17 +564,13 @@ static NSString *const UpdatedKey = @"updated";
   }
 
   NYPLBookContentType defaultType = NYPLBookContentTypeUnsupported;
-  if (finalTypes.count == 1) {
-    defaultType = NYPLBookContentTypeFromMIMEType(finalTypes.firstObject);
-  } else if (finalTypes.count > 1) {
-    // Defualt to epub if it exists, else assign a random supported type if one exists.
-    for (NSString *const type in finalTypes) {
-      NYPLBookContentType const contentType = NYPLBookContentTypeFromMIMEType(type);
-      if (contentType != NYPLBookContentTypeUnsupported) {
-        defaultType = contentType;
-        if (contentType == NYPLBookContentTypeEPUB) {
-          break;
-        }
+  // Defualt to epub if it exists, else assign a random supported type if one exists.
+  for (NSString *const type in finalTypes) {
+    NYPLBookContentType const contentType = NYPLBookContentTypeFromMIMEType(type);
+    if (contentType != NYPLBookContentTypeUnsupported) {
+      defaultType = contentType;
+      if (contentType == NYPLBookContentTypeEPUB) {
+        break;
       }
     }
   }

--- a/Simplified/NYPLBookAcquisitionPath.h
+++ b/Simplified/NYPLBookAcquisitionPath.h
@@ -37,10 +37,11 @@ static NSString * const _Nonnull ContentTypeOpenAccessPDF = @"application/pdf";
 
 /// O(n).
 /// @param types The types by which to limit the search for supported paths.
+/// Paths will also be limited by supported sub-types.
 /// @param acqusitions The OPDS acquisitions to search.
-/// @return The set of possible acquisition paths supported by the application
-/// limited by the types and relations supplied.
-+ (NSSet<NYPLBookAcquisitionPath *> *_Nonnull)
+/// @return The array of possible acquisition paths supported by the application, limited
+/// by the types and relations supplied, deduplicated, in the order they appear.
++ (NSArray<NYPLBookAcquisitionPath *> *_Nonnull)
 supportedAcquisitionPathsForAllowedTypes:(NSSet<NSString *> *_Nonnull)types
 allowedRelations:(NYPLOPDSAcquisitionRelationSet)relations
 acquisitions:(NSArray<NYPLOPDSAcquisition *> *_Nonnull)acquisitions;

--- a/Simplified/NYPLBookAcquisitionPath.m
+++ b/Simplified/NYPLBookAcquisitionPath.m
@@ -126,12 +126,13 @@ mutableTypePaths(
 }
 
 
-+ (NSSet<NYPLBookAcquisitionPath *> *_Nonnull)
++ (NSArray<NYPLBookAcquisitionPath *> *_Nonnull)
 supportedAcquisitionPathsForAllowedTypes:(NSSet<NSString *> *_Nonnull)types
 allowedRelations:(NYPLOPDSAcquisitionRelationSet)relations
 acquisitions:(NSArray<NYPLOPDSAcquisition *> *_Nonnull)acquisitions
 {
-  NSMutableSet *const mutableAcquisitionPaths = [NSMutableSet set];
+  NSMutableSet *const mutableAcquisitionPathSet = [NSMutableSet set];
+  NSMutableArray *const mutableAcquisitionPaths = [NSMutableArray array];
 
   for (NYPLOPDSAcquisition *const acquisition in acquisitions) {
     if ([types containsObject:acquisition.type]
@@ -157,7 +158,10 @@ acquisitions:(NSArray<NYPLOPDSAcquisition *> *_Nonnull)acquisitions
              initWithRelation:acquisition.relation
              types:[mutableTypePath copy]
              url:acquisition.hrefURL];
-            [mutableAcquisitionPaths addObject:acquisitionPath];
+            if (![mutableAcquisitionPathSet containsObject:acquisitionPath]) {
+              [mutableAcquisitionPaths addObject:acquisitionPath];
+              [mutableAcquisitionPathSet addObject:acquisitionPath];
+            }
           }
         }
       }

--- a/Simplified/NYPLBookCellDelegate.m
+++ b/Simplified/NYPLBookCellDelegate.m
@@ -189,11 +189,11 @@
   __weak AudiobookPlayerViewController *weakAudiobookVC = audiobookVC;
   [manager setPlaybackCompletionHandler:^{
     NSSet<NSString *> *types = [[NSSet alloc] initWithObjects:ContentTypeFindaway, ContentTypeOpenAccessAudiobook, nil];
-    NSSet<NYPLBookAcquisitionPath *> *paths = [NYPLBookAcquisitionPath
-                                               supportedAcquisitionPathsForAllowedTypes:types
-                                               allowedRelations:(NYPLOPDSAcquisitionRelationSetBorrow |
-                                                                 NYPLOPDSAcquisitionRelationSetGeneric)
-                                               acquisitions:book.acquisitions];
+    NSArray<NYPLBookAcquisitionPath *> *paths = [NYPLBookAcquisitionPath
+                                                 supportedAcquisitionPathsForAllowedTypes:types
+                                                 allowedRelations:(NYPLOPDSAcquisitionRelationSetBorrow |
+                                                                   NYPLOPDSAcquisitionRelationSetGeneric)
+                                                 acquisitions:book.acquisitions];
     if (paths.count > 0) {
       UIAlertController *alert = [NYPLReturnPromptHelper audiobookPromptWithCompletion:^(BOOL returnWasChosen) {
         if (returnWasChosen) {

--- a/Simplified/NYPLConfiguration.m
+++ b/Simplified/NYPLConfiguration.m
@@ -51,7 +51,7 @@
 + (BOOL)releaseStageIsBeta
 {
   NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
-  return ([[receiptURL path] rangeOfString:@"sandboxReceipt"].location != NSNotFound);
+  return ([[receiptURL path] rangeOfString:@"sandboxReceipt"].location != NSNotFound) || TARGET_OS_SIMULATOR;
 }
 
 + (NSURL *)mainFeedURL

--- a/SimplifiedTests/NYPLBookAcquisitionPathEntry.xml
+++ b/SimplifiedTests/NYPLBookAcquisitionPathEntry.xml
@@ -30,6 +30,7 @@
     <opds:indirectAcquisition type="application/unsupported">
       <opds:indirectAcquisition type="application/epub+zip"/>
     </opds:indirectAcquisition>
+    <opds:indirectAcquisition type="application/pdf"/>
     <opds:indirectAcquisition type="application/vnd.adobe.adept+xml">
       <opds:indirectAcquisition type="application/pdf"/>
     </opds:indirectAcquisition>

--- a/SimplifiedTests/NYPLBookAcquisitionPathTests.swift
+++ b/SimplifiedTests/NYPLBookAcquisitionPathTests.swift
@@ -13,22 +13,25 @@ class NYPLBookAcquisitionPathTests: XCTestCase {
       .acquisitions;
 
   func testSimplifiedAdeptEpubAcquisition() {
-    let acquisitionPaths: Set<NYPLBookAcquisitionPath> =
+    let acquisitionPaths: Array<NYPLBookAcquisitionPath> =
       NYPLBookAcquisitionPath.supportedAcquisitionPaths(
         forAllowedTypes: NYPLBookAcquisitionPath.supportedTypes(),
         allowedRelations: [.borrow, .openAccess],
         acquisitions: acquisitions)
 
-    XCTAssert(acquisitionPaths.count == 1)
+    XCTAssert(acquisitionPaths.count == 2)
 
-    let acquisitionPath: NYPLBookAcquisitionPath = acquisitionPaths.first!
-
-    XCTAssert(acquisitionPath.relation == NYPLOPDSAcquisitionRelation.borrow)
-
-    XCTAssert(acquisitionPath.types == [
+    XCTAssert(acquisitionPaths[0].relation == NYPLOPDSAcquisitionRelation.borrow)
+    XCTAssert(acquisitionPaths[0].types == [
       "application/atom+xml;type=entry;profile=opds-catalog",
       "application/vnd.adobe.adept+xml",
       "application/epub+zip"
     ])
+    
+    XCTAssert(acquisitionPaths[1].relation == NYPLOPDSAcquisitionRelation.borrow)
+    XCTAssert(acquisitionPaths[1].types == [
+      "application/atom+xml;type=entry;profile=opds-catalog",
+      "application/pdf"
+      ])
   }
 }


### PR DESCRIPTION
Also, don't crash on book with no valid acquisition paths, and show beta button on Simulator.

On removing the log / throw: I think it's the wrong place to log, since semantically it makes sense that we could ask for the default content type of a book that we don't have a valid acquisition path for. It's also inconsistent, since we would just silently return `NYPLBookContentTypeUnsupported` if we had a path but it was of an unsupported type (which should have already been filtered out before that point). I think if we wanted to log (to bugsnag for instance), it should happen somewhere where we actually don't expect to have an unsupported book.