### PR TITLE
SIMPLY-2590 Replace deprecated method for autorotation

### DIFF
--- a/Simplified/NYPLBarcodeScanningViewController.m
+++ b/Simplified/NYPLBarcodeScanningViewController.m
@@ -85,18 +85,13 @@
   [self dismissViewControllerAnimated:YES completion:nil];
 }
 
-// TODO: remove after fixing SIMPLY-2590
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-implementations"
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
-  return toInterfaceOrientation == UIInterfaceOrientationPortrait;
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
 }
 
-- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
-	[super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
-	[self applyOrientation];
+- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
+    return UIInterfaceOrientationPortrait;
 }
-#pragma clang diagnostic pop
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id <UIViewControllerTransitionCoordinator>)coordinator {
 	[super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];


### PR DESCRIPTION
**What's this do?**
Replace deprecated method with modern method

**Why are we doing this? (w/ JIRA link if applicable)**
Those methods are deprecated in iOS 6.0

**How should this be tested? / Do these changes have associated tests?**
Open barcode scanner in account setting, rotate device and make sure the orientation stays portrait

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@ErnestFan ran this in simulator