### PR TITLE
Add full NYPLBookRegistry.h nullability

### DIFF
--- a/Simplified/NYPLBookRegistry.h
+++ b/Simplified/NYPLBookRegistry.h
@@ -7,22 +7,22 @@
 @class NYPLReadiumBookmark;
 
 // This is broadcast whenever the book registry is modified.
-static NSString *const NYPLBookRegistryDidChangeNotification =
+static NSString *const _Nonnull NYPLBookRegistryDidChangeNotification =
   @"NYPLBookRegistryDidChangeNotification";
 
-static NSString *const NYPLBookProcessingDidChangeNotification =
+static NSString *const _Nonnull NYPLBookProcessingDidChangeNotification =
   @"NYPLBookProcessingDidChangeNotification";
 
 @interface NYPLBookRegistry : NSObject
 
 // Returns all registered books.
-@property (atomic, readonly) NSArray *allBooks;
+@property (atomic, readonly, nonnull) NSArray *allBooks;
 
 // Returns all books that are on hold
-@property (atomic, readonly) NSArray *heldBooks;
+@property (atomic, readonly, nonnull) NSArray *heldBooks;
 
 // Returns all books not on hold (borrowed or kept)
-@property (atomic, readonly) NSArray *myBooks;
+@property (atomic, readonly, nonnull) NSArray *myBooks;
 
 // Returns the number of books currently registered.
 @property (atomic, readonly) NSUInteger count;
@@ -30,14 +30,14 @@ static NSString *const NYPLBookProcessingDidChangeNotification =
 // Returns YES if the registry is currently syncing, else NO;
 @property (atomic, readonly) BOOL syncing;
 
-+ (id)new NS_UNAVAILABLE;
-- (id)init NS_UNAVAILABLE;
++ (nonnull id)new NS_UNAVAILABLE;
+- (nonnull id)init NS_UNAVAILABLE;
 
-+ (NYPLBookRegistry *)sharedRegistry;
++ (nonnull NYPLBookRegistry *)sharedRegistry;
 
 // Returns the URL of the directory used by the registry for storing content and metadata. The
 // directory is not guaranteed to exist at the time this method is called.
-- (NSURL *)registryDirectory;
+- (nullable NSURL *)registryDirectory;
 
 // Saves the registry. This should be called before the application is terminated.
 - (void)save;
@@ -49,7 +49,7 @@ static NSString *const NYPLBookProcessingDidChangeNotification =
 
  @param handler Completion Handler is on main thread, but not gauranteed to be called.
  */
-- (void)syncWithCompletionHandler:(void (^)(BOOL success))handler;
+- (void)syncWithCompletionHandler:(void (^ _Nullable)(BOOL success))handler;
 
 /**
  Syncs the latest loans content from the server. Attempting to sync while one is
@@ -62,8 +62,8 @@ static NSString *const NYPLBookProcessingDidChangeNotification =
  from a Background App State, like from the App Delegate method. Calls to this
  block should be balanced with calls to the method.
  */
-- (void)syncWithCompletionHandler:(void (^)(BOOL success))handler
-            backgroundFetchHandler:(void (^)(UIBackgroundFetchResult))fetchHandler;
+- (void)syncWithCompletionHandler:(void (^ _Nullable)(BOOL success))handler
+            backgroundFetchHandler:(void (^ _Nullable)(UIBackgroundFetchResult))fetchHandler;
 
 /**
  Calls syncWithCompletionHandler: with a handler that presents standard
@@ -75,114 +75,121 @@ static NSString *const NYPLBookProcessingDidChangeNotification =
 // present information about obtained books when offline. Attempting to add a book already present
 // will overwrite the existing book as if |updateBook:| were called. The location may be nil. The
 // state provided must not be |NYPLBookStateUnregistered|.
-- (void)addBook:(NYPLBook *)book
-       location:(NYPLBookLocation *)location
+- (void)addBook:(nonnull NYPLBook *)book
+       location:(nullable NYPLBookLocation *)location
           state:(NYPLBookState)state
-  fulfillmentId:(NSString *)fulfillmentId
-readiumBookmarks:(NSArray<NYPLReadiumBookmark *> *)readiumBookmarks
-genericBookmarks:(NSArray<NYPLBookLocation *> *)genericBookmarks;
+  fulfillmentId:(nullable NSString *)fulfillmentId
+readiumBookmarks:(nullable NSArray<NYPLReadiumBookmark *> *)readiumBookmarks
+genericBookmarks:(nullable NSArray<NYPLBookLocation *> *)genericBookmarks;
 
 // This method should be called whenever new book information is retrieved from a server. Doing so
 // ensures that once the user has seen the new information, they will continue to do so when
 // accessing the application off-line or when viewing books outside of the catalog. Attempts to
 // update a book not already stored in the registry will simply be ignored, so it's reasonable to
 // call this method whenever new information is obtained regardless of a given book's state.
-- (void)updateBook:(NYPLBook *)book;
+- (void)updateBook:(nonnull NYPLBook *)book;
 
 // This will update the book like updateBook does, but will also set its state to unregistered, then
 // broadcast the change, then remove the book from the registry. This gives any views using the book
 // a chance to update their copy with the new one, without having to keep it in the registry after.
-- (void)updateAndRemoveBook:(NYPLBook *)book;
+- (void)updateAndRemoveBook:(nonnull NYPLBook *)book;
 
 // This method should be called whenever new book information is retrieved from a server, but may
 // not include user-specific information. We want to update the metadata, but not overwrite the
 // existing availability information and acquisition URLs.
-- (void)updateBookMetadata:(NYPLBook *)book;
+- (void)updateBookMetadata:(nonnull NYPLBook *)book;
 
 // Returns the book for a given identifier if it is registered, else nil.
-- (NYPLBook *)bookForIdentifier:(NSString *)identifier;
+- (nullable NYPLBook *)bookForIdentifier:(nonnull NSString *)identifier;
 
 // Sets the state for a book previously registered given its identifier.
-- (void)setState:(NYPLBookState)state forIdentifier:(NSString *)identifier;
+- (void)setState:(NYPLBookState)state forIdentifier:(nonnull NSString *)identifier;
 
 // Returns the state of a book given its identifier.
-- (NYPLBookState)stateForIdentifier:(NSString *)identifier;
+- (NYPLBookState)stateForIdentifier:(nonnull NSString *)identifier;
 
 // Sets the location for a book previously registered given its identifier.
-- (void)setLocation:(NYPLBookLocation *)location forIdentifier:(NSString *)identifier;
+- (void)setLocation:(nullable NYPLBookLocation *)location
+      forIdentifier:(nonnull NSString *)identifier;
 
 // Returns the location of a book given its identifier.
-- (NYPLBookLocation *)locationForIdentifier:(NSString *)identifier;
+- (nullable NYPLBookLocation *)locationForIdentifier:(nonnull NSString *)identifier;
 
 // Sets the fulfillmentId for a book previously registered given its identifier.
-- (void)setFulfillmentId:(NSString *)fulfillmentId forIdentifier:(NSString *)identifier;
+- (void)setFulfillmentId:(nullable NSString *)fulfillmentId forIdentifier:(nonnull NSString *)identifier;
 
 // Returns whether a book is processing something, given its identifier.
-- (BOOL)processingForIdentifier:(NSString *)identifier;
+- (BOOL)processingForIdentifier:(nonnull NSString *)identifier;
 
 // Sets the processing flag for a book previously registered given its identifier.
-- (void)setProcessing:(BOOL)processing forIdentifier:(NSString *)identifier;
+- (void)setProcessing:(BOOL)processing forIdentifier:(nonnull NSString *)identifier;
 
 // Returns the fulfillmentId of a book given its identifier.
-- (NSString *)fulfillmentIdForIdentifier:(NSString *)identifier;
+- (nullable NSString *)fulfillmentIdForIdentifier:(nonnull NSString *)identifier;
     
 // Returns the bookmarks for a book given its identifier
-- (NSArray<NYPLReadiumBookmark *> *)readiumBookmarksForIdentifier:(NSString *)identifier;
+- (nonnull NSArray<NYPLReadiumBookmark *> *)readiumBookmarksForIdentifier:(nonnull NSString *)identifier;
   
 // Add bookmark for a book given its identifier
-- (void)addReadiumBookmark:(NYPLReadiumBookmark *)bookmark forIdentifier:(NSString *)identifier;
+- (void)addReadiumBookmark:(nonnull NYPLReadiumBookmark *)bookmark
+             forIdentifier:(nonnull NSString *)identifier;
   
 // Delete bookmark for a book given its identifer
-- (void)deleteReadiumBookmark:(NYPLReadiumBookmark *)bookmark forIdentifier:(NSString *)identifier;
+- (void)deleteReadiumBookmark:(nonnull NYPLReadiumBookmark *)bookmark
+                forIdentifier:(nonnull NSString *)identifier;
 
 // Replace a bookmark with another, given its identifer
-- (void)replaceBookmark:(NYPLReadiumBookmark *)oldBookmark with:(NYPLReadiumBookmark *)newBookmark forIdentifier:(NSString *)identifier;
+- (void)replaceBookmark:(nonnull NYPLReadiumBookmark *)oldBookmark
+                   with:(nonnull NYPLReadiumBookmark *)newBookmark
+          forIdentifier:(nonnull NSString *)identifier;
 
 // Returns the generic bookmarks for a any renderer's bookmarks given its identifier
-- (NSArray<NYPLBookLocation *> *)genericBookmarksForIdentifier:(NSString *)identifier;
+- (nullable NSArray<NYPLBookLocation *> *)genericBookmarksForIdentifier:(nonnull NSString *)identifier;
 
 // Add a generic bookmark (book location) for a book given its identifier
-- (void)addGenericBookmark:(NYPLBookLocation *)bookmark forIdentifier:(NSString *)identifier;
+- (void)addGenericBookmark:(nonnull NYPLBookLocation *)bookmark
+             forIdentifier:(nonnull NSString *)identifier;
 
 // Delete a generic bookmark (book location) for a book given its identifier
-- (void)deleteGenericBookmark:(NYPLBookLocation *)bookmark forIdentifier:(NSString *)identifier;
+- (void)deleteGenericBookmark:(nonnull NYPLBookLocation *)bookmark
+                forIdentifier:(nonnull NSString *)identifier;
 
 // Given an identifier, this method removes a book from the registry. Attempting to remove a book
 // that is not present will result in an error being logged.
-- (void)removeBookForIdentifier:(NSString *)book;
+- (void)removeBookForIdentifier:(nonnull NSString *)book;
 
 // Returns the thumbnail for a book via a handler called on the main thread. The book does not have
 // to be registered in order to retrieve a cover.
-- (void)thumbnailImageForBook:(NYPLBook *)book
-                      handler:(void (^)(UIImage *image))handler;
+- (void)thumbnailImageForBook:(nonnull NYPLBook *)book
+                      handler:(void (^ _Nonnull)(UIImage * _Nonnull image))handler;
 
 // Returns cover image if it exists, or falls back to thumbnail image load.
-- (void)coverImageForBook:(NYPLBook *const)book
-                  handler:(void (^)(UIImage *image))handler;
+- (void)coverImageForBook:(nonnull NYPLBook *const)book
+                  handler:(void (^ _Nonnull)(UIImage * _Nonnull image))handler;
 
 // The set passed in should contain NYPLBook objects. If |books| is nil or does not strictly contain
 // NYPLBook objects, the handler will be called with nil. Otherwise, the dictionary passed to the
 // handler maps book identifiers to images. The handler is always called on the main thread. The
 // books do not have to be registered in order to retrieve covers.
-- (void)thumbnailImagesForBooks:(NSSet *)books
-                        handler:(void (^)(NSDictionary *bookIdentifiersToImages))handler;
+- (void)thumbnailImagesForBooks:(nonnull NSSet *)books
+                        handler:(void (^ _Nonnull)(NSDictionary * _Nonnull bookIdentifiersToImages))handler;
 
 // Immediately returns the cached thumbnail if available, else nil. Generated images are not
 // returned. The book does not have to be registered in order to retrieve a cover.
-- (UIImage *)cachedThumbnailImageForBook:(NYPLBook *)book;
+- (nullable UIImage *)cachedThumbnailImageForBook:(nonnull NYPLBook *)book;
 
 // Resets the registry to an empty state.
 - (void)reset;
 
 // Resets the registry for a specific account
-- (void)reset:(NSString *)account;
+- (void)reset:(nonnull NSString *)account;
 
 /// Returns all book identifiers in the registry for a given account.
 /// @note The identifiers returned should not be passed to @c -[NYPLBookRegistry @c bookForIdentifier:]
 ///       or similar methods unless the account provided to this method is also the currently active account.
 /// @param account The id of the account to inspect.
 /// @return A possibly empty array of book identifiers.
-- (NSArray<NSString *> *__nonnull)bookIdentifiersForAccount:(NSString *)account;
+- (NSArray<NSString *> *_Nonnull)bookIdentifiersForAccount:(nonnull NSString *)account;
 
 // Delay committing any changes from a sync indefinitely.
 - (void)delaySyncCommit;
@@ -197,6 +204,7 @@ genericBookmarks:(NSArray<NYPLBookLocation *> *)genericBookmarks;
 ///          behavior.
 /// @param account The account to use while @c block is executing.
 /// @param block   The function to execute while the registry is set to another account.
-- (void)performUsingAccount:(NSString *)account block:(void (^__nonnull)(void))block;
+- (void)performUsingAccount:(nonnull NSString *)account
+                      block:(void (^_Nonnull)(void))block;
 
 @end

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -39,6 +39,7 @@ static NSString *const RecordsKey = @"records";
     sharedRegistry = [[self alloc] init];
     if(!sharedRegistry) {
       NYPLLOG(@"Failed to create shared registry.");
+      @throw NSMallocException;
     }
     
     [sharedRegistry load];

--- a/Simplified/NYPLUserNotifications.swift
+++ b/Simplified/NYPLUserNotifications.swift
@@ -162,7 +162,7 @@ extension NYPLUserNotifications: UNUserNotificationCenterDelegate
         return
       }
       guard let downloadCenter = NYPLMyBooksDownloadCenter.shared(),
-        let book = NYPLBookRegistry.shared()?.book(forIdentifier: bookID) else {
+        let book = NYPLBookRegistry.shared().book(forIdentifier: bookID) else {
           Log.error(#file, "Problem creating book or download center singleton. BookID: \(bookID)")
           return
       }


### PR DESCRIPTION
**What's this do?**
Adds nullability annotations to NYPLBookRegistry.h, eliminating a lot of warnings.

**Why are we doing this? (w/ JIRA link if applicable)**
Nullability annotations are essential for proper objc-swift communication. This header file already specified if for a couple members, and when you do that Xcode expects the whole file to deal with annotations.

**How should this be tested? / Do these changes have associated tests?**
There are no tests added but I verified every single change is safe.
- i looked at the usage in source files to determine what made sense at runtime. E.g. passing a nil bookmark to `addReadiumBookmark:forIdentifier:` would crash the app.
- i checked usages in swift code of every api/property I modified, in particular `nonnull`s.
- When Swift was not involved, I opted for what made more sense semantically. E.g. `cachedThumbnailImageForBook:` is not used by swift, so nullability is irrelevant, but it makes sense for the book parameter to be nonnull (there's no thumbnail for a nil book).
- A few cases were ambiguous: I used existing comments in the code to decide (e.g. location may be nil when adding a book) and/or exercised code in the debugger (e.g. forcing a nil).

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ettore
