### PR TITLE
Updating build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ ReaderClientCert.sig
 Simplified/APIKeys.swift
 AudioEngine.json
 Carthage
-Accounts.json
 bugsnag-dsym-upload.rb

--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@
 
 In theory, following the instructions in "adobe-rmsdk/RMSDK_User_Manual(obj).pdf", you should be able to build OpenSSL (section 12.1) and cURL (section 12.3) since Adobe provides this package to their developers.
 The following are some smoother steps to achieving this:
-- From `adobe-rmsdk/thirdparty/openssl` run `mkdir public; mv iOS-openssl/ public/ios/`
-- Download openssl 1.0.1 (1.0.1u should suffice) to `adobe-rmsdk/thirdparty/openssl/public/ios/openssl-1.0.1u.tar.gz` (note that the build script is expecting a tarball; as of this writing the download can be found at: https://www.openssl.org/source/old/1.0.1/)
-- Modify the `adobe-rmsdk/thirdparty/openssl/public/ios/build.sh` such that:
+01. From `adobe-rmsdk/thirdparty/openssl` run `mkdir public; mv iOS-openssl/ public/ios/`
+02. Download openssl 1.0.1 (1.0.1u should suffice) to `adobe-rmsdk/thirdparty/openssl/public/ios/openssl-1.0.1u.tar.gz` (note that the build script is expecting a tarball; as of this writing the download can be found at: https://www.openssl.org/source/old/1.0.1/)
+03. Modify the `adobe-rmsdk/thirdparty/openssl/public/ios/build.sh` such that:
     - `OPENSSL_VERSION` reflects the version you downloaded, in this case "1.0.1u"
     - `SDK_VERSION` reflects the iOS SDK you're using (you can check what you have installed using `xcodebuild -showsdks`)
     - `MIN_VERSION` is "9.0"
-- From the directory of the build script (this will take a while): `bash ./build.sh`
-- Download curl (7.64.1 is known to work) to `adobe-rmsdk/thirdparty/curl/ios-libCurl/curl-7.64.1.zip` (note that the build script expects a ZIP, not tarball; as of this writing this download can be found at: https://curl.haxx.se/download/)
-- Replace `adobe-rmsdk/thirdparty/curl/ios/build.sh` with `build_curl.sh`, a fixed version of the build script
-- Modify the build script similary to the openssl one:
+04. From the directory of the build script (this will take a while): `bash ./build.sh`
+05. Download curl (7.64.1 is known to work) to `adobe-rmsdk/thirdparty/curl/ios-libCurl/curl-7.64.1.zip` (note that the build script expects a ZIP, not tarball; as of this writing this download can be found at: https://curl.haxx.se/download/)
+06. Replace `adobe-rmsdk/thirdparty/curl/ios/build.sh` with `build_curl.sh`, a fixed version of the build script
+07. Modify the build script similary to the openssl one:
     - `CURL_VERSION` reflects the version you downloaded, in this case "7.64.1"
     - `SDK_VERSION` reflects the iOS SDK you're using (you can check what you have installed using `xcodebuild -showsdks`)
     - `MIN_VERSION` is "9.0"
-- From the directory of the build script (this will take a while): `bash ./build.sh` (or whatever you named the copied script)
+08. From the directory of the build script (this will take a while): `bash ./build.sh` (or whatever you named the copied script)
 
 Be sure to note the following:
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 02. `cd Simplified-iOS`
 03. Ensure you have xcode CLI tools installed; `xcode-select --install`
 04. `git submodule update --init --recursive` (please check you have repo access to the submodules, notably the private repos)
-05. Populate the following files accordingly (external to repo for security reasons):
+05. Populate the following files accordingly (external to repo for security reasons; please contact team lead for locating these files):
     - `AudioEngine.json` (as a requirement to build NYPLAEToolkit)
     - `bugsnag-dsym-upload.rb` (a post-build script to upload symbols to bugsnag)
     - `Simplified/ReaderClientCert.sig` (RMSDK certificate)
     - `Simplified/APIKeys.swift` (file that holds various API keys; sample exists in repo at `APIKeys.swift.example`)
 06. Install [Carthage](https://github.com/Carthage/Carthage) if you haven't already.
 07. `carthage bootstrap --platform ios --use-ssh`. Note: If `carthage bootstrap` fails, you may need to create an installer package from our fork: https://github.com/NYPL-Simplified/Carthage. Specifically, there is a branch `dwarfdump-fix` which resolves https://github.com/Carthage/Carthage/issues/2514
-08. Symlink an unzipped copy of Adobe RMSDK to "adobe-rmsdk" within the "Simplified-iOS" directory. (You will need to have obtained this archive from Adobe.)
+08. Symlink an unzipped copy of Adobe RMSDK to "adobe-rmsdk" within the "Simplified-iOS" directory. (You will need to have obtained this archive from Adobe; please contact team lead for this archive)
 07. Build OpenSSL and cURL as described in the following "Building OpenSSL and cURL" section. Ensure you're in the "Simplified-iOS" directory before continuing to the next step.
 08. `sh adobe-rmsdk-build.sh`
 09. `(cd readium-sdk; sh MakeHeaders.sh Apple)` (parentheses included) to generate the headers for Readium.
@@ -25,19 +25,19 @@
 In theory, following the instructions in "adobe-rmsdk/RMSDK_User_Manual(obj).pdf", you should be able to build OpenSSL (section 12.1) and cURL (section 12.3) since Adobe provides this package to their developers.
 The following are some smoother steps to achieving this:
 - From `adobe-rmsdk/thirdparty/openssl` run `mkdir public; mv iOS-openssl/ public/ios/`
-- Download openssl 1.0.1 (1.0.1u should suffice) to `adobe-rmsdk/thirdparty/openssl/public/ios/openssl-1.0.1u.tar.gz` (note that the build script is expecting a tarball)
+- Download openssl 1.0.1 (1.0.1u should suffice) to `adobe-rmsdk/thirdparty/openssl/public/ios/openssl-1.0.1u.tar.gz` (note that the build script is expecting a tarball; as of this writing the download can be found at: https://www.openssl.org/source/old/1.0.1/)
 - Modify the `adobe-rmsdk/thirdparty/openssl/public/ios/build.sh` such that:
     - `OPENSSL_VERSION` reflects the version you downloaded, in this case "1.0.1u"
     - `SDK_VERSION` reflects the iOS SDK you're using (you can check what you have installed using `xcodebuild -showsdks`)
     - `MIN_VERSION` is "9.0"
-- From the directory of the build script: `bash ./build.sh`
-- Download curl (7.64.1 is known to work) to `adobe-rmsdk/thirdparty/curl/ios-libCurl/curl-7.64.1.zip` (note that the build script expects a ZIP, not tarball)
+- From the directory of the build script (this will take a while): `bash ./build.sh`
+- Download curl (7.64.1 is known to work) to `adobe-rmsdk/thirdparty/curl/ios-libCurl/curl-7.64.1.zip` (note that the build script expects a ZIP, not tarball; as of this writing this download can be found at: https://curl.haxx.se/download/)
 - Replace `adobe-rmsdk/thirdparty/curl/ios/build.sh` with `build_curl.sh`, a fixed version of the build script
 - Modify the build script similary to the openssl one:
     - `CURL_VERSION` reflects the version you downloaded, in this case "7.64.1"
     - `SDK_VERSION` reflects the iOS SDK you're using (you can check what you have installed using `xcodebuild -showsdks`)
     - `MIN_VERSION` is "9.0"
-- From the directory of the build script: `bash ./build.sh` (or whatever you named the copied script)
+- From the directory of the build script (this will take a while): `bash ./build.sh` (or whatever you named the copied script)
 
 Be sure to note the following:
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,42 @@
 
 01. `git clone https://github.com/NYPL-Simplified/Simplified-iOS.git` or `git clone git@github.com:NYPL-Simplified/Simplified-iOS.git`
 02. `cd Simplified-iOS`
-03. `git submodule update --init --recursive`
-04. Install [Carthage](https://github.com/Carthage/Carthage) if you haven't already.
-05. `carthage bootstrap --platform ios --use-ssh`. Note: If `carthage bootstrap` fails, you may need to create an installer package from our fork: https://github.com/NYPL-Simplified/Carthage. Specifically, there is a branch `dwarfdump-fix` which resolves https://github.com/Carthage/Carthage/issues/2514
-06. Symlink the unzipped "DRM_Connector_Prerelease" directory to "adobe-rmsdk" within the "Simplified-iOS" directory. (You will need to have obtained this binary from Adobe.)
+03. Ensure you have xcode CLI tools installed; `xcode-select --install`
+04. `git submodule update --init --recursive` (please check you have repo access to the submodules, notably the private repos)
+05. Populate the following files accordingly (external to repo for security reasons):
+    - `AudioEngine.json` (as a requirement to build NYPLAEToolkit)
+    - `bugsnag-dsym-upload.rb` (a post-build script to upload symbols to bugsnag)
+    - `Simplified/ReaderClientCert.sig` (RMSDK certificate)
+    - `Simplified/APIKeys.swift` (file that holds various API keys; sample exists in repo at `APIKeys.swift.example`)
+06. Install [Carthage](https://github.com/Carthage/Carthage) if you haven't already.
+07. `carthage bootstrap --platform ios --use-ssh`. Note: If `carthage bootstrap` fails, you may need to create an installer package from our fork: https://github.com/NYPL-Simplified/Carthage. Specifically, there is a branch `dwarfdump-fix` which resolves https://github.com/Carthage/Carthage/issues/2514
+08. Symlink an unzipped copy of Adobe RMSDK to "adobe-rmsdk" within the "Simplified-iOS" directory. (You will need to have obtained this archive from Adobe.)
 07. Build OpenSSL and cURL as described in the following "Building OpenSSL and cURL" section. Ensure you're in the "Simplified-iOS" directory before continuing to the next step.
 08. `sh adobe-rmsdk-build.sh`
 09. `(cd readium-sdk; sh MakeHeaders.sh Apple)` (parentheses included) to generate the headers for Readium.
-10. `cp APIKeys.swift.example Simplified/APIKeys.swift` and edit accordingly.
-11. `cp Accounts.json.example Simplfiied/Accounts.json`.
 12. `open Simplified.xcodeproj`
-13. Build.
+13. Build
 
 ## Building OpenSSL and cURL
 
-Follow the instructions in "adobe-rmsdk/RMSDK_User_Manual(obj).pdf" to build OpenSSL (section 12.1) and cURL (section 12.3). Be sure to note the following:
+In theory, following the instructions in "adobe-rmsdk/RMSDK_User_Manual(obj).pdf", you should be able to build OpenSSL (section 12.1) and cURL (section 12.3) since Adobe provides this package to their developers.
+The following are some smoother steps to achieving this:
+- From `adobe-rmsdk/thirdparty/openssl` run `mkdir public; mv iOS-openssl/ public/ios/`
+- Download openssl 1.0.1 (1.0.1u should suffice) to `adobe-rmsdk/thirdparty/openssl/public/ios/openssl-1.0.1u.tar.gz` (note that the build script is expecting a tarball)
+- Modify the `adobe-rmsdk/thirdparty/openssl/public/ios/build.sh` such that:
+    - `OPENSSL_VERSION` reflects the version you downloaded, in this case "1.0.1u"
+    - `SDK_VERSION` reflects the iOS SDK you're using (you can check what you have installed using `xcodebuild -showsdks`)
+    - `MIN_VERSION` is "9.0"
+- From the directory of the build script: `bash ./build.sh`
+- Download curl (7.64.1 is known to work) to `adobe-rmsdk/thirdparty/curl/ios-libCurl/curl-7.64.1.zip` (note that the build script expects a ZIP, not tarball)
+- Replace `adobe-rmsdk/thirdparty/curl/ios/build.sh` with `build_curl.sh`, a fixed version of the build script
+- Modify the build script similary to the openssl one:
+    - `CURL_VERSION` reflects the version you downloaded, in this case "7.64.1"
+    - `SDK_VERSION` reflects the iOS SDK you're using (you can check what you have installed using `xcodebuild -showsdks`)
+    - `MIN_VERSION` is "9.0"
+- From the directory of the build script: `bash ./build.sh` (or whatever you named the copied script)
+
+Be sure to note the following:
 
 * You will need to verify and edit the "build.sh" scripts for both OpenSSL and cURL to reflect the correct version numbers and local directory names (lines 11–24).
 * You must add `--enable-ipv6` to line 80 of Adobe's "build.sh" script used for building cURL. This necessary both due to Apple's requirements for IPv6 support and because the library may not build against recent iOS SDKs otherwise.

--- a/Simplified/Accounts.json
+++ b/Simplified/Accounts.json
@@ -1,0 +1,687 @@
+[
+    {
+      "id_numeric": 0,
+      "id_uuid": "urn:uuid:065c0c11-0d0f-42a3-82e4-277b18786949"
+    },
+    {
+      "id_numeric": 1,
+      "id_uuid": "urn:uuid:edef2358-9f6a-4ce6-b64f-9b351ec68ac4"
+    },
+    {
+      "id_numeric": 128,
+      "id_uuid": "urn:uuid:1a110ef6-3018-4359-84f9-e24abee9aeb3"
+    },
+    {
+      "id_numeric": 7,
+      "id_uuid": "urn:uuid:bce4c73c-9d0b-4eac-92e1-1405bcee9367"
+    },
+    {
+      "id_numeric": 21,
+      "id_uuid": "urn:uuid:1d80d5e5-d304-4be0-9110-49582a12162d"
+    },
+    {
+      "id_numeric": 11,
+      "id_uuid": "urn:uuid:4a490a70-0bd2-4f14-a81f-aeca4dda620b"
+    },
+    {
+      "id_numeric": 30,
+      "id_uuid": "urn:uuid:1ef19c4c-7380-4ab7-b85b-8487376e8e88"
+    },
+    {
+      "id_numeric": 29,
+      "id_uuid": "urn:uuid:301d32db-ac98-43d0-a207-7112fd1d62f8"
+    },
+    {
+      "id_numeric": 1231,
+      "id_uuid": "urn:uuid:f1b7a6c6-1c80-4422-8942-1df0b01236ab"
+    },
+    {
+      "id_numeric": 31,
+      "id_uuid": "urn:uuid:2183a032-a4e6-4405-a4d3-7447d3c6886e"
+    },
+    {
+      "id_numeric": 32,
+      "id_uuid": "urn:uuid:cb1d94fc-5c5c-4e38-9469-6182a6537881"
+    },
+    {
+      "id_numeric": 60,
+      "id_uuid": "urn:uuid:d16d6a75-f4e5-40ff-a942-21b5ffb876c6"
+    },
+    {
+      "id_numeric": 1232,
+      "id_uuid": "urn:uuid:0f5b790f-112e-4a24-8dc7-071f86892e24"
+    },
+    {
+      "id_numeric": 12,
+      "id_uuid": "urn:uuid:f856053f-635b-48bd-b0b1-1982643fb3b4"
+    },
+    {
+      "id_numeric": 61,
+      "id_uuid": "urn:uuid:5e1c8e01-2bb3-49d0-9b4e-7764f6da8811"
+    },
+    {
+      "id_numeric": 66,
+      "id_uuid": "urn:uuid:725aed61-b893-4327-a768-ce54af0aee36"
+    },
+    {
+      "id_numeric": 70,
+      "id_uuid": "urn:uuid:705afc58-a1ab-40f9-9a80-030be5c12d1e"
+    },
+    {
+      "id_numeric": 1233,
+      "id_uuid": "urn:uuid:ec19e1c2-5fb5-47aa-b1ce-9d712507e34e"
+    },
+    {
+      "id_numeric": 62,
+      "id_uuid": "urn:uuid:f4760d4d-bb1b-4ecc-a47a-f8c039c78158"
+    },
+    {
+      "id_numeric": 1235,
+      "id_uuid": "urn:uuid:4759fc7d-0cb8-43af-a895-34449ba78257"
+    },
+    {
+      "id_numeric": 63,
+      "id_uuid": "urn:uuid:9d26dbea-fcd1-4e4c-b00e-febab8931211"
+    },
+    {
+      "id_numeric": 1234,
+      "id_uuid": "urn:uuid:8e5bda1a-c7d7-47b5-a783-2e8f4fdb54c3"
+    },
+    {
+      "id_numeric": 17,
+      "id_uuid": "urn:uuid:6be885a0-d899-4b20-8c90-b8a6d1c8ab8e"
+    },
+    {
+      "id_numeric": 14,
+      "id_uuid": "urn:uuid:4fa12865-a9d5-439b-8ed4-24ccabcdb9be"
+    },
+    {
+      "id_numeric": 64,
+      "id_uuid": "urn:uuid:3f4783f5-a1c1-4f2f-8156-01af60d47742"
+    },
+    {
+      "id_numeric": 36,
+      "id_uuid": "urn:uuid:a53993ce-91ca-4070-b965-b236e2ea146b"
+    },
+    {
+      "id_numeric": 16,
+      "id_uuid": "urn:uuid:1ae0909b-e9a8-4fe3-8064-f3b2cfe52cea"
+    },
+    {
+      "id_numeric": 129,
+      "id_uuid": "urn:uuid:750106ef-eceb-43b9-9a85-a8e505ac80ad"
+    },
+    {
+      "id_numeric": 15,
+      "id_uuid": "urn:uuid:fe694ac0-d897-4bc8-9c71-bc103f2af810"
+    },
+    {
+      "id_numeric": 76,
+      "id_uuid": "urn:uuid:37fbb5a4-617b-46ac-9fd1-4ac447d7697e"
+    },
+    {
+      "id_numeric": 46,
+      "id_uuid": "urn:uuid:b4590bdb-160c-4025-9d73-af2382e7c898"
+    },
+    {
+      "id_numeric": 87,
+      "id_uuid": "urn:uuid:e689ff0b-ba28-4e43-a598-2fe56964272b"
+    },
+    {
+      "id_numeric": 138,
+      "id_uuid": "urn:uuid:15ff1a0d-8e1b-44bd-9c7a-c57d99ef841f"
+    },
+    {
+      "id_numeric": 117,
+      "id_uuid": "urn:uuid:d2213bb8-544f-4912-832d-dc5a564fef85"
+    },
+    {
+      "id_numeric": 33,
+      "id_uuid": "urn:uuid:f78e7d78-5342-4aa1-b954-7422998e914c"
+    },
+    {
+      "id_numeric": 77,
+      "id_uuid": "urn:uuid:68a96afb-5f38-4ec6-bdb3-8ad706e5db42"
+    },
+    {
+      "id_numeric": 78,
+      "id_uuid": "urn:uuid:6f6c6d79-b8fb-43ba-ae45-b9342954affa"
+    },
+    {
+      "id_numeric": 1236,
+      "id_uuid": "urn:uuid:06f4e89b-7a64-4bd1-9787-c58361eab651"
+    },
+    {
+      "id_numeric": 1205,
+      "id_uuid": "urn:uuid:4be05696-f269-4409-9754-7b9dce4e3dc5"
+    },
+    {
+      "id_numeric": 34,
+      "id_uuid": "urn:uuid:0226f878-134d-42e0-bcb2-2b3ad3f13380"
+    },
+    {
+      "id_numeric": 35,
+      "id_uuid": "urn:uuid:489402d9-97f1-419c-a267-f4cce4b6dd54"
+    },
+    {
+      "id_numeric": 86,
+      "id_uuid": "urn:uuid:6b849570-070f-43b4-9dcc-7ebb4bca292e"
+    },
+    {
+      "id_numeric": 55,
+      "id_uuid": "urn:uuid:10b84c15-8097-4f01-9da6-57c8b32b247c"
+    },
+    {
+      "id_numeric": 56,
+      "id_uuid": "urn:uuid:33a32e9e-ea4b-404f-b4ab-0de7d9f6c4e4"
+    },
+    {
+      "id_numeric": 48,
+      "id_uuid": "urn:uuid:2d1c8df1-fbfe-41e8-aa64-e0285ecd8599"
+    },
+    {
+      "id_numeric": 81,
+      "id_uuid": "urn:uuid:f86aa852-ff5f-4970-88b4-d54ce97ef9a8"
+    },
+    {
+      "id_numeric": 135,
+      "id_uuid": "urn:uuid:816199c6-1446-42a4-9a8f-8254fbc1017c"
+    },
+    {
+      "id_numeric": 49,
+      "id_uuid": "urn:uuid:8bb90cee-5c31-4ebf-8c82-a541269d1dce"
+    },
+    {
+      "id_numeric": 79,
+      "id_uuid": "urn:uuid:f74ff17c-d7a1-4657-9c4a-d6d09b9a69b8"
+    },
+    {
+      "id_numeric": 50,
+      "id_uuid": "urn:uuid:3c9cbc42-db02-4119-9f11-31796aa84bcd"
+    },
+    {
+      "id_numeric": 90,
+      "id_uuid": "urn:uuid:e0f433c7-5372-467a-bf5a-42ce614112e0"
+    },
+    {
+      "id_numeric": 94,
+      "id_uuid": "urn:uuid:f7bc9a4d-aa0e-4d5a-bfb2-ccdfeecba207"
+    },
+    {
+      "id_numeric": 110,
+      "id_uuid": "urn:uuid:0e4d8366-d7f6-48eb-b276-7574cd623344"
+    },
+    {
+      "id_numeric": 51,
+      "id_uuid": "urn:uuid:2e1af0df-ee4d-4216-bcc7-266e521f1ec3"
+    },
+    {
+      "id_numeric": 1259,
+      "id_uuid": "urn:uuid:fddd8eaa-c2ce-4eb3-a8b8-fcf100b47f05"
+    },
+    {
+      "id_numeric": 1247,
+      "id_uuid": "urn:uuid:f1954241-99df-433d-badd-71c06c2f833d"
+    },
+    {
+      "id_numeric": 10,
+      "id_uuid": "urn:uuid:90c35943-e6e6-4425-9315-73cea8fe7ded"
+    },
+    {
+      "id_numeric": 1261,
+      "id_uuid": "urn:uuid:a7bddadc-91c7-45a3-a642-dfd137480a22"
+    },
+    {
+      "id_numeric": 111,
+      "id_uuid": "urn:uuid:df2a9cd2-889a-440b-9ecc-cf60b92b6277"
+    },
+    {
+      "id_numeric": 28,
+      "id_uuid": "urn:uuid:a73d1088-b462-47d4-bf6f-8a029d5fba0b"
+    },
+    {
+      "id_numeric": 65,
+      "id_uuid": "urn:uuid:4ece1d0a-68ce-4637-ba47-6f7ed29548d1"
+    },
+    {
+      "id_numeric": 1228,
+      "id_uuid": "urn:uuid:19b3fe47-4ac4-4a15-a1ac-eb52327c393f"
+    },
+    {
+      "id_numeric": 57,
+      "id_uuid": "urn:uuid:02b1ff6c-55ce-40d6-af09-2d19a054514a"
+    },
+    {
+      "id_numeric": 58,
+      "id_uuid": "urn:uuid:73d3f233-f332-4cb6-b319-738239f4f7fb"
+    },
+    {
+      "id_numeric": 91,
+      "id_uuid": "urn:uuid:c728624e-bada-4953-b645-ece46c958157"
+    },
+    {
+      "id_numeric": 67,
+      "id_uuid": "urn:uuid:45f7ea1a-2262-4af6-95ce-4cee2adb421f"
+    },
+    {
+      "id_numeric": 1257,
+      "id_uuid": "urn:uuid:8bb7b978-4b62-41af-87e3-379df87f788b"
+    },
+    {
+      "id_numeric": 1245,
+      "id_uuid": "urn:uuid:ead249d3-12c0-42d5-a0de-eefc0529606e"
+    },
+    {
+      "id_numeric": 1206,
+      "id_uuid": "urn:uuid:654fd577-b1dc-4db2-9de3-75fcb908474d"
+    },
+    {
+      "id_numeric": 1221,
+      "id_uuid": "urn:uuid:1d6b2000-fca2-4391-9eb7-ec4e43a28703"
+    },
+    {
+      "id_numeric": 8,
+      "id_uuid": "urn:uuid:f60ee2fd-0734-4112-92e1-06063358a7d9"
+    },
+    {
+      "id_numeric": 59,
+      "id_uuid": "urn:uuid:63bfea56-0d89-4d5d-80af-e6fc7044b8e5"
+    },
+    {
+      "id_numeric": 5,
+      "id_uuid": "urn:uuid:f60b644e-4955-4996-a4e5-a192feb4e7f8"
+    },
+    {
+      "id_numeric": 68,
+      "id_uuid": "urn:uuid:a3f7a338-7266-4f0b-8433-d976a2f384cf"
+    },
+    {
+      "id_numeric": 47,
+      "id_uuid": "urn:uuid:36b5a718-0b90-4921-841b-87992355e814"
+    },
+    {
+      "id_numeric": 71,
+      "id_uuid": "urn:uuid:37957a24-0f6e-4740-a560-6599e8314caf"
+    },
+    {
+      "id_numeric": 1248,
+      "id_uuid": "urn:uuid:964392a7-8f23-47f3-bafc-5b67996b4bdb"
+    },
+    {
+      "id_numeric": 72,
+      "id_uuid": "urn:uuid:0c9c1c7f-13fc-4f5a-ac58-3bd155e86e25"
+    },
+    {
+      "id_numeric": 1253,
+      "id_uuid": "urn:uuid:23c0910c-bde2-4da5-9f42-c25616128353"
+    },
+    {
+      "id_numeric": 73,
+      "id_uuid": "urn:uuid:9e881a55-45e3-427d-aa8e-22c4cf4c5996"
+    },
+    {
+      "id_numeric": 1244,
+      "id_uuid": "urn:uuid:89d41123-c7f6-48cf-ab1c-735df71f44e4"
+    },
+    {
+      "id_numeric": 74,
+      "id_uuid": "urn:uuid:2443ac65-55f4-43cb-a07d-60682f82bab1"
+    },
+    {
+      "id_numeric": 69,
+      "id_uuid": "urn:uuid:b1a7b2ae-98d5-45d7-a531-82938c9fe694"
+    },
+    {
+      "id_numeric": 1249,
+      "id_uuid": "urn:uuid:cc0eba87-1487-495f-94f1-2c363b9e28f8"
+    },
+    {
+      "id_numeric": 83,
+      "id_uuid": "urn:uuid:122d9720-640d-4cf3-9931-819ea091a158"
+    },
+    {
+      "id_numeric": 80,
+      "id_uuid": "urn:uuid:f8aaaa27-e4d5-4604-9404-697cfc79ba70"
+    },
+    {
+      "id_numeric": 18,
+      "id_uuid": "urn:uuid:5fbf105c-bebb-495a-b0ee-50ba8ef0fda1"
+    },
+    {
+      "id_numeric": 114,
+      "id_uuid": "urn:uuid:43044b1e-5b1b-4d6d-b2af-75542c272b01"
+    },
+    {
+      "id_numeric": 112,
+      "id_uuid": "urn:uuid:471ef85e-b35c-4880-932b-ba91b785740c"
+    },
+    {
+      "id_numeric": 1243,
+      "id_uuid": "urn:uuid:d2d8bfbd-7144-4dc7-b44c-3684151afa33"
+    },
+    {
+      "id_numeric": 100,
+      "id_uuid": "urn:uuid:7e6c7eb6-b915-45cf-a19a-a6d339da8fc2"
+    },
+    {
+      "id_numeric": 82,
+      "id_uuid": "urn:uuid:2922723f-5c4c-4e25-81b8-81fad628b528"
+    },
+    {
+      "id_numeric": 93,
+      "id_uuid": "urn:uuid:bb86001e-c810-4c48-98cd-f4ae84e85db4"
+    },
+    {
+      "id_numeric": 75,
+      "id_uuid": "urn:uuid:a5748a8b-ffa5-46e4-908e-3278f691b856"
+    },
+    {
+      "id_numeric": 9,
+      "id_uuid": "urn:uuid:6e4575eb-abaf-4ddb-a246-52065ae3de8c"
+    },
+    {
+      "id_numeric": 95,
+      "id_uuid": "urn:uuid:77320694-95ff-467f-8abb-a8a7c606d44f"
+    },
+    {
+      "id_numeric": 136,
+      "id_uuid": "urn:uuid:4ddbed61-b789-4eac-957d-f93ff204798f"
+    },
+    {
+      "id_numeric": 44,
+      "id_uuid": "urn:uuid:7d6f67d1-d4a3-4ff1-a6d2-db6d7af585a9"
+    },
+    {
+      "id_numeric": 1255,
+      "id_uuid": "urn:uuid:389bf866-2dae-4b46-a320-789a48772990"
+    },
+    {
+      "id_numeric": 1258,
+      "id_uuid": "urn:uuid:9d365be3-abac-40e5-bb5f-1df66e5109f2"
+    },
+    {
+      "id_numeric": 1199,
+      "id_uuid": "urn:uuid:acdcf485-a920-4210-8354-c0504d96532a"
+    },
+    {
+      "id_numeric": 1254,
+      "id_uuid": "urn:uuid:00603c60-a261-4faf-a5eb-79107f3d7f9e"
+    },
+    {
+      "id_numeric": 96,
+      "id_uuid": "urn:uuid:cccc6e9a-e938-40f7-aeff-2cfd2dd5bff2"
+    },
+    {
+      "id_numeric": 124,
+      "id_uuid": "urn:uuid:ddb50957-6453-4bd3-a3ce-bd5b7333930c"
+    },
+    {
+      "id_numeric": 125,
+      "id_uuid": "urn:uuid:f3ded2c4-b182-42e1-a486-c9e6f1de61ff"
+    },
+    {
+      "id_numeric": 1260,
+      "id_uuid": "urn:uuid:4e547dac-3203-427f-9fb1-0b74e81b5e22"
+    },
+    {
+      "id_numeric": 127,
+      "id_uuid": "urn:uuid:c62ecb1d-99e8-438d-9bca-13536ef216ac"
+    },
+    {
+      "id_numeric": 97,
+      "id_uuid": "urn:uuid:400f87c9-1ac6-40e3-adf9-fe5321d6ca8b"
+    },
+    {
+      "id_numeric": 1263,
+      "id_uuid": "urn:uuid:5278562c-d642-4fda-ad7e-1613077cfb8d"
+    },
+    {
+      "id_numeric": 126,
+      "id_uuid": "urn:uuid:724811c4-7af7-47e7-aace-bf6a35ba25f7"
+    },
+    {
+      "id_numeric": 137,
+      "id_uuid": "urn:uuid:0006e04c-f47d-46ca-aba6-f5848d210e27"
+    },
+    {
+      "id_numeric": 98,
+      "id_uuid": "urn:uuid:339aa64f-7d2b-4f64-a4bc-bb4320419681"
+    },
+    {
+      "id_numeric": 1250,
+      "id_uuid": "urn:uuid:2fc0dc8d-e697-41c7-b925-588a7b00b0a5"
+    },
+    {
+      "id_numeric": 115,
+      "id_uuid": "urn:uuid:b0065fa8-6719-4f7c-9022-b8ed77e5cbca"
+    },
+    {
+      "id_numeric": 19,
+      "id_uuid": "urn:uuid:84106637-891f-4544-b638-dfa8bd0be92b"
+    },
+    {
+      "id_numeric": 116,
+      "id_uuid": "urn:uuid:643be35c-27be-4c98-acb3-e01031a10655"
+    },
+    {
+      "id_numeric": 123,
+      "id_uuid": "urn:uuid:4711ac2e-49d9-47e5-9aef-6896166c291d"
+    },
+    {
+      "id_numeric": 99,
+      "id_uuid": "urn:uuid:ef52fc30-ca51-4c1f-9b7d-cf525a29ac04"
+    },
+    {
+      "id_numeric": 113,
+      "id_uuid": "urn:uuid:0a09f0b4-e978-49ee-b6b4-efc42b4cc755"
+    },
+    {
+      "id_numeric": 101,
+      "id_uuid": "urn:uuid:f8272064-bc72-429d-8b22-758c5999caf3"
+    },
+    {
+      "id_numeric": 102,
+      "id_uuid": "urn:uuid:378d0def-bea5-4845-9f65-4864344f15ed"
+    },
+    {
+      "id_numeric": 1256,
+      "id_uuid": "urn:uuid:b9a27dd4-a4f4-4ebe-826c-cf4b63d32745"
+    },
+    {
+      "id_numeric": 103,
+      "id_uuid": "urn:uuid:81a20070-869c-4810-b883-bab77bbf3403"
+    },
+    {
+      "id_numeric": 84,
+      "id_uuid": "urn:uuid:130f48a8-4b71-413f-a71e-9b8f58138ced"
+    },
+    {
+      "id_numeric": 22,
+      "id_uuid": "urn:uuid:dbb59ed3-a9b4-45e9-be00-934c02b21f3f"
+    },
+    {
+      "id_numeric": 104,
+      "id_uuid": "urn:uuid:88ecde03-b1a6-4ed7-be62-6bc22776f748"
+    },
+    {
+      "id_numeric": 1242,
+      "id_uuid": "urn:uuid:2a0812a0-5eb1-4abc-a7a3-262b124c9b14"
+    },
+    {
+      "id_numeric": 88,
+      "id_uuid": "urn:uuid:16ba4234-ee15-47d9-9c70-fb699ebd48d2"
+    },
+    {
+      "id_numeric": 1246,
+      "id_uuid": "urn:uuid:db931a14-59da-4543-91fb-697fb766d4ec"
+    },
+    {
+      "id_numeric": 20,
+      "id_uuid": "urn:uuid:bd2baa3c-98f0-49de-8a62-3bc98065faa2"
+    },
+    {
+      "id_numeric": 105,
+      "id_uuid": "urn:uuid:2c48ad29-6eb8-4ba1-a058-a3491a28d522"
+    },
+    {
+      "id_numeric": 106,
+      "id_uuid": "urn:uuid:9626096b-3604-4f76-8885-84a655204f5f"
+    },
+    {
+      "id_numeric": 107,
+      "id_uuid": "urn:uuid:2003c69e-3b79-42d2-818c-5ec1f0e72ad0"
+    },
+    {
+      "id_numeric": 108,
+      "id_uuid": "urn:uuid:972888b7-7abe-407d-835d-9610c43580f3"
+    },
+    {
+      "id_numeric": 1251,
+      "id_uuid": "urn:uuid:639a814f-18a4-4d1a-9c18-6284448ae9e6"
+    },
+    {
+      "id_numeric": 109,
+      "id_uuid": "urn:uuid:1fb8d6ea-9072-4686-abed-fa0f9479e635"
+    },
+    {
+      "id_numeric": 2,
+      "id_uuid": "urn:uuid:56906f26-2c9a-4ae9-bd02-552557720b99"
+    },
+    {
+      "id_numeric": 45,
+      "id_uuid": "urn:uuid:306436c4-f024-41aa-bc28-9c58f877ee24"
+    },
+    {
+      "id_numeric": 92,
+      "id_uuid": "urn:uuid:944a14a1-3d07-4ddf-a9c1-94435ec16315"
+    },
+    {
+      "id_numeric": 1198,
+      "id_uuid": "urn:uuid:6c92feac-a2a5-4b53-82f5-265f40c9187d"
+    },
+    {
+      "id_numeric": 118,
+      "id_uuid": "urn:uuid:f6eb4e88-c9ed-442f-ae17-988c25b6c23d"
+    },
+    {
+      "id_numeric": 1222,
+      "id_uuid": "urn:uuid:3a2e8b39-ef65-4acf-a17c-d662b2888cf1"
+    },
+    {
+      "id_numeric": 119,
+      "id_uuid": "urn:uuid:414b7738-2abd-493a-874f-ad4191b04a61"
+    },
+    {
+      "id_numeric": 1201,
+      "id_uuid": "urn:uuid:625a725d-2324-4407-9407-20d230e2648a"
+    },
+    {
+      "id_numeric": 13,
+      "id_uuid": "urn:uuid:3e4028e1-4882-4e9a-a6c1-aafbd585f4f5"
+    },
+    {
+      "id_numeric": 1202,
+      "id_uuid": "urn:uuid:4c0fcc4b-777b-42f3-a3d0-2577b6a23ba7"
+    },
+    {
+      "id_numeric": 1203,
+      "id_uuid": "urn:uuid:dea97614-8838-4339-a4a3-2340af1ad582"
+    },
+    {
+      "id_numeric": 139,
+      "id_uuid": "urn:uuid:fd692093-00c0-4885-b0e8-0365f82244f1"
+    },
+    {
+      "id_numeric": 1223,
+      "id_uuid": "urn:uuid:d3fdbdc9-d129-46fc-bb4e-f7422b3f3725"
+    },
+    {
+      "id_numeric": 1207,
+      "id_uuid": "urn:uuid:6f0e930f-25c2-41de-b6c4-feb66ab2df34"
+    },
+    {
+      "id_numeric": 1208,
+      "id_uuid": "urn:uuid:6e206037-215e-4d1a-b89f-0f69af6f5ec3"
+    },
+    {
+      "id_numeric": 1224,
+      "id_uuid": "urn:uuid:3a2f7d77-fc34-4ba4-a046-73e80b4f8bee"
+    },
+    {
+      "id_numeric": 1225,
+      "id_uuid": "urn:uuid:733f5c08-0d60-4e18-a80d-db15bb1e35e1"
+    },
+    {
+      "id_numeric": 131,
+      "id_uuid": "urn:uuid:c6a50365-e90e-4b8a-8f36-a1eaf26e751d"
+    },
+    {
+      "id_numeric": 1226,
+      "id_uuid": "urn:uuid:015a8c7c-d188-4773-b839-1ceaedb67a70"
+    },
+    {
+      "id_numeric": 23,
+      "id_uuid": "urn:uuid:6263da4e-723f-417a-9d87-9ca4cbc2da6d"
+    },
+    {
+      "id_numeric": 41,
+      "id_uuid": "urn:uuid:f160318e-2d32-4821-97ed-e8bf03828b51"
+    },
+    {
+      "id_numeric": 42,
+      "id_uuid": "urn:uuid:bdbd1482-1336-4684-8267-9d48f80f00f9"
+    },
+    {
+      "id_numeric": 132,
+      "id_uuid": "urn:uuid:ba6e4b4b-0c34-47c2-ab83-df1a820eba54"
+    },
+    {
+      "id_numeric": 133,
+      "id_uuid": "urn:uuid:74a72251-75ca-4813-b982-ce28ad8036b5"
+    },
+    {
+      "id_numeric": 1219,
+      "id_uuid": "urn:uuid:8c5a57c2-6c98-4b57-a7d9-1cced4afdab2"
+    },
+    {
+      "id_numeric": 120,
+      "id_uuid": "urn:uuid:825b934f-5cf9-4bd8-91ef-dbc80b84d78b"
+    },
+    {
+      "id_numeric": 1252,
+      "id_uuid": "urn:uuid:ea7e5398-7091-420d-9560-378d479847c0"
+    },
+    {
+      "id_numeric": 1218,
+      "id_uuid": "urn:uuid:0557a7e4-58c3-41ef-9d8f-fcb81affa262"
+    },
+    {
+      "id_numeric": 130,
+      "id_uuid": "urn:uuid:8a773572-178a-4fae-920a-26af646dbbb6"
+    },
+    {
+      "id_numeric": 1227,
+      "id_uuid": "urn:uuid:8a9b61df-36f3-41de-bcbb-e821cf6559c2"
+    },
+    {
+      "id_numeric": 121,
+      "id_uuid": "urn:uuid:d74acd09-e42d-44da-a468-e2d98509642c"
+    },
+    {
+      "id_numeric": 122,
+      "id_uuid": "urn:uuid:88fbd66a-4a91-4a90-949b-75a4d2b46c53"
+    },
+    {
+      "id_numeric": 1229,
+      "id_uuid": "urn:uuid:1374649b-86ee-4779-a0b2-0142598ce418"
+    },
+    {
+      "id_numeric": 134,
+      "id_uuid": "urn:uuid:f09d725a-1e1d-42ba-8f95-8fd3eedd4d5f"
+    },
+    {
+      "id_numeric": 1230,
+      "id_uuid": "urn:uuid:fb5e191b-2779-4b66-8e54-91abf7fa535f"
+    }
+  ]
+  

--- a/Simplified/build_curl.sh
+++ b/Simplified/build_curl.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# This script builds a static version of
+# curl ${CURL_VERSION} for iOS 9.0 that contains code for
+# arm64, armv7, arm7s, i386 and x86_64.
+
+# Based off of build script from RMSDK
+# Patched by cross-referencing with: https://github.com/sinofool/build-libcurl-ios
+
+set -x
+
+# Setup paths to stuff we need
+
+CURL_VERSION="7.64.1"
+
+DEVELOPER="/Applications/Xcode.app/Contents/Developer"
+
+SDK_VERSION="12.2"
+MIN_VERSION="9.0"
+
+IPHONEOS_PLATFORM="${DEVELOPER}/Platforms/iPhoneOS.platform"
+IPHONEOS_SDK="${IPHONEOS_PLATFORM}/Developer/SDKs/iPhoneOS${SDK_VERSION}.sdk"
+IPHONEOS_GCC="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
+
+IPHONESIMULATOR_PLATFORM="${DEVELOPER}/Platforms/iPhoneSimulator.platform"
+IPHONESIMULATOR_SDK="${IPHONESIMULATOR_PLATFORM}/Developer/SDKs/iPhoneSimulator${SDK_VERSION}.sdk"
+IPHONESIMULATOR_GCC="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
+
+# Make sure things actually exist
+
+if [ ! -d "$IPHONEOS_PLATFORM" ]; then
+  echo "Cannot find $IPHONEOS_PLATFORM"
+  exit 1
+fi
+
+if [ ! -d "$IPHONEOS_SDK" ]; then
+  echo "Cannot find $IPHONEOS_SDK"
+  exit 1
+fi
+
+if [ ! -x "$IPHONEOS_GCC" ]; then
+  echo "Cannot find $IPHONEOS_GCC"
+  exit 1
+fi
+
+if [ ! -d "$IPHONESIMULATOR_PLATFORM" ]; then
+  echo "Cannot find $IPHONESIMULATOR_PLATFORM"
+  exit 1
+fi
+
+if [ ! -d "$IPHONESIMULATOR_SDK" ]; then
+  echo "Cannot find $IPHONESIMULATOR_SDK"
+  exit 1
+fi
+
+if [ ! -x "$IPHONESIMULATOR_GCC" ]; then
+  echo "Cannot find $IPHONESIMULATOR_GCC"
+  exit 1
+fi
+
+# Clean up whatever was left from our previous build
+
+rm -rf lib include-32 include-64
+rm -rf /tmp/curl-${CURL_VERSION}-*
+rm -rf /tmp/curl-${CURL_VERSION}-*.*-log
+
+build()
+{
+    HOST=$1
+    ARCH=$2
+    SDK=$3
+    MOREFLAGS=$4
+    rm -rf "curl-${CURL_VERSION}"
+    unzip "curl-${CURL_VERSION}.zip" -d "."
+    pushd .
+    cd "curl-${CURL_VERSION}"
+    export IPHONEOS_DEPLOYMENT_TARGET=${MIN_VERSION}
+    export CFLAGS="-arch ${ARCH} -pipe -Os -gdwarf-2 -isysroot ${SDK} -miphoneos-version-min=${MIN_VERSION}"
+    export CPPFLAGS=${MOREFLAGS}
+    export LDFLAGS="-arch ${ARCH} -isysroot ${SDK}"
+    ./configure --disable-shared --enable-static --enable-ipv6 --host=${HOST} --prefix="/tmp/curl-${CURL_VERSION}-${ARCH}" --with-darwinssl --enable-threaded-resolver &> "/tmp/curl-${CURL_VERSION}-${ARCH}.log"
+    make -j `sysctl -n hw.logicalcpu_max` &> "/tmp/curl-${CURL_VERSION}-${ARCH}-build.log"
+    make install &> "/tmp/curl-${CURL_VERSION}-${ARCH}-install.log"
+    popd
+    rm -rf "curl-${CURL_VERSION}"
+}
+
+build "armv7-apple-darwin"  "armv7"  "${IPHONEOS_SDK}" ""
+build "armv7s-apple-darwin" "armv7s" "${IPHONEOS_SDK}" ""
+build "arm-apple-darwin"    "arm64"  "${IPHONEOS_SDK}" ""
+build "i386-apple-darwin"   "i386"   "${IPHONESIMULATOR_SDK}" "-D__IPHONE_OS_VERSION_MIN_REQUIRED=${IPHONEOS_DEPLOYMENT_TARGET%%.*}0000"
+build "x86_64-apple-darwin" "x86_64" "${IPHONESIMULATOR_SDK}" "-D__IPHONE_OS_VERSION_MIN_REQUIRED=${IPHONEOS_DEPLOYMENT_TARGET%%.*}0000"
+
+mkdir -p ../public/ios/lib ../public/ios/include-32 ../public/ios/include-64
+cp -r /tmp/curl-${CURL_VERSION}-i386/include/curl ../public/ios/include-32/
+cp -r /tmp/curl-${CURL_VERSION}-x86_64/include/curl ../public/ios/include-64/
+lipo \
+"/tmp/curl-${CURL_VERSION}-armv7/lib/libcurl.a" \
+"/tmp/curl-${CURL_VERSION}-armv7s/lib/libcurl.a" \
+"/tmp/curl-${CURL_VERSION}-arm64/lib/libcurl.a" \
+"/tmp/curl-${CURL_VERSION}-i386/lib/libcurl.a" \
+"/tmp/curl-${CURL_VERSION}-x86_64/lib/libcurl.a" \
+-create -output ../public/ios/lib/libcurl.a
+
+rm -rf "/tmp/curl-${CURL_VERSION}-*"
+rm -rf "/tmp/curl-${CURL_VERSION}-*.*-log"


### PR DESCRIPTION
Adding `Accounts.json` to the repo as a commit. This is required for 3.1.x -> 3.2.0 migrations and can be phased out later since we no longer use hardcoded lists.  
The Accounts list has been stripped of most information, leaving only enough for id->uuid mapping.  
The build notes were written with effort to keep enough sensitive info out of the process while making things easier to identify and understand.