### PR TITLE
SIMPLY-2583 Refactor error reporting to Bugsnag wrapper

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -153,7 +153,7 @@
 		5D60D3542297353C001080D0 /* NYPLMigrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D60D3532297353C001080D0 /* NYPLMigrationManager.swift */; };
 		5D73DA4322A080BA00162CB8 /* NYPLMyBooksDownloadCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D73DA3D22A07B9A00162CB8 /* NYPLMyBooksDownloadCenterTests.swift */; };
 		5D7CF86422C19EBA007CAA34 /* NYPLReaderContainerDelegateBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D7CF86322C19EBA007CAA34 /* NYPLReaderContainerDelegateBase.m */; };
-		5D7CF8B922C3FC06007CAA34 /* NYPLBugsnagLogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7CF8B422C3FC06007CAA34 /* NYPLBugsnagLogs.swift */; };
+		5D7CF8B922C3FC06007CAA34 /* NYPLErrorLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7CF8B422C3FC06007CAA34 /* NYPLErrorLogger.swift */; };
 		5D7CF8BC22C42AE2007CAA34 /* LogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7CF8BA22C427F6007CAA34 /* LogTests.swift */; };
 		5DD5674522B303DF001F0C83 /* NYPLDeveloperSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD5674422B303DF001F0C83 /* NYPLDeveloperSettingsTableViewController.swift */; };
 		5DD5677222B7ECE3001F0C83 /* NYPLSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */; };
@@ -529,7 +529,7 @@
 		5D73DA3D22A07B9A00162CB8 /* NYPLMyBooksDownloadCenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLMyBooksDownloadCenterTests.swift; sourceTree = "<group>"; };
 		5D7CF86322C19EBA007CAA34 /* NYPLReaderContainerDelegateBase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NYPLReaderContainerDelegateBase.m; sourceTree = "<group>"; };
 		5D7CF86922C1A2F1007CAA34 /* NYPLReaderContainerDelegateBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NYPLReaderContainerDelegateBase.h; sourceTree = "<group>"; };
-		5D7CF8B422C3FC06007CAA34 /* NYPLBugsnagLogs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLBugsnagLogs.swift; sourceTree = "<group>"; };
+		5D7CF8B422C3FC06007CAA34 /* NYPLErrorLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLErrorLogger.swift; sourceTree = "<group>"; };
 		5D7CF8BA22C427F6007CAA34 /* LogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTests.swift; sourceTree = "<group>"; };
 		5DD5674422B303DF001F0C83 /* NYPLDeveloperSettingsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLDeveloperSettingsTableViewController.swift; sourceTree = "<group>"; };
 		5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSettings.swift; sourceTree = "<group>"; };
@@ -1102,7 +1102,7 @@
 				114C8CD619BE2FD300719B72 /* NYPLAttributedString.m */,
 				A4E254F81B0E610900193FE4 /* NYPLBasicAuth.h */,
 				A4E254F91B0E610900193FE4 /* NYPLBasicAuth.m */,
-				5D7CF8B422C3FC06007CAA34 /* NYPLBugsnagLogs.swift */,
+				5D7CF8B422C3FC06007CAA34 /* NYPLErrorLogger.swift */,
 				E66AE32F1DC0FCFC00124AE2 /* NYPLCirculationAnalytics.swift */,
 				116A5EB71947B57500491A21 /* NYPLConfiguration.h */,
 				116A5EB81947B57500491A21 /* NYPLConfiguration.m */,
@@ -1672,7 +1672,7 @@
 				113DB8A719C24E54004E1154 /* NYPLIndeterminateProgressView.m in Sources */,
 				119BEB89198C43A600121439 /* NSString+NYPLStringAdditions.m in Sources */,
 				E6B6E76F1F6859A4007EE361 /* NYPLKeychainManager.swift in Sources */,
