### PR TITLE
Fix scripts to build 3rd party dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ git clone git@github.com:NYPL-Simplified/Simplified-iOS.git
 git clone git@github.com:NYPL-Simplified/Certificates.git
 cd Simplified-iOS
 ln -s <rmsdk_path>/DRM_Connector_Prerelease adobe-rmsdk
-git checkout master
+git checkout develop
 git submodule update --init --recursive
 ```
 03. Build dependencies (carthage, OpenSSL, cURL). You can also use this script at any other time if you never need to rebuild them: it should be idempotent. The non-optional parameter specifies which configuration of the AudioEngine framework to use. Note that the Release build of AudioEngine does not contain slices for Simulator architectures, causing a Carthage build failure.
 ```bash
-build-3rd-parties-dependencies.sh <Debug | Release>
+./build-3rd-parties-dependencies.sh <Debug | Release>
 ```
 04. Open Simplified.xcodeproj and Build!
 

--- a/build-3rd-parties-dependencies.sh
+++ b/build-3rd-parties-dependencies.sh
@@ -23,8 +23,8 @@ AE_BUILD_CONFIG=$1
 cp ../Certificates/SimplyE/iOS/AudioEngine.json ../Certificates/SimplyE/iOS/bugsnag-dsym-upload.rb .
 cp ../Certificates/SimplyE/iOS/APIKeys.swift Simplified/
 cp ../Certificates/SimplyE/iOS/ReaderClientCertProduction.sig Simplified/ReaderClientCert.sig
-build-carthage.sh $AE_BUILD_CONFIG
-build-openssl-curl.sh
+./build-carthage.sh $AE_BUILD_CONFIG
+./build-openssl-curl.sh
 
 # these commands must always be run from the Simplified-iOS repo root.
 sh adobe-rmsdk-build.sh


### PR DESCRIPTION
**What's this do?**
Update the shell script for building 3rd party dependencies

**Why are we doing this? (w/ JIRA link if applicable)**
Previous script will give `command not found` error when trying to build

**How should this be tested? / Do these changes have associated tests?**
`./build-3rd-parties-dependencies.sh Debug` on `develop` branch
`./build-3rd-parties-dependencies.sh Release` will not build because AudioEngine does not support x86_64 architecture, for detail see [PR#1077](https://github.com/NYPL-Simplified/Simplified-iOS/pull/1077)

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
@ErnestFan 