### PR TITLE
SIMPLY-2142 - Unify error messages for library fetch errors

### DIFF
--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -383,7 +383,7 @@ static NSString *const RecordsKey = @"records";
       [self save];
     } else {
       UIAlertController *alert = [NYPLAlertUtils alertWithTitle:@"SyncFailed"
-                                                        message:@"LibraryLoadError"];
+                                                        message:@"DataError"];
       [NYPLAlertUtils presentFromViewControllerOrNilWithAlertController:alert viewController:nil animated:YES completion:nil];
     }
   }];

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -383,7 +383,7 @@ static NSString *const RecordsKey = @"records";
       [self save];
     } else {
       UIAlertController *alert = [NYPLAlertUtils alertWithTitle:@"SyncFailed"
-                                                        message:@"CheckConnection"];
+                                                        message:@"LibraryLoadError"];
       [NYPLAlertUtils presentFromViewControllerOrNilWithAlertController:alert viewController:nil animated:YES completion:nil];
     }
   }];

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -122,7 +122,7 @@
       workflowsInProgress = ([NYPLBookRegistry sharedRegistry].syncing == YES);
     #endif
 
-      if(workflowsInProgress) {
+      if (workflowsInProgress) {
         UIAlertController *alert = [NYPLAlertUtils
                                     alertWithTitle:@"PleaseWait"
                                     message:@"PleaseWaitMessage"];
@@ -139,7 +139,7 @@
             } else {
               UIAlertController *alert = [NYPLAlertUtils
                                           alertWithTitle:@""
-                                          message:@"UnknownRequestError"];
+                                          message:@"LibraryLoadError"];
               [self presentViewController:alert
                                  animated:YES
                                completion:nil];

--- a/Simplified/NYPLSettingsAccountsList.swift
+++ b/Simplified/NYPLSettingsAccountsList.swift
@@ -104,7 +104,7 @@
   func addAccount() {
     AccountsManager.shared.loadCatalogs(options: .online) { (success) in
       guard success else {
-        let alert = NYPLAlertUtils.alert(title:nil, message:"CheckConnection", style: .cancel)
+        let alert = NYPLAlertUtils.alert(title:nil, message:"LibraryLoadError", style: .cancel)
         NYPLAlertUtils.presentFromViewControllerOrNil(alertController: alert, viewController: self, animated: true, completion: nil)
         return
       }

--- a/Simplified/NYPLWelcomeScreen.swift
+++ b/Simplified/NYPLWelcomeScreen.swift
@@ -145,7 +145,7 @@ import PureLayout
   }
   
   func showLoadingFailureAlert() {
-    let alert = NYPLAlertUtils.alert(title:nil, message:"CheckConnection", style: .cancel)
+    let alert = NYPLAlertUtils.alert(title:nil, message:"LibraryLoadError", style: .cancel)
     present(alert, animated: true, completion: nil)
   }
   

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -30,6 +30,7 @@
 "ConnectionFailedDescription" = "Unable to load the web page at this time.";
 "Contact" = "Contact";
 "ContentLicenses" = "Content Licenses";
+"DataError" = "We found a problem. Please check your connection or close and reopen the app to retry.";
 "Delete" = "Delete";
 "Description" = "Description";
 "DeviceAuthorizationError" = "An error occurred while authorizing this device.";
@@ -43,6 +44,7 @@
 "Hide" = "Hide";
 "Information" = "Information";
 "LibraryCard" = "Library Card";
+"LibraryLoadError" = "We can’t get your library right now. Please close and reopen the app to try again.";
 "Licenses" = "Licenses";
 "LogIn" = "Log In";
 "ManageAccounts" = "Manage Accounts";


### PR DESCRIPTION
I couldn't find any instances where I could swap an error message for "disk crashes" or "generic errors" as per https://jira.nypl.org/browse/SIMPLY-2142