-				5D7CF8B922C3FC06007CAA34 /* NYPLBugsnagLogs.swift in Sources */,
+				5D7CF8B922C3FC06007CAA34 /* NYPLErrorLogger.swift in Sources */,
 				A499BF261B39EFC7002F8B8B /* NYPLOPDSEntryGroupAttributes.m in Sources */,
 				1196F75B1970727C00F62670 /* NYPLMyBooksDownloadCenter.m in Sources */,
 				8C40D6A72375FF8B006EA63B /* NYPLProblemDocumentCacheManager.swift in Sources */,

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -866,7 +866,7 @@ completionHandler:(void (^)(void))handler
          NSError *pDocError = nil;
          UserProfileDocument *pDoc = [UserProfileDocument fromData:data error:&pDocError];
          if (!pDoc) {
-           [NYPLBugsnagLogs reportUserProfileDocumentErrorWithError:pDocError];
+           [NYPLErrorLogger reportUserProfileDocumentErrorWithError:pDocError];
            [self authorizationAttemptDidFinish:NO error:[NSError errorWithDomain:@"NYPLAuth" code:20 userInfo:@{ @"message":@"Error parsing user profile doc" }]];
            return;
          } else {
@@ -915,7 +915,7 @@ completionHandler:(void (^)(void))handler
                   [[NYPLAccount sharedAccount] setDeviceID:deviceID];
                 }];
               } else {
-                [NYPLBugsnagLogs reportLocalAuthFailedWithError:error libraryName:self.currentAccount.name];
+                [NYPLErrorLogger reportLocalAuthFailedWithError:error libraryName:self.currentAccount.name];
               }
               
               [self authorizationAttemptDidFinish:success error:error];
@@ -940,8 +940,8 @@ completionHandler:(void (^)(void))handler
          [self.PINTextField becomeFirstResponder];
        }
 
-       // Report event to bugsnag that login failed
-       [NYPLBugsnagLogs reportRemoteLoginErrorWithUrl:request.URL response:response error:error libraryName:self.currentAccount.name];
+       // Report event that login failed
+       [NYPLErrorLogger reportRemoteLoginErrorWithUrl:request.URL response:response error:error libraryName:self.currentAccount.name];
     
        if ([response.MIMEType isEqualToString:@"application/vnd.opds.authentication.v1.0+json"]) {
          // TODO: Maybe do something special for when we supposedly didn't supply credentials
@@ -949,7 +949,7 @@ completionHandler:(void (^)(void))handler
          NSError *problemDocumentParseError = nil;
          NYPLProblemDocument *problemDocument = [NYPLProblemDocument fromData:data error:&problemDocumentParseError];
          if (problemDocumentParseError) {
-           [NYPLBugsnagLogs logProblemDocumentParseErrorWithError:problemDocumentParseError url:request.URL];
+           [NYPLErrorLogger logProblemDocumentParseErrorWithError:problemDocumentParseError url:request.URL];
          } else if (problemDocument) {
            UIAlertController *alert = [NYPLAlertUtils alertWithTitle:@"SettingsAccountViewControllerLoginFailed" message:@"SettingsAccountViewControllerLoginFailed"];
            [NYPLAlertUtils setProblemDocumentWithController:alert document:problemDocument append:YES];

--- a/Simplified/NYPLBookCellDelegate.m
+++ b/Simplified/NYPLBookCellDelegate.m
@@ -1,4 +1,3 @@
-@import Bugsnag;
 @import MediaPlayer;
 @import NYPLAudiobookToolkit;
 @import PDFRendererProvider;
@@ -227,14 +226,12 @@
 {
   [DefaultAudiobookManager setLogHandler:^(enum LogLevel level, NSString * _Nonnull message, NSError * _Nullable error) {
     if (error) {
-      [Bugsnag notifyError:error block:^(BugsnagCrashReport * _Nonnull report) {
-        report.errorMessage = message;
-      }];
+      [NYPLBugsnagLogs reportError:error message:message];
     } else {
       NSError *error = [NSError errorWithDomain:@"org.nypl.labs.audiobookToolkit" code:0 userInfo:nil];
-      [Bugsnag notifyError:error block:^(BugsnagCrashReport * _Nonnull report) {
-        report.errorMessage = [NSString stringWithFormat:@"Level: %ld. Message: %@", (long)level, message];
-      }];
+      [NYPLBugsnagLogs reportError:error
+                           message:[NSString stringWithFormat:@"Level: %ld. Message: %@",
+                                    (long)level, message]];
     }
   }];
 }

--- a/Simplified/NYPLBookCellDelegate.m
+++ b/Simplified/NYPLBookCellDelegate.m
@@ -226,10 +226,10 @@
 {
   [DefaultAudiobookManager setLogHandler:^(enum LogLevel level, NSString * _Nonnull message, NSError * _Nullable error) {
     if (error) {
-      [NYPLBugsnagLogs reportError:error message:message];
+      [NYPLErrorLogger reportError:error message:message];
     } else {
       NSError *error = [NSError errorWithDomain:@"org.nypl.labs.audiobookToolkit" code:0 userInfo:nil];
-      [NYPLBugsnagLogs reportError:error
+      [NYPLErrorLogger reportError:error
                            message:[NSString stringWithFormat:@"Level: %ld. Message: %@",
                                     (long)level, message]];
     }

--- a/Simplified/NYPLBugsnagLogs.swift
+++ b/Simplified/NYPLBugsnagLogs.swift
@@ -1,3 +1,8 @@
+//
+//  SimplyE
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
 import Foundation
 import Bugsnag
 
@@ -5,8 +10,41 @@ fileprivate let simplyeDomain = "org.nypl.labs.SimplyE"
 fileprivate let nullString = "null"
 fileprivate let tabName = "Extra Data"
 
+@objc enum NYPLSeverity: NSInteger {
+  case error, warning, info
+}
+
 @objcMembers class NYPLBugsnagLogs : NSObject {
-  
+  class func configureCrashAnalytics() {
+    let config = BugsnagConfiguration()
+    config.apiKey = APIKeys.bugsnagID
+
+    #if DEBUG
+    config.releaseStage = "development"
+    #else
+    if releaseStageIsBeta() {
+      config.releaseStage = "beta"
+      if let userID = NYPLAccount.shared()?.barcode {
+        config.setUser(userID, withName: nil, andEmail: nil)
+      }
+    } else {
+      config.releaseStage = "production"
+    }
+    #endif
+
+    Bugsnag.start(with: config)
+  }
+
+  private class func releaseStageIsBeta() -> Bool {
+    guard let receiptURLPath = Bundle.main.appStoreReceiptURL?.path else {
+      // returning true here is somewhat odd, but it was left for backward
+      // compatibility reasons with previous objc code
+      return true
+    }
+
+    return receiptURLPath.contains("sandboxReceipt")
+  }
+
   /**
     Helper method for other logging functions that adds logfile to bugsnag report
     @param metadata report metadata dictionary
@@ -185,7 +223,7 @@ fileprivate let tabName = "Extra Data"
       report.addMetadata(metadata, toTabWithName: tabName)
     })
   }
-  
+
   /**
     Report new app session
     @return
@@ -228,7 +266,7 @@ fileprivate let tabName = "Extra Data"
     @param library library for which the barcode is being created
     @return
    */
-  class func logExceptionToBugsnag(exception: NSException?, library: String?) {
+  class func logBarcodeException(_ exception: NSException?, library: String?) {
     var metadata = [AnyHashable : Any]()
     addAccountInfoToMetadata(&metadata)
     addLogfileToMetadata(&metadata)
@@ -239,6 +277,13 @@ fileprivate let tabName = "Extra Data"
       report.errorMessage = "\(library ?? nullString): \(exception?.name.rawValue ?? nullString). \(exception?.reason ?? nullString)"
       report.addMetadata(metadata, toTabWithName: tabName)
     })
+  }
+
+
+  /// Logs a generic exception.
+  /// - Parameter exception: The exception to be logged.
+  class func logException(_ exception: NSException) {
+    Bugsnag.notify(exception)
   }
   
   /**
@@ -302,5 +347,51 @@ fileprivate let tabName = "Extra Data"
     Bugsnag.notifyError(err, block: { report in
       report.addMetadata(metadata, toTabWithName: tabName)
     })
+  }
+
+
+  /// Report a generic error with a given message.
+  /// - Parameters:
+  ///   - error: The error that occurred.
+  ///   - message: The message to append for more context.
+  /// - Note: Only use from Objc. From Swift, use
+  /// report(:with:severity:groupingHash:context:metadata:).
+  @objc(reportError:message:)
+  class func objc_reportError(_ error: Error, message: String) {
+    report(error, with: message)
+  }
+
+
+  /// Logs a generic error with associated information.
+  /// - Parameters:
+  ///   - error: The error that occurred.
+  ///   - message: An optional message.
+  ///   - severity: How severe the error is.
+  ///   - groupingHash: A string to group similar errors.
+  ///   - context: A string identifying the page/VC where the error occurred.
+  ///   - metadata: Any additional metadata.
+  @objc(reportError:message:severity:groupingHash:context:metadata:)
+  class func report(_ error: Error,
+                    with message: String? = nil,
+                    severity: NYPLSeverity = .error,
+                    groupingHash: String? = nil,
+                    context: String? = nil,
+                    metadata: [AnyHashable : Any]? = nil) {
+    Bugsnag.notifyError(error) { report in
+      report.errorMessage = message
+      switch severity {
+      case .error:
+        report.severity = .error
+      case .warning:
+        report.severity = .warning
+      case .info:
+        report.severity = .info
+      }
+      report.groupingHash = groupingHash
+      report.context = context
+      if let metadata = metadata {
+        report.addMetadata(metadata, toTabWithName: tabName)
+      }
+    }
   }
 }

--- a/Simplified/NYPLConfiguration.h
+++ b/Simplified/NYPLConfiguration.h
@@ -10,8 +10,6 @@
 
 + (BOOL)cardCreationEnabled;
 
-+ (BOOL)releaseStageIsBeta;
-
 // This can be overriden by setting |customMainFeedURL| in NYPLSettings.
 + (NSURL *)mainFeedURL;
 

--- a/Simplified/NYPLConfiguration.m
+++ b/Simplified/NYPLConfiguration.m
@@ -18,8 +18,8 @@
   dispatch_once (&onceToken, ^{
     dispatch_async(dispatch_get_main_queue(), ^{
       if (!TARGET_OS_SIMULATOR) {
-        [NYPLBugsnagLogs configureCrashAnalytics];
-        [NYPLBugsnagLogs reportNewActiveSession];
+        [NYPLErrorLogger configureCrashAnalytics];
+        [NYPLErrorLogger reportNewActiveSession];
       }
     });
   });

--- a/Simplified/NYPLConfiguration.m
+++ b/Simplified/NYPLConfiguration.m
@@ -1,5 +1,3 @@
-@import Bugsnag;
-
 #import "NYPLConfiguration.h"
 #import "NYPLAccount.h"
 #import "NYPLAppDelegate.h"
@@ -19,37 +17,12 @@
   static dispatch_once_t onceToken;
   dispatch_once (&onceToken, ^{
     dispatch_async(dispatch_get_main_queue(), ^{
-      [self configureCrashAnalytics];
+      if (!TARGET_OS_SIMULATOR) {
+        [NYPLBugsnagLogs configureCrashAnalytics];
+        [NYPLBugsnagLogs reportNewActiveSession];
+      }
     });
   });
-}
-
-+ (void)configureCrashAnalytics
-{
-  if (!TARGET_OS_SIMULATOR) {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
-    config.apiKey = [APIKeys bugsnagID];
-
-    if (DEBUG) {
-      config.releaseStage = @"development";
-    } else if ([self releaseStageIsBeta]) {
-      config.releaseStage = @"beta";
-      if ([[NYPLAccount sharedAccount] barcode]) {
-        [config setUser:[[NYPLAccount sharedAccount] barcode] withName:nil andEmail:nil];
-      }
-    } else {
-      config.releaseStage = @"production";
-    }
-
-    [Bugsnag startBugsnagWithConfiguration:config];
-    [NYPLBugsnagLogs reportNewActiveSession];
-  }
-}
-
-+ (BOOL)releaseStageIsBeta
-{
-  NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
-  return ([[receiptURL path] rangeOfString:@"sandboxReceipt"].location != NSNotFound) || TARGET_OS_SIMULATOR;
 }
 
 + (NSURL *)mainFeedURL

--- a/Simplified/NYPLDirectoryManager.swift
+++ b/Simplified/NYPLDirectoryManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Bugsnag
 
 /// Returns the URL of the directory used for storing content and metadata.
 /// The directory is not guaranteed to exist at the time this method is called.
@@ -7,10 +6,9 @@ import Bugsnag
   
   class func current() -> URL? {
     guard let account = AccountsManager.shared.currentAccount else {
-      Bugsnag.notifyError(NSError(domain:"org.nypl.labs.SimplyE", code:11, userInfo:nil)) { report in
-        report.groupingHash = "unexpected-nil-account"
-        report.context = "DirectoryManager::current"
-      }
+      NYPLBugsnagLogs.report(NSError(domain:"org.nypl.labs.SimplyE", code:11, userInfo:nil),
+                             groupingHash: "unexpected-nil-account",
+                             context: "DirectoryManager::current")
       return nil
     }
     return directory(account.uuid)
@@ -20,17 +18,15 @@ import Bugsnag
     let paths = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)
     
     if paths.count < 1 {
-      Bugsnag.notifyError(NSError(domain:"org.nypl.labs.SimplyE", code:12, userInfo:nil)) { report in
-        report.groupingHash = "directory-manager"
-        report.errorMessage = "No valid paths"
-      }
+      NYPLBugsnagLogs.report(NSError(domain:"org.nypl.labs.SimplyE", code:12, userInfo:nil),
+                             with: "No valid paths",
+                             groupingHash: "directory-manager")
       return nil
     } else if paths.count > 1 {
-      Bugsnag.notifyError(NSError(domain:"org.nypl.labs.SimplyE", code:12, userInfo:nil)) { report in
-        report.groupingHash = "directory-manager"
-        report.errorMessage = "Multiple paths"
-        report.severity = BSGSeverity.warning
-      }
+      NYPLBugsnagLogs.report(NSError(domain:"org.nypl.labs.SimplyE", code:12, userInfo:nil),
+                             with: "Multiple paths",
+                             severity: .warning,
+                             groupingHash: "directory-manager")
     }
     
     var directoryURL = URL.init(fileURLWithPath: paths[0]).appendingPathComponent(Bundle.main.object(forInfoDictionaryKey: "CFBundleIdentifier") as! String)

--- a/Simplified/NYPLDirectoryManager.swift
+++ b/Simplified/NYPLDirectoryManager.swift
@@ -6,7 +6,7 @@ import Foundation
   
   class func current() -> URL? {
     guard let account = AccountsManager.shared.currentAccount else {
-      NYPLBugsnagLogs.report(NSError(domain:"org.nypl.labs.SimplyE", code:11, userInfo:nil),
+      NYPLErrorLogger.report(NSError(domain:"org.nypl.labs.SimplyE", code:11, userInfo:nil),
                              groupingHash: "unexpected-nil-account",
                              context: "DirectoryManager::current")
       return nil
@@ -18,12 +18,12 @@ import Foundation
     let paths = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)
     
     if paths.count < 1 {
-      NYPLBugsnagLogs.report(NSError(domain:"org.nypl.labs.SimplyE", code:12, userInfo:nil),
+      NYPLErrorLogger.report(NSError(domain:"org.nypl.labs.SimplyE", code:12, userInfo:nil),
                              with: "No valid paths",
                              groupingHash: "directory-manager")
       return nil
     } else if paths.count > 1 {
-      NYPLBugsnagLogs.report(NSError(domain:"org.nypl.labs.SimplyE", code:12, userInfo:nil),
+      NYPLErrorLogger.report(NSError(domain:"org.nypl.labs.SimplyE", code:12, userInfo:nil),
                              with: "Multiple paths",
                              severity: .warning,
                              groupingHash: "directory-manager")

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -14,7 +14,7 @@ fileprivate let tabName = "Extra Data"
   case error, warning, info
 }
 
-@objcMembers class NYPLBugsnagLogs : NSObject {
+@objcMembers class NYPLErrorLogger : NSObject {
   class func configureCrashAnalytics() {
     let config = BugsnagConfiguration()
     config.apiKey = APIKeys.bugsnagID
@@ -119,7 +119,7 @@ fileprivate let tabName = "Extra Data"
     @param title name of the book
     @return
    */
-  class func reportNilContentCFIToBugsnag(location: NYPLBookLocation?, locationDictionary: Dictionary<String, Any>?, bookId: String?, title: String?) {
+  class func reportNilContentCFI(location: NYPLBookLocation?, locationDictionary: Dictionary<String, Any>?, bookId: String?, title: String?) {
     var metadata = [AnyHashable : Any]()
     metadata["bookID"] = bookId ?? nullString
     metadata["bookTitle"] = title ?? nullString
@@ -210,7 +210,7 @@ fileprivate let tabName = "Extra Data"
     @param accountId id of the account
     @return
    */
-  class func bugsnagLogInvalidLicensorWith(accountId: String?) {
+  class func logInvalidLicensor(withAccountID accountId: String?) {
     var metadata = [AnyHashable : Any]()
     metadata["accountTypeID"] = accountId ?? nullString
     addAccountInfoToMetadata(&metadata)

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -182,7 +182,7 @@ didFinishDownloadingToURL:(NSURL *const)location
     NSError *problemDocumentParseError = nil;
     problemDocument = [NYPLProblemDocument fromData:[NSData dataWithContentsOfURL:location] error:&problemDocumentParseError];
     if (problemDocumentParseError) {
-      [NYPLBugsnagLogs logProblemDocumentParseErrorWithError:problemDocumentParseError url:location];
+      [NYPLErrorLogger logProblemDocumentParseErrorWithError:problemDocumentParseError url:location];
     }
     [[NSFileManager defaultManager] removeItemAtURL:location error:NULL];
     success = NO;
@@ -467,7 +467,7 @@ didCompleteWithError:(NSError *)error
   NYPLBookState state = [[NYPLBookRegistry sharedRegistry] stateForIdentifier:identifier];
   BOOL downloaded = state & (NYPLBookStateDownloadSuccessful | NYPLBookStateUsed);
   if (!book.identifier) {
-    [NYPLBugsnagLogs recordUnexpectedNilIdentifierWithBook:book identifier:identifier title:bookTitle];
+    [NYPLErrorLogger recordUnexpectedNilIdentifierWithBook:book identifier:identifier title:bookTitle];
   }
 
   // Process Adobe Return
@@ -913,7 +913,7 @@ didCompleteWithError:(NSError *)error
 
     if (![self fileURLForBookIndentifier:book.identifier]) {
       [self failDownloadForBook:book];
-      [NYPLBugsnagLogs recordFailureToCopyWithBook:book];
+      [NYPLErrorLogger recordFailureToCopyWithBook:book];
       return;
     }
     

--- a/Simplified/NYPLReaderReadiumView.m
+++ b/Simplified/NYPLReaderReadiumView.m
@@ -563,7 +563,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
     NSString *contentCFI = locationDictionary[@"contentCFI"];
     if (!contentCFI) {
       contentCFI = @"";
-      [NYPLBugsnagLogs reportNilContentCFIToBugsnagWithLocation:location locationDictionary:locationDictionary bookId:self.book.identifier title:self.book.title];
+      [NYPLErrorLogger reportNilContentCFIWithLocation:location locationDictionary:locationDictionary bookId:self.book.identifier title:self.book.title];
     }
     dictionary[@"openPageRequest"] = @{@"idref": locationDictionary[@"idref"], @"elementCfi": contentCFI};
     NYPLLOG_F(@"Readium Initialize: Open Page Req idref: %@ elementCfi: %@", locationDictionary[@"idref"], contentCFI);
@@ -766,7 +766,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 
        if(!result || [result isKindOfClass:[NSNull class]]) {
          NYPLLOG(@"Readium failed to generate a CFI. This is a bug in Readium.");
-         [NYPLBugsnagLogs reportNilContentCFIToBugsnagWithLocation:nil locationDictionary:nil bookId:nil title:nil];
+         [NYPLErrorLogger reportNilContentCFIWithLocation:nil locationDictionary:nil bookId:nil title:nil];
          return;
        }
        NSString *const locationJSON = result;

--- a/Simplified/NYPLReaderTOCViewController.m
+++ b/Simplified/NYPLReaderTOCViewController.m
@@ -1,5 +1,3 @@
-@import Bugsnag;
-
 #import "NYPLConfiguration.h"
 #import "NYPLReaderSettings.h"
 #import "NYPLReaderTOCCell.h"
@@ -289,14 +287,15 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       NSMutableDictionary *metadataParams = [NSMutableDictionary dictionary];
       [metadataParams setObject:[NSNumber numberWithLong:indexPath.row] forKey:@"rowIndex"];
       [metadataParams setObject:[NSNumber numberWithLong:self.bookmarks.count] forKey:@"bookmarkCount"];
-      [Bugsnag notifyError:[NSError errorWithDomain:@"org.nypl.labs.SimplyE" code:11 userInfo:nil]
-                     block:^(BugsnagCrashReport * _Nonnull report) {
-                       report.context = @"NYPLReaderTOCViewController";
-                       report.severity = BSGSeverityWarning;
-                       report.errorMessage = @"Attempting to delete bookmark out of bounds.";
-                       [report addMetadata:metadataParams toTabWithName:@"Extra Data"];
-                     }
-       ];
+      NSError *err = [NSError errorWithDomain:@"org.nypl.labs.SimplyE"
+                                         code:11
+                                     userInfo:nil];
+      [NYPLBugsnagLogs reportError:err
+                           message:@"Attempting to delete bookmark out of bounds."
+                          severity:NYPLSeverityWarning
+                      groupingHash:nil
+                           context:@"NYPLReaderTOCViewController"
+                          metadata:metadataParams];
     }
     [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:(UITableViewRowAnimationFade)];
   }

--- a/Simplified/NYPLReaderTOCViewController.m
+++ b/Simplified/NYPLReaderTOCViewController.m
@@ -290,7 +290,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       NSError *err = [NSError errorWithDomain:@"org.nypl.labs.SimplyE"
                                          code:11
                                      userInfo:nil];
-      [NYPLBugsnagLogs reportError:err
+      [NYPLErrorLogger reportError:err
                            message:@"Attempting to delete bookmark out of bounds."
                           severity:NYPLSeverityWarning
                       groupingHash:nil

--- a/Simplified/NYPLRemoteViewController.m
+++ b/Simplified/NYPLRemoteViewController.m
@@ -159,7 +159,7 @@
     NYPLProblemDocument *pDoc = [NYPLProblemDocument fromData:self.data error:&problemDocumentParseError];
     UIAlertController *alert;
     if (problemDocumentParseError) {
-      [NYPLBugsnagLogs logProblemDocumentParseErrorWithError:problemDocumentParseError url:[self.response URL]];
+      [NYPLErrorLogger logProblemDocumentParseErrorWithError:problemDocumentParseError url:[self.response URL]];
       alert = [NYPLAlertUtils alertWithTitle:@"Error" message:@"Unknown error parsing problem document"];
     } else {
       alert = [NYPLAlertUtils alertWithTitle:pDoc.title message:pDoc.detail];
@@ -209,7 +209,7 @@
   
   if (connection.currentRequest.URL) {
     self.reloadView.hidden = NO;
-    [NYPLBugsnagLogs catalogLoadErrorWithError:error url:self.URL];
+    [NYPLErrorLogger catalogLoadErrorWithError:error url:self.URL];
   }
 
   self.connection = nil;

--- a/Simplified/NYPLReturnPromptHelper.swift
+++ b/Simplified/NYPLReturnPromptHelper.swift
@@ -1,4 +1,7 @@
-import Bugsnag
+//
+//  SimplyE
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
 
 @objcMembers final class NYPLReturnPromptHelper: NSObject {
 
@@ -46,7 +49,7 @@ fileprivate func logKeepAction()
   let keepException = NSException(name:NSExceptionName(rawValue: "NYPLAudiobookKeepException"),
                                   reason:"User chose to keep the audiobook, and not return it.",
                                   userInfo:nil)
-  Bugsnag.notify(keepException)
+  NYPLBugsnagLogs.logException(keepException)
 }
 
 fileprivate func logReturnAction()
@@ -54,5 +57,5 @@ fileprivate func logReturnAction()
   let returnException = NSException(name:NSExceptionName(rawValue: "NYPLAudiobookReturnException"),
                                     reason:"User chose to return the Audiobook early.",
                                     userInfo:nil)
-  Bugsnag.notify(returnException)
+  NYPLBugsnagLogs.logException(returnException)
 }

--- a/Simplified/NYPLReturnPromptHelper.swift
+++ b/Simplified/NYPLReturnPromptHelper.swift
@@ -49,7 +49,7 @@ fileprivate func logKeepAction()
   let keepException = NSException(name:NSExceptionName(rawValue: "NYPLAudiobookKeepException"),
                                   reason:"User chose to keep the audiobook, and not return it.",
                                   userInfo:nil)
-  NYPLBugsnagLogs.logException(keepException)
+  NYPLErrorLogger.logException(keepException)
 }
 
 fileprivate func logReturnAction()
@@ -57,5 +57,5 @@ fileprivate func logReturnAction()
   let returnException = NSException(name:NSExceptionName(rawValue: "NYPLAudiobookReturnException"),
                                     reason:"User chose to return the Audiobook early.",
                                     userInfo:nil)
-  NYPLBugsnagLogs.logException(returnException)
+  NYPLErrorLogger.logException(returnException)
 }

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -432,7 +432,7 @@ double const requestTimeoutInterval = 25.0;
        NSError *pDocError = nil;
        UserProfileDocument *pDoc = [UserProfileDocument fromData:data error:&pDocError];
        if (!pDoc) {
-         [NYPLBugsnagLogs reportUserProfileDocumentErrorWithError:pDocError];
+         [NYPLErrorLogger reportUserProfileDocumentErrorWithError:pDocError];
          [self showLogoutAlertWithError:pDocError responseCode:statusCode];
          [self removeActivityTitle];
          [[UIApplication sharedApplication] endIgnoringInteractionEvents];
@@ -496,7 +496,7 @@ double const requestTimeoutInterval = 25.0;
   NSDictionary *licensor = [self.selectedNYPLAccount licensor];
   if (!licensor) {
     NYPLLOG(@"No Licensor available to deauthorize device. Signing out NYPLAccount creds anyway.");
-    [NYPLBugsnagLogs bugsnagLogInvalidLicensorWithAccountId:self.selectedAccountId];
+    [NYPLErrorLogger logInvalidLicensorWithAccountID:self.selectedAccountId];
     afterDeauthorization();
     return;
   }
@@ -523,7 +523,7 @@ double const requestTimeoutInterval = 25.0;
      if(!success) {
        // Even though we failed, let the user continue to log out.
        // The most likely reason is a user changing their PIN.
-       [NYPLBugsnagLogs deauthorizationError];
+       [NYPLErrorLogger deauthorizationError];
      }
      else {
        NYPLLOG(@"***Successful DRM Deactivation***");
@@ -574,7 +574,7 @@ double const requestTimeoutInterval = 25.0;
   NSError *pDocError = nil;
   UserProfileDocument *pDoc = [UserProfileDocument fromData:data error:&pDocError];
   if (!pDoc) {
-    [NYPLBugsnagLogs reportUserProfileDocumentErrorWithError:pDocError];
+    [NYPLErrorLogger reportUserProfileDocumentErrorWithError:pDocError];
     [self authorizationAttemptDidFinish:NO error:[NSError errorWithDomain:@"NYPLAuth" code:20 userInfo:@{ @"message":@"Error parsing user profile doc" }]];
     return;
   }
@@ -620,7 +620,7 @@ double const requestTimeoutInterval = 25.0;
         [self.selectedNYPLAccount setDeviceID:deviceID];
       }];
     } else {
-      [NYPLBugsnagLogs reportLocalAuthFailedWithError:error libraryName:self.selectedAccount.name];
+      [NYPLErrorLogger reportLocalAuthFailedWithError:error libraryName:self.selectedAccount.name];
     }
 
     [self authorizationAttemptDidFinish:success error:error];
@@ -643,8 +643,8 @@ double const requestTimeoutInterval = 25.0;
     [self.PINTextField becomeFirstResponder];
   }
 
-  // Report event to bugsnag that login failed
-  [NYPLBugsnagLogs reportRemoteLoginErrorWithUrl:request.URL response:response error:error libraryName:self.selectedAccount.name];
+  // Report event that login failed
+  [NYPLErrorLogger reportRemoteLoginErrorWithUrl:request.URL response:response error:error libraryName:self.selectedAccount.name];
 
   if ([response.MIMEType isEqualToString:@"application/vnd.opds.authentication.v1.0+json"]) {
     // TODO: Maybe do something special for when we supposedly didn't supply credentials
@@ -652,7 +652,7 @@ double const requestTimeoutInterval = 25.0;
     NSError *problemDocumentParseError = nil;
     NYPLProblemDocument *problemDocument = [NYPLProblemDocument fromData:data error:&problemDocumentParseError];
     if (problemDocumentParseError) {
-      [NYPLBugsnagLogs logProblemDocumentParseErrorWithError:problemDocumentParseError url:request.URL];
+      [NYPLErrorLogger logProblemDocumentParseErrorWithError:problemDocumentParseError url:request.URL];
     } else if (problemDocument) {
       UIAlertController *alert = [NYPLAlertUtils alertWithTitle:@"SettingsAccountViewControllerLoginFailed" message:@"SettingsAccountViewControllerLoginFailed"];
       [NYPLAlertUtils setProblemDocumentWithController:alert document:problemDocument append:YES];

--- a/Simplified/NYPLZXingEncoder.m
+++ b/Simplified/NYPLZXingEncoder.m
@@ -37,7 +37,9 @@
   }
   @catch (NSException *exception) {
     NYPLLOG_F(@"Exception thrown during barcode image encoding: %@",exception.name);
-    if (exception.name && exception.reason) [NYPLBugsnagLogs logExceptionToBugsnagWithException:exception library:library];
+    if (exception.name && exception.reason) {
+      [NYPLBugsnagLogs logBarcodeException:exception library:library];
+    }
     return nil;
   }
 }

--- a/Simplified/NYPLZXingEncoder.m
+++ b/Simplified/NYPLZXingEncoder.m
@@ -38,7 +38,7 @@
   @catch (NSException *exception) {
     NYPLLOG_F(@"Exception thrown during barcode image encoding: %@",exception.name);
     if (exception.name && exception.reason) {
-      [NYPLBugsnagLogs logBarcodeException:exception library:library];
+      [NYPLErrorLogger logBarcodeException:exception library:library];
     }
     return nil;
   }


### PR DESCRIPTION
**What's this do?**
Replaces all direct calls to Bugsnag with a wrapper call, making NYPLBugsnagLogs (now renamed to NYPLErrorLogger) the only class that depends on Bugsnag.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2583
This is an interim change to ease the upcoming work for actually replacing Bugsnag. This way it's simpler to see how we are using Bugsnag and all we'll need to do to replace it would be to rewrite the calls in NYPLErrorLogger.
It also future-proofs replacing any other future bug/crash reporting tool we want to may use.

**How should this be tested? / Do these changes have associated tests?**
At app startup there's a call to report the app launch. Verifying that that even was recorded before and after this change would verify that Bugsnag is still configured correctly.

**Dependencies for merging? Releasing to production?**
None. Releasable to prod if needed.

**Has the application documentation been updated for these changes?**
I updated the in-code docs.

**Did someone actually run this code to verify it works?**
@ettore 