### PR TITLE
SIMPLY-2491 Fix retain cycles related to URLSession in Settings tab

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		7307A5F423FF2A6000DE53DE /* NYPLStringAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7307A5F323FF2A6000DE53DE /* NYPLStringAdditionsTests.swift */; };
 		7327A89323EE017300954748 /* NYPLMainThreadChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7327A89223EE017300954748 /* NYPLMainThreadChecker.swift */; };
 		732F929323ECB51F0099244C /* NYPLBackgroundExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732F929223ECB51F0099244C /* NYPLBackgroundExecutor.swift */; };
+		73A3EAED2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 73A3EAEC2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m */; };
 		841B55431B740F2700FAC1AF /* NYPLSettingsEULAViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 841B55421B740F2700FAC1AF /* NYPLSettingsEULAViewController.m */; };
 		84B7A3461B84E8FE00584FB2 /* OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3431B84E8FE00584FB2 /* OFL.txt */; };
 		84B7A3471B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3441B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf */; };
@@ -538,6 +539,8 @@
 		7307A5F323FF2A6000DE53DE /* NYPLStringAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLStringAdditionsTests.swift; sourceTree = "<group>"; };
 		7327A89223EE017300954748 /* NYPLMainThreadChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLMainThreadChecker.swift; sourceTree = "<group>"; };
 		732F929223ECB51F0099244C /* NYPLBackgroundExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBackgroundExecutor.swift; sourceTree = "<group>"; };
+		73A3EAEB2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NYPLSettingsAccountURLSessionChallengeHandler.h; sourceTree = "<group>"; };
+		73A3EAEC2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NYPLSettingsAccountURLSessionChallengeHandler.m; sourceTree = "<group>"; };
 		841B55411B740F2700FAC1AF /* NYPLSettingsEULAViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYPLSettingsEULAViewController.h; sourceTree = "<group>"; };
 		841B55421B740F2700FAC1AF /* NYPLSettingsEULAViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYPLSettingsEULAViewController.m; sourceTree = "<group>"; };
 		84B7A3431B84E8FE00584FB2 /* OFL.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OFL.txt; sourceTree = "<group>"; };
@@ -933,6 +936,8 @@
 				5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */,
 				E6202A001DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.h */,
 				E6202A011DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.m */,
+				73A3EAEB2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.h */,
+				73A3EAEC2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m */,
 				E6B1F4FA1DD20EA900D73CA1 /* NYPLSettingsAccountsList.swift */,
 				D787E8431FB6B0290016D9D5 /* NYPLSettingsAdvancedViewController.swift */,
 				841B55411B740F2700FAC1AF /* NYPLSettingsEULAViewController.h */,
@@ -1642,6 +1647,7 @@
 				11C5DCF21976D1E0005A9945 /* NYPLHoldsNavigationController.m in Sources */,
 				A42E0DF11B3F5A490095EBAE /* NYPLRemoteViewController.m in Sources */,
 				E6202A041DD52B8600C99553 /* NYPLWelcomeScreen.swift in Sources */,
+				73A3EAED2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m in Sources */,
 				110AD83D19E497D6005724C3 /* NYPLOPDSAttribute.m in Sources */,
 				1114A6A1195884CB007507A2 /* NYPLCatalogUngroupedFeed.m in Sources */,
 				11C5DCF51976D22F005A9945 /* NYPLHoldsViewController.m in Sources */,

--- a/Simplified.xcodeproj/xcshareddata/xcschemes/Simplified.xcscheme
+++ b/Simplified.xcodeproj/xcshareddata/xcschemes/Simplified.xcscheme
@@ -69,6 +69,18 @@
             ReferencedContainer = "container:Simplified.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "PrefersMallocStackLoggingLite"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
       <LocationScenarioReference
          identifier = "New York, NY, USA"
          referenceType = "1">

--- a/Simplified/NYPLSettingsAccountURLSessionChallengeHandler.h
+++ b/Simplified/NYPLSettingsAccountURLSessionChallengeHandler.h
@@ -1,0 +1,31 @@
+//
+//  NYPLSettingsAccountURLSessionChallengeHandler.h
+//  SimplyE
+//
+//  Created by Ettore Pasquini on 2/21/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ Defines the interface required by the URLSession delegate to perform the
+ authentication challenge.
+ */
+@protocol NYPLSettingsAccountUIDelegate <NSObject>
+@required
+- (NSString *)username;
+- (NSString *)pin;
+@end
+
+/**
+ A class responsible for handling the authentication challenge initiated
+ by the URLSession used in a Settings Account UI context.
+ */
+@interface NYPLSettingsAccountURLSessionChallengeHandler : NSObject <NSURLSessionDelegate>
+
+@property(weak) id<NYPLSettingsAccountUIDelegate> uiDelegate;
+
+- (instancetype)initWithUIDelegate:(id<NYPLSettingsAccountUIDelegate>)uiDelegate;
+
+@end

--- a/Simplified/NYPLSettingsAccountURLSessionChallengeHandler.m
+++ b/Simplified/NYPLSettingsAccountURLSessionChallengeHandler.m
@@ -1,0 +1,39 @@
+//
+//  NYPLSettingsAccountURLSessionChallengeHandler.m
+//  SimplyE
+//
+//  Created by Ettore Pasquini on 2/21/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+#import "NYPLSettingsAccountURLSessionChallengeHandler.h"
+#import "NYPLBasicAuth.h"
+
+@implementation NYPLSettingsAccountURLSessionChallengeHandler
+
+- (instancetype)initWithUIDelegate:(id<NYPLSettingsAccountUIDelegate>)uiDelegate
+{
+  self = [super init];
+  if (self == nil) {
+    return nil;
+  }
+
+  _uiDelegate = uiDelegate;
+  return self;
+}
+
+#pragma mark NSURLSessionDelegate
+
+- (void) URLSession:(__attribute__((unused)) NSURLSession *)session
+               task:(__attribute__((unused)) NSURLSessionTask *)task
+didReceiveChallenge:(NSURLAuthenticationChallenge *const)challenge
+  completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition,
+                              NSURLCredential *credential))completionHandler
+{
+  NYPLBasicAuthCustomHandler(challenge,
+                             completionHandler,
+                             self.uiDelegate.username,
+                             self.uiDelegate.pin);
+}
+
+@end


### PR DESCRIPTION
**What's this do?**
Fixes retain cycles caused by URLSession setup and when executing validating credentials.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2491
While this is not a fix for 2491, memory issues related to network request handling could be cause of hard-to-reproduce bugs. E.g. if the completion closure is living longer that it should, it could keep alive any object that it captured, with unknown side effects.
Since we haven't been able to reproduce the bug on our dev environments, releasing this fix would rule out these known peripheral problems in the code.

**How should this be tested? / Do these changes have associated tests?**
This is affecting sign-in flow from the Settings tab only. So hammering on the Settings page signing in and out of various accounts / libraries would be good.
NB: Similar cycles still exist in the pop-up sign in panel, but that is not the flow described in SIMPLY-2491. We are thinking to address these issues with a larger refactor of the code in these 2 VCs.

**Dependencies for merging? Releasing to production?**
None. 

**Has the application documentation been updated for these changes?**
I will update the JIRA ticket.

**Did someone actually run this code to verify it works?**
@ettore 