### PR TITLE
SIMPLY-2072 Fix background fetch and background execution

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -160,6 +160,8 @@
 		5DD5677222B7ECE3001F0C83 /* NYPLSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */; };
 		5DD567AF22B95A30001F0C83 /* String+MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD567AE22B95A30001F0C83 /* String+MD5.swift */; };
 		5DD567B522B97344001F0C83 /* Data+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD567B422B97344001F0C83 /* Data+Base64.swift */; };
+		7327A89323EE017300954748 /* NYPLMainThreadChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7327A89223EE017300954748 /* NYPLMainThreadChecker.swift */; };
+		732F929323ECB51F0099244C /* NYPLBackgroundExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732F929223ECB51F0099244C /* NYPLBackgroundExecutor.swift */; };
 		841B55431B740F2700FAC1AF /* NYPLSettingsEULAViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 841B55421B740F2700FAC1AF /* NYPLSettingsEULAViewController.m */; };
 		84B7A3461B84E8FE00584FB2 /* OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3431B84E8FE00584FB2 /* OFL.txt */; };
 		84B7A3471B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3441B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf */; };
@@ -530,6 +532,8 @@
 		5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSettings.swift; sourceTree = "<group>"; };
 		5DD567AE22B95A30001F0C83 /* String+MD5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+MD5.swift"; sourceTree = "<group>"; };
 		5DD567B422B97344001F0C83 /* Data+Base64.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Base64.swift"; sourceTree = "<group>"; };
+		7327A89223EE017300954748 /* NYPLMainThreadChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLMainThreadChecker.swift; sourceTree = "<group>"; };
+		732F929223ECB51F0099244C /* NYPLBackgroundExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBackgroundExecutor.swift; sourceTree = "<group>"; };
 		841B55411B740F2700FAC1AF /* NYPLSettingsEULAViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYPLSettingsEULAViewController.h; sourceTree = "<group>"; };
 		841B55421B740F2700FAC1AF /* NYPLSettingsEULAViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYPLSettingsEULAViewController.m; sourceTree = "<group>"; };
 		84B7A3431B84E8FE00584FB2 /* OFL.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OFL.txt; sourceTree = "<group>"; };
@@ -967,6 +971,15 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		7327A88D23EE00FE00954748 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				7327A89223EE017300954748 /* NYPLMainThreadChecker.swift */,
+				732F929223ECB51F0099244C /* NYPLBackgroundExecutor.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
 		84B7A3421B84E8FE00584FB2 /* OpenDyslexicFont */ = {
 			isa = PBXGroup;
 			children = (
@@ -1137,6 +1150,7 @@
 				145798F5215BE9E300F68AFD /* ProblemReportEmail.swift */,
 				119504051994061E009FB788 /* Reader */,
 				11C5DCEE1976D19E005A9945 /* Settings */,
+				7327A88D23EE00FE00954748 /* Utilities */,
 				A823D817192BABA400B55DE2 /* Supporting Files */,
 				2DC8D9DB1D09F797007DD125 /* UpdateCheck.swift */,
 				2DC8D9DD1D09F9B4007DD125 /* UpdateCheckShim.swift */,
@@ -1523,6 +1537,7 @@
 				11616E11196B0531003D60D9 /* NYPLBookRegistry.m in Sources */,
 				081387571BC574DA003DEA6A /* UILabel+NYPLAppearanceAdditions.m in Sources */,
 				11369D48199527C200BB11F8 /* NYPLJSON.m in Sources */,
+				7327A89323EE017300954748 /* NYPLMainThreadChecker.swift in Sources */,
 				116A5EB91947B57500491A21 /* NYPLConfiguration.m in Sources */,
 				5D1B142A22CC179F0006C964 /* NYPLAlertUtils.swift in Sources */,
 				B51C1E0222861BBF003B49A5 /* OPDS2Publication.swift in Sources */,
@@ -1538,6 +1553,7 @@
 				E694040A1E4A789800E566ED /* NYPLReachabilityManager.m in Sources */,
 				E6845D971FB38D1300EBF69A /* NYPLReadiumViewSyncManager.m in Sources */,
 				A4BA1D0E1B430341006F83DF /* NYPLCatalogGroupedFeedViewController.m in Sources */,
+				732F929323ECB51F0099244C /* NYPLBackgroundExecutor.swift in Sources */,
 				5D1B141522CBE3570006C964 /* NYPLProblemDocument.swift in Sources */,
 				A92FB0F921CDCE3D004740F4 /* NYPLReturnPromptHelper.swift in Sources */,
 				03690E231EB2B35000F75D5F /* NYPLReaderBookmarkCell.swift in Sources */,

--- a/Simplified/NYPLUserNotifications.swift
+++ b/Simplified/NYPLUserNotifications.swift
@@ -7,7 +7,7 @@ let DefaultActionIdentifier = "UNNotificationDefaultActionIdentifier"
 @available (iOS 10.0, *)
 @objcMembers class NYPLUserNotifications: NSObject
 {
-  let unCenter = UNUserNotificationCenter.current()
+  private let unCenter = UNUserNotificationCenter.current()
 
   /// If a user has not yet been presented with Notifications authorization,
   /// defer the presentation for later to maximize acceptance rate. Otherwise,
@@ -144,6 +144,7 @@ extension NYPLUserNotifications: UNUserNotificationCenterDelegate
         completionHandler()
         return
       }
+
       if currentAccount.details?.supportsReservations == true {
         if let holdsTab = NYPLRootTabBarController.shared()?.viewControllers?[2],
         holdsTab.isKind(of: NYPLHoldsNavigationController.self) {
@@ -157,25 +158,60 @@ extension NYPLUserNotifications: UNUserNotificationCenterDelegate
     else if response.actionIdentifier == CheckOutActionIdentifier {
       Log.debug(#file, "'Check Out' Notification Action.")
       let userInfo = response.notification.request.content.userInfo
+      
       guard let bookID = userInfo["bookID"] as? String else {
         Log.error(#file, "Bad user info in Local Notification. UserInfo: \n\(userInfo)")
+        completionHandler()
         return
       }
-      guard let downloadCenter = NYPLMyBooksDownloadCenter.shared(),
-        let book = NYPLBookRegistry.shared().book(forIdentifier: bookID) else {
-          Log.error(#file, "Problem creating book or download center singleton. BookID: \(bookID)")
+      guard let downloadCenter = NYPLMyBooksDownloadCenter.shared() else {
+          Log.error(#file, "Download center singleton is nil!")
+          completionHandler()
+          return
+      }
+      guard let book = NYPLBookRegistry.shared().book(forIdentifier: bookID) else {
+          Log.error(#file, "Problem creating book. BookID: \(bookID)")
+          completionHandler()
           return
       }
 
-      // Asynchronous network task in the background app state.
-      let bgTask = UIApplication.shared.beginBackgroundTask {
-        Log.error(#file, "Background task expired before borrow action could complete.")
-        completionHandler()
-      }
-      downloadCenter.startBorrow(for: book, attemptDownload: false) {
-        completionHandler()
+      borrow(book, inBackgroundFrom: downloadCenter, completion: completionHandler)
+    }
+    else {
+      Log.warn(#file, "Unknown action identifier: \(response.actionIdentifier)")
+      completionHandler()
+    }
+  }
+
+  private func borrow(_ book: NYPLBook,
+                      inBackgroundFrom downloadCenter: NYPLMyBooksDownloadCenter,
+                      completion: @escaping () -> Void) {
+    // Asynchronous network task in the background app state.
+    var bgTask: UIBackgroundTaskIdentifier = .invalid
+    bgTask = UIApplication.shared.beginBackgroundTask {
+      if bgTask != .invalid {
+        Log.warn(#file, "Expiring background borrow task \(bgTask.rawValue)")
+        completion()
         UIApplication.shared.endBackgroundTask(bgTask)
+        bgTask = .invalid
       }
+    }
+
+    Log.debug(#file, "Beginning background borrow task \(bgTask.rawValue)")
+
+    if bgTask == .invalid {
+      Log.debug(#file, "Unable to run borrow task in background")
+    }
+
+    // bg task body
+    downloadCenter.startBorrow(for: book, attemptDownload: false) {
+      completion()
+      guard bgTask != .invalid else {
+        return
+      }
+      Log.info(#file, "Finishing up background borrow task \(bgTask.rawValue)")
+      UIApplication.shared.endBackgroundTask(bgTask)
+      bgTask = .invalid
     }
   }
 }

--- a/Simplified/Utilities/NYPLBackgroundExecutor.swift
+++ b/Simplified/Utilities/NYPLBackgroundExecutor.swift
@@ -1,0 +1,132 @@
+//
+//  NYPLBackgroundExecutor.swift
+//  SimplyE
+//
+//  Created by Ettore Pasquini on 2/6/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import UIKit
+import Dispatch
+
+/**
+ Protocol that should be implemented by a class that wants to schedule work
+ in the background.
+ */
+@objc protocol NYPLBackgroundWorkOwner {
+  /// Implementors should do 2 things:
+  ///
+  /// 1. Create the work item.
+  /// If you're calling this function from ObjC, the work item must be
+  /// created via `dispatch_block_create` to avoid undefined
+  /// behavior (see docs for `dispatch_block_cancel()`).
+  ///
+  /// 2. Invoke the `backgroundWork` parameter from inside the work item.
+  ///
+  /// E.g. at a minimum this means:
+  /// ```objc
+  /// - (dispatch_block_t)setUpWorkItemWrappingBackgroundWork:(void(^)(void))backgroundWork
+  /// {
+  ///   dispatch_block_t workItem = dispatch_block_create(0, ^{
+  ///     backgroundWork();
+  ///   });
+  ///   return workItem;
+  /// }
+  /// ```
+  ///
+  /// `NYPLBackgroundExecutor` will call this function at the right time
+  /// passing in a wrapper `block` that takes care of ending the background
+  /// task for you, performing the appropriate logging.
+  ///
+  /// - Parameter backgroundWork: The block that the owning class should invoke
+  /// from inside the work-item / dispatch-block it created.
+  ///
+  /// - Returns: The created work item. Callers are not required to retain
+  /// this since it will be retained NYPLBackgroundExecutor's queue.
+  ///
+  @objc(setUpWorkItemWrappingBackgroundWork:)
+  func setUpWorkItem(wrapping backgroundWork: @escaping () -> Void) -> (() -> Void)?
+
+  /// The actual expensive / long running work. Don't add any background task
+  /// handling in here!
+  func performBackgroundWork()
+}
+
+/**
+ This class wraps the logic of initiating and ending a background task on behalf
+ of a `owner` in a thread-safe manner.
+
+ The work defined in `NYPLBackgroundWorkOwner::performBackgroundWork` is
+ executed concurrently on the global background queue with the assumption that
+ it is thread-safe.
+ */
+@objc class NYPLBackgroundExecutor: NSObject {
+  private let taskName: String
+  private weak var owner: NYPLBackgroundWorkOwner?
+  private let queue = DispatchQueue.global(qos: .background)
+  private let endLock = NSRecursiveLock()
+  
+  //----------------------------------------------------------------------------
+
+  /// - Parameters:
+  ///   - owner: The object wanting to run an expensive task in the background.
+  ///   - taskName: A name for the task, for debugging/logging purposes.
+  @objc init(owner: NYPLBackgroundWorkOwner, taskName: String) {
+    self.taskName = taskName
+    self.owner = owner
+    super.init()
+  }
+  
+  //----------------------------------------------------------------------------
+
+  /// The owner needs to call this function to perform in the background the
+  ///  work specified in `NYPLBackgroundWorkOwner::performBackgroundWork`.
+  /// All the mechanics of starting and ending a background task (including
+  /// the related logging) are handled here.
+  @objc func dispatchBackgroundWork() {
+    var bgTask: UIBackgroundTaskIdentifier = .invalid
+    
+    func endTaskIfNeeded(context: String, timeRemaining: TimeInterval) {
+      endLock.lock()
+      Log.info(#file, """
+        \(context) \(taskName) background task \(bgTask.rawValue). \
+        Time remaining: \(timeRemaining)
+        """)
+      
+      if bgTask != .invalid {
+        UIApplication.shared.endBackgroundTask(bgTask)
+        bgTask = .invalid
+      }
+      endLock.unlock()
+    }
+    
+    bgTask = UIApplication.shared
+      .beginBackgroundTask(withName: taskName) {
+        endTaskIfNeeded(context: "Expiring",
+                        timeRemaining: UIApplication.shared.backgroundTimeRemaining)
+    }
+
+    Log.debug(#file, "Beginning \(taskName) background task \(bgTask.rawValue)")
+    
+    if bgTask == .invalid {
+      Log.warn(#file, "Unable to run background task \(taskName)")
+    }
+
+    var timeRemaining: TimeInterval = 0.0
+    let workItem = owner?.setUpWorkItem(wrapping: { [weak self] in
+      self?.owner?.performBackgroundWork()
+
+      NYPLMainThreadRun.sync {
+        timeRemaining = UIApplication.shared.backgroundTimeRemaining
+      }
+
+      endTaskIfNeeded(context: "Finishing up", timeRemaining: timeRemaining)
+    })
+    
+    if let backgroundWorkItem = workItem {
+      queue.async(execute: backgroundWorkItem)
+    } else {
+      Log.warn(#file, "No work item available for \(taskName) background task \(bgTask.rawValue)!")
+    }
+  }
+}

--- a/Simplified/Utilities/NYPLMainThreadChecker.swift
+++ b/Simplified/Utilities/NYPLMainThreadChecker.swift
@@ -1,0 +1,51 @@
+//
+//  NYPLMainThreadChecker.swift
+//  SimplyE
+//
+//  Created by Ettore Pasquini on 2/7/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+import Dispatch
+
+@objc class NYPLMainThreadRun: NSObject {
+
+  /// Makes sure to run the specified work item synchronously on the
+  /// main __thread__.
+  /// - Note: If the caller was already executing on the main thread,
+  /// the block is executed immediately on the same queue of the caller, which
+  /// may not be the main queue.
+  /// - See: https://github.com/apple/swift-corelibs-libdispatch/commit/e64e4b962e1f356d7561e7a6103b424f335d85f6
+  /// - Parameters:
+  ///   - work: The block to run on the main thread.
+  static func sync(_ work: () -> Void) {
+    if Thread.isMainThread {
+      work()
+    } else {
+      DispatchQueue.main.sync {
+        work()
+      }
+    }
+  }
+
+  /// Runs the specified work item on the main thread asynchrounously if we
+  /// are not already on the main thread. Otherwise, the work block is run
+  /// synchronously.
+  /// - Note: If the caller was already executing on the main thread,
+  /// the block is executed immediately on the same queue of the caller, which
+  /// may not be the main queue.
+  /// - See: https://github.com/apple/swift-corelibs-libdispatch/commit/e64e4b962e1f356d7561e7a6103b424f335d85f6
+  /// - Parameters:
+  ///   - work: The block to run on the main thread.
+  static func asyncIfNeeded(_ work: @escaping () -> Void) {
+    if Thread.isMainThread {
+      work()
+    } else {
+      DispatchQueue.main.async {
+        work()
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
**What's this do?**
1. Simplifies Background Fetch code in app delegate by removing an additional background task (unneeded since we are already in the background, by definition).
2. For background task execution: it makes sure we are ending the task only once.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2072

**How should this be tested? / Do these changes have associated tests?**
_Background Fetch_: this is hard to test because we do not control when the app delegate callback is called. My suggestion is to leave a device connected to a Mac and inspect the device logs in Console.app, filtering by "[Background Fetch]". Logs should show something like:
```
[Background Fetch] Starting book registry sync. ElapsedTime=0.1 seconds
[Background Fetch] Completed with result [0 or 1. 2 means Fail]. ElapsedTime=2s
OR:
[Background Fetch] Registry sync not needed. ElapsedTime=3s
```
_Background execution, Borrow flow_: reserve a book, wait until the book becomes available and inspect logs filtering by "borrow task". Logs should show:
```
16:35:28.877172-0800	SimplyE	[DEBUG] [11-02-2020 16:35:28] .../NYPLUserNotifications.swift: Beginning background borrow task 3
16:35:33.173449-0800	SimplyE	[INFO] [11-02-2020 16:35:33] .../NYPLUserNotifications.swift: Finishing OR Expiring up background borrow task 3
```
_Background execution, Readium flow_: download a book, tap on Read, put app in background. Filter logs by "NYPLReadiumInit".
```
15:58:56.102824-0800	SimplyE	[DEBUG] [11-02-2020 15:58:56] .../NYPLBackgroundExecutor.swift: Beginning NYPLReadiumInit background task 3
15:58:58.472204-0800	SimplyE	[INFO] [11-02-2020 15:58:58] .../NYPLBackgroundExecutor.swift: Finishing up OR Expiring NYPLReadiumInit background task 3. Time remaining: 28.93609533333438
```

**Dependencies for merging? Releasing to production?**
None. Not releasing to prod.

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 