### PR TITLE
Fixing execution on non-main threads

### DIFF
--- a/Simplified/NYPLHoldsNavigationController.m
+++ b/Simplified/NYPLHoldsNavigationController.m
@@ -56,7 +56,13 @@
 
 - (void)currentAccountChanged
 {
-  [self popToRootViewControllerAnimated:NO];
+  if (![NSThread isMainThread]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self popToRootViewControllerAnimated:NO];
+    });
+  } else {
+    [self popToRootViewControllerAnimated:NO];
+  }
 }
 
 - (void) switchLibrary

--- a/Simplified/NYPLMyBooksNavigationController.m
+++ b/Simplified/NYPLMyBooksNavigationController.m
@@ -58,7 +58,13 @@
 
 - (void)currentAccountChanged
 {
-  [self popToRootViewControllerAnimated:NO];
+  if (![NSThread isMainThread]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self popToRootViewControllerAnimated:NO];
+    });
+  } else {
+    [self popToRootViewControllerAnimated:NO];
+  }
 }
 
 - (void) switchLibrary

--- a/Simplified/NYPLRootTabBarController.m
+++ b/Simplified/NYPLRootTabBarController.m
@@ -69,6 +69,17 @@
 
 - (void)setTabViewControllers
 {
+  if (![NSThread isMainThread]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self setTabViewControllersInternal];
+    });
+  } else {
+    [self setTabViewControllersInternal];
+  }
+}
+
+- (void)setTabViewControllersInternal
+{
   Account *const currentAccount = [AccountsManager shared].currentAccount;
   if (currentAccount.details.supportsReservations) {
     self.viewControllers = @[self.catalogNavigationController,


### PR DESCRIPTION
While fixing presentation modals, I discovered many issues with calling UI-changing operations on non-main threads. This is considered to put the app in potentially unknown states. It doesn't necessarily crash the app in production but it can produce unpredictable behaviour. It certainly crashes in the debugger.

Most of the changes involve wrapping the calls in question in thread checks