### PR TITLE
Bump version to 3.3.6 and fix Firebase dSYM submission

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1596,7 +1596,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"${CONFIGURATION}\" == \"Release\" ]; then\n  \"${PROJECT_DIR}/Carthage/Build/iOS/Fabric.framework/upload-symbols\" -gsp \"$SCRIPT_INPUT_FILE_1\" -p ios \"$SCRIPT_INPUT_FILE_2\"\nelse\n  \"${PROJECT_DIR}/Carthage/Build/iOS/Fabric.framework/run\"\nfi\n";
+			shellScript = "\"${PROJECT_DIR}/Carthage/Build/iOS/Fabric.framework/run\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -2005,7 +2005,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2018,7 +2018,7 @@
 				INFOPLIST_FILE = "Simplified/Simplified-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.3.5;
+				MARKETING_VERSION = 3.3.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
@@ -2049,7 +2049,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2066,7 +2066,7 @@
 				INFOPLIST_FILE = "Simplified/Simplified-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.3.5;
+				MARKETING_VERSION = 3.3.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";

--- a/Simplified.xcodeproj/xcshareddata/xcschemes/Simplified.xcscheme
+++ b/Simplified.xcodeproj/xcshareddata/xcschemes/Simplified.xcscheme
@@ -109,5 +109,23 @@
    <ArchiveAction
       buildConfiguration = "Release"
       revealArchiveInOrganizer = "YES">
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "exec &gt; /tmp/xcode_archive_post_action.log 2&gt;&amp;1&#10;echo &quot;PWD=`pwd`&quot;&#10;echo &quot;ARCHIVE_PATH=$ARCHIVE_PATH&quot;&#10;echo &quot;DWARF_DSYM_FOLDER_PATH=${DWARF_DSYM_FOLDER_PATH}&quot;&#10;echo &quot;DWARF_DSYM_FILE_NAME=${DWARF_DSYM_FILE_NAME}&quot;&#10;&#10;&quot;${PROJECT_DIR}/Carthage/Build/iOS/Fabric.framework/upload-symbols&quot; -gsp &quot;${PROJECT_DIR}/GoogleService-Info.plist&quot; -p ios &quot;${DWARF_DSYM_FOLDER_PATH}&quot;&#10;&#10;&#10;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "A823D80C192BABA400B55DE2"
+                     BuildableName = "SimplyE.app"
+                     BlueprintName = "SimplyE"
+                     ReferencedContainer = "container:Simplified.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
    </ArchiveAction>
 </Scheme>


### PR DESCRIPTION
**What's this do?**
Bumps version number for upcoming release and fixes dSYM submission when archiving.

**Why are we doing this? (w/ JIRA link if applicable)**
Brings `develop` up-to-date with correct version we are releasing.

**How should this be tested? / Do these changes have associated tests?**
For the dSYMs stuff, I tested it by archiving and checking build logs to verify no errors occurred.

**Dependencies for merging? Releasing to production?**
This is just tracking the upcoming release with the correct version number.

**Has the application documentation been updated for these changes?**
Not required.

**Did someone actually run this code to verify it works?**
@ettore 