### PR TITLE
[SIMPLY-2491] Handle error when logging in, report error detail to Crashlytics

### DIFF
--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -64,6 +64,12 @@ fileprivate let nullString = "null"
 
     // ereader
     case deleteBookmarkFail = 500
+    
+    // Parse failure
+    case parseProfileDataCorrupted = 600
+    case parseProfileTypeMismatch = 601
+    case parseProfileValueNotFound = 602
+    case parseProfileKeyNotFound = 603
   }
 
   // MARK:- Generic helpers

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -450,12 +450,13 @@ fileprivate let nullString = "null"
     let err = error ?? NSError.init(domain: simplyeDomain,
                                     code: ErrorCode.userProfileDocFail.rawValue,
                                     userInfo: nil)
-    var metadata = [AnyHashable : Any]()
+    var metadata: [AnyHashable : Any] = error?.userInfo ?? [AnyHashable : Any]()
     metadata["errorDescription"] = error?.localizedDescription ?? nullString
     addAccountInfoToMetadata(&metadata)
     reportLogs()
 
     let userInfo = additionalInfo(severity: .error, metadata: metadata)
+    print("Sending record to Crashlytics")
     Crashlytics.sharedInstance().recordError(err,
                                              withAdditionalUserInfo: userInfo)
   }

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -450,7 +450,7 @@ fileprivate let nullString = "null"
     let err = error ?? NSError.init(domain: simplyeDomain,
                                     code: ErrorCode.userProfileDocFail.rawValue,
                                     userInfo: nil)
-    var metadata: [AnyHashable : Any] = error?.userInfo ?? [AnyHashable : Any]()
+    var metadata = [AnyHashable : Any]()
     metadata["errorDescription"] = error?.localizedDescription ?? nullString
     addAccountInfoToMetadata(&metadata)
     reportLogs()

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -456,7 +456,6 @@ fileprivate let nullString = "null"
     reportLogs()
 
     let userInfo = additionalInfo(severity: .error, metadata: metadata)
-    print("Sending record to Crashlytics")
     Crashlytics.sharedInstance().recordError(err,
                                              withAdditionalUserInfo: userInfo)
   }

--- a/Simplified/NYPLUserProfileDocument.swift
+++ b/Simplified/NYPLUserProfileDocument.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 @objcMembers public class UserProfileDocument : NSObject, Codable {
+  static let parseErrorKey: String = "NYPLParseProfileErrorKey"
+  static let parseErrorDescription: String = "NYPLParseProfileErrorDescription"
+  static let parseErrorCodingPath: String = "NYPLParseProfileErrorCodingPath"
+
+  static let decodingErrorCodeInvalid: Int = 4864
+  static let decodingErrorCodeNotFound: Int = 4865
+    
   @objc @objcMembers public class DRMObject : NSObject, Codable {
     let vendor: String?
     let clientToken: String?
@@ -50,6 +57,13 @@ import Foundation
     case authorizationExpires = "simplified:authorization_expires"
     case settings = "settings"
   }
+    
+  enum NYPLParseProfileErrorKey: Int {
+    case dataCorrupted = 1001
+    case typeMismatch = 1002
+    case valueNotFound = 1003
+    case keyNotFound = 1004
+  }
   
   func toJson() -> String {
     let jsonEncoder = JSONEncoder()
@@ -67,6 +81,32 @@ import Foundation
     dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
     jsonDecoder.dateDecodingStrategy = .formatted(dateFormatter)
     
-    return try jsonDecoder.decode(UserProfileDocument.self, from: data)
+    do {
+      return try jsonDecoder.decode(UserProfileDocument.self, from: data)
+    } catch let DecodingError.dataCorrupted(context) {
+      throw NSError(domain: NSCocoaErrorDomain,
+                    code: decodingErrorCodeInvalid,
+                    userInfo: [parseErrorKey: NYPLParseProfileErrorKey.dataCorrupted.rawValue,
+                               parseErrorDescription: context.debugDescription,
+                               parseErrorCodingPath: context.codingPath])
+    } catch let DecodingError.typeMismatch(_, context) {
+      throw NSError(domain: NSCocoaErrorDomain,
+                    code: decodingErrorCodeInvalid,
+                    userInfo: [parseErrorKey: NYPLParseProfileErrorKey.typeMismatch.rawValue,
+                               parseErrorDescription: context.debugDescription,
+                               parseErrorCodingPath: context.codingPath])
+    } catch let DecodingError.valueNotFound(_, context) {
+      throw NSError(domain: NSCocoaErrorDomain,
+                    code: decodingErrorCodeNotFound,
+                    userInfo: [parseErrorKey: NYPLParseProfileErrorKey.valueNotFound.rawValue,
+                               parseErrorDescription: context.debugDescription,
+                               parseErrorCodingPath: context.codingPath])
+    } catch let DecodingError.keyNotFound(_, context) {
+      throw NSError(domain: NSCocoaErrorDomain,
+                    code: decodingErrorCodeNotFound,
+                    userInfo: [parseErrorKey: NYPLParseProfileErrorKey.keyNotFound.rawValue,
+                               parseErrorDescription: context.debugDescription,
+                               parseErrorCodingPath: context.codingPath])
+    }
   }
 }

--- a/Simplified/NYPLUserProfileDocument.swift
+++ b/Simplified/NYPLUserProfileDocument.swift
@@ -4,9 +4,6 @@ import Foundation
   static let parseErrorKey: String = "NYPLParseProfileErrorKey"
   static let parseErrorDescription: String = "NYPLParseProfileErrorDescription"
   static let parseErrorCodingPath: String = "NYPLParseProfileErrorCodingPath"
-
-  static let decodingErrorCodeInvalid: Int = 4864
-  static let decodingErrorCodeNotFound: Int = 4865
     
   @objc @objcMembers public class DRMObject : NSObject, Codable {
     let vendor: String?
@@ -57,13 +54,6 @@ import Foundation
     case authorizationExpires = "simplified:authorization_expires"
     case settings = "settings"
   }
-    
-  enum NYPLParseProfileErrorKey: Int {
-    case dataCorrupted = 1001
-    case typeMismatch = 1002
-    case valueNotFound = 1003
-    case keyNotFound = 1004
-  }
   
   func toJson() -> String {
     let jsonEncoder = JSONEncoder()
@@ -85,26 +75,26 @@ import Foundation
       return try jsonDecoder.decode(UserProfileDocument.self, from: data)
     } catch let DecodingError.dataCorrupted(context) {
       throw NSError(domain: NSCocoaErrorDomain,
-                    code: decodingErrorCodeInvalid,
-                    userInfo: [parseErrorKey: NYPLParseProfileErrorKey.dataCorrupted.rawValue,
+                    code: NSCoderReadCorruptError,
+                    userInfo: [parseErrorKey: NYPLErrorLogger.ErrorCode.parseProfileDataCorrupted.rawValue,
                                parseErrorDescription: context.debugDescription,
                                parseErrorCodingPath: context.codingPath])
     } catch let DecodingError.typeMismatch(_, context) {
       throw NSError(domain: NSCocoaErrorDomain,
-                    code: decodingErrorCodeInvalid,
-                    userInfo: [parseErrorKey: NYPLParseProfileErrorKey.typeMismatch.rawValue,
+                    code: NSCoderReadCorruptError,
+                    userInfo: [parseErrorKey: NYPLErrorLogger.ErrorCode.parseProfileTypeMismatch.rawValue,
                                parseErrorDescription: context.debugDescription,
                                parseErrorCodingPath: context.codingPath])
     } catch let DecodingError.valueNotFound(_, context) {
       throw NSError(domain: NSCocoaErrorDomain,
-                    code: decodingErrorCodeNotFound,
-                    userInfo: [parseErrorKey: NYPLParseProfileErrorKey.valueNotFound.rawValue,
+                    code: NSCoderValueNotFoundError,
+                    userInfo: [parseErrorKey: NYPLErrorLogger.ErrorCode.parseProfileValueNotFound.rawValue,
                                parseErrorDescription: context.debugDescription,
                                parseErrorCodingPath: context.codingPath])
     } catch let DecodingError.keyNotFound(_, context) {
       throw NSError(domain: NSCocoaErrorDomain,
-                    code: decodingErrorCodeNotFound,
-                    userInfo: [parseErrorKey: NYPLParseProfileErrorKey.keyNotFound.rawValue,
+                    code: NSCoderValueNotFoundError,
+                    userInfo: [parseErrorKey: NYPLErrorLogger.ErrorCode.parseProfileKeyNotFound.rawValue,
                                parseErrorDescription: context.debugDescription,
                                parseErrorCodingPath: context.codingPath])
     }

--- a/SimplifiedTests/UserProfileDocumentTests.swift
+++ b/SimplifiedTests/UserProfileDocumentTests.swift
@@ -3,30 +3,128 @@ import XCTest
 @testable import SimplyE
 
 class UserProfileDocumentTests: XCTestCase {
-  func testParse() {
-    let rawJson = """
-{
-  "simplified:authorization_identifier": "23333999999915",
-  "drm": [
-    {
-      "drm:vendor": "NYPL",
-      "drm:scheme": "http://librarysimplified.org/terms/drm/scheme/ACS",
-      "drm:clientToken": "someToken"
+  let validJson = """
+  {
+    "simplified:authorization_identifier": "23333999999915",
+    "drm": [
+      {
+        "drm:vendor": "NYPL",
+        "drm:scheme": "http://librarysimplified.org/terms/drm/scheme/ACS",
+        "drm:clientToken": "someToken"
+      }
+    ],
+    "links": [
+      {
+        "href": "https://circulation.librarysimplified.org/NYNYPL/AdobeAuth/devices",
+        "rel": "http://librarysimplified.org/terms/drm/rel/devices"
+      }
+    ],
+    "simplified:authorization_expires": "2025-05-01T00:00:00Z",
+    "settings": {
+      "simplified:synchronize_annotations": true
     }
-  ],
-  "links": [
-    {
-      "href": "https://circulation.librarysimplified.org/NYNYPL/AdobeAuth/devices",
-      "rel": "http://librarysimplified.org/terms/drm/rel/devices"
-    }
-  ],
-  "simplified:authorization_expires": "2025-05-01T00:00:00Z",
-  "settings": {
-    "simplified:synchronize_annotations": true
   }
-}
-"""
-    let data = rawJson.data(using: .utf8)
+  """
+
+  let dataCorruptedJson = "lll"
+    
+  let extraPropertyJson = """
+  {
+    "simplified:authorization_identifier": "23333999999915",
+    "drm": [
+      {
+        "drm:vendor": "NYPL",
+        "drm:scheme": "http://librarysimplified.org/terms/drm/scheme/ACS",
+        "drm:clientToken": "someToken",
+        "drm:testExtra":"extra property"
+      }
+    ],
+    "links": [
+      {
+        "href": "https://circulation.librarysimplified.org/NYNYPL/AdobeAuth/devices",
+        "rel": "http://librarysimplified.org/terms/drm/rel/devices",
+        "extra": "http://librarysimplified.org/"
+      }
+    ],
+    "simplified:authorization_expires": "2025-05-01T00:00:00Z",
+    "settings": {
+      "simplified:synchronize_annotations": true,
+      "simplified:extra_annotations": false
+    },
+    "extra_property": false
+  }
+  """
+    
+  let keyNotFoundJson = """
+  {
+    "simplified:authorization_identifier": "23333999999915",
+    "drm": [
+      {
+        "drm:vendor": "NYPL",
+        "drm:scheme": "http://librarysimplified.org/terms/drm/scheme/ACS",
+        "drm:clientToken": "someToken"
+      }
+    ],
+    "links": [
+      {
+        "rel": "http://librarysimplified.org/terms/drm/rel/devices"
+      }
+    ],
+    "simplified:authorization_expires": "2025-05-01T00:00:00Z",
+    "settings": {
+      "simplified:synchronize_annotations": true
+    }
+  }
+  """
+    
+  let mismatchTypeJson = """
+    {
+      "simplified:authorization_identifier": "23333999999915",
+      "drm": [
+        {
+          "drm:vendor": "NYPL",
+          "drm:scheme": "http://librarysimplified.org/terms/drm/scheme/ACS",
+          "drm:clientToken": true
+        }
+      ],
+      "links": [
+        {
+          "href": "https://circulation.librarysimplified.org/NYNYPL/AdobeAuth/devices",
+          "rel": 123
+        }
+      ],
+      "simplified:authorization_expires": "2025-05-01T00:00:00Z",
+      "settings": {
+        "simplified:synchronize_annotations": "true"
+      }
+    }
+    """
+
+  let valueNotFoundJson = """
+  {
+    "simplified:authorization_identifier": "23333999999915",
+    "drm": [
+      {
+        "drm:vendor": "NYPL",
+        "drm:scheme": "http://librarysimplified.org/terms/drm/scheme/ACS",
+        "drm:clientToken": "someToken"
+      }
+    ],
+    "links": [
+      {
+        "href": null,
+        "rel": "http://librarysimplified.org/terms/drm/rel/devices"
+      }
+    ],
+    "simplified:authorization_expires": "2025-05-01T00:00:00Z",
+    "settings": {
+      "simplified:synchronize_annotations": true
+    }
+  }
+  """
+
+  func testParse() {
+    let data = validJson.data(using: .utf8)
     XCTAssertNotNil(data)
     do {
       let pDoc = try UserProfileDocument.fromData(data!)
@@ -60,6 +158,108 @@ class UserProfileDocumentTests: XCTestCase {
       XCTAssertTrue(pDoc.settings?.synchronizeAnnotations ?? false)
     } catch {
       XCTAssert(false, error.localizedDescription)
+    }
+  }
+    
+  func testParseJSONExtraProperty() {
+    let data = extraPropertyJson.data(using: .utf8)
+    XCTAssertNotNil(data)
+    do {
+      let pDoc = try UserProfileDocument.fromData(data!)
+      
+      XCTAssert(pDoc.authorizationIdentifier == "23333999999915")
+      XCTAssertNotNil(pDoc.authorizationExpires)
+      print(pDoc.authorizationExpires!)
+      
+      // Test DRM
+      XCTAssertNotNil(pDoc.drm)
+      if let drms = pDoc.drm {
+        XCTAssert(drms.count == 1)
+        XCTAssert(drms[0].vendor == "NYPL")
+        XCTAssert(drms[0].scheme == "http://librarysimplified.org/terms/drm/scheme/ACS")
+        XCTAssert(drms[0].clientToken == "someToken")
+        XCTAssertNil(drms[0].serverToken)
+      }
+      
+      // Test Links
+      XCTAssertNotNil(pDoc.links)
+      if let links = pDoc.links {
+        XCTAssert(links.count == 1)
+        XCTAssert(links[0].href == "https://circulation.librarysimplified.org/NYNYPL/AdobeAuth/devices")
+        XCTAssert(links[0].rel == "http://librarysimplified.org/terms/drm/rel/devices")
+        XCTAssertNil(links[0].type)
+        XCTAssertNil(links[0].templated)
+      }
+      
+      // Test Settings
+      XCTAssertNotNil(pDoc.settings)
+      XCTAssertTrue(pDoc.settings?.synchronizeAnnotations ?? false)
+    } catch {
+      XCTAssert(false, error.localizedDescription)
+    }
+  }
+    
+  func testParseJSONInvalid() {
+    let data = dataCorruptedJson.data(using: .utf8)
+    XCTAssertNotNil(data)
+    
+    do {
+      let _ = try UserProfileDocument.fromData(data!)
+      XCTAssert(false)
+    } catch {
+      let err = error as NSError
+      XCTAssertEqual(err.code, UserProfileDocument.decodingErrorCodeInvalid)
+        
+      let customErrorCode = err.userInfo[UserProfileDocument.parseErrorKey] as? Int ?? -1
+      XCTAssertEqual(customErrorCode, UserProfileDocument.NYPLParseProfileErrorKey.dataCorrupted.rawValue)
+    }
+  }
+    
+  func testParseJSONMissingProperty() {
+    let data = keyNotFoundJson.data(using: .utf8)
+    XCTAssertNotNil(data)
+    
+    do {
+      let _ = try UserProfileDocument.fromData(data!)
+      XCTAssert(false)
+    } catch {
+      let err = error as NSError
+      XCTAssertEqual(err.code, UserProfileDocument.decodingErrorCodeNotFound)
+        
+      let customErrorCode = err.userInfo[UserProfileDocument.parseErrorKey] as? Int ?? -1
+      XCTAssertEqual(customErrorCode, UserProfileDocument.NYPLParseProfileErrorKey.keyNotFound.rawValue)
+    }
+  }
+    
+  func testParseJSONTypeMismatch() {
+    let data = mismatchTypeJson.data(using: .utf8)
+    XCTAssertNotNil(data)
+    
+    do {
+      let _ = try UserProfileDocument.fromData(data!)
+      XCTAssert(false)
+    } catch {
+      let err = error as NSError
+      XCTAssertEqual(err.code, UserProfileDocument.decodingErrorCodeInvalid)
+        
+      let customErrorCode = err.userInfo[UserProfileDocument.parseErrorKey] as? Int ?? -1
+      XCTAssertEqual(customErrorCode, UserProfileDocument.NYPLParseProfileErrorKey.typeMismatch.rawValue)
+    }
+  }
+    
+  func testParseJSONNilValue() {
+    let data = valueNotFoundJson.data(using: .utf8)
+    XCTAssertNotNil(data)
+    
+    do {
+      let _ = try UserProfileDocument.fromData(data!)
+      XCTAssert(false)
+    } catch {
+      let err = error as NSError
+      XCTAssertEqual(err.code, UserProfileDocument.decodingErrorCodeNotFound)
+        
+      let customErrorCode = err.userInfo[UserProfileDocument.parseErrorKey] as? Int ?? -1
+      XCTAssertEqual(customErrorCode, UserProfileDocument.NYPLParseProfileErrorKey.valueNotFound.rawValue)
     }
   }
 }

--- a/SimplifiedTests/UserProfileDocumentTests.swift
+++ b/SimplifiedTests/UserProfileDocumentTests.swift
@@ -208,10 +208,13 @@ class UserProfileDocumentTests: XCTestCase {
       XCTAssert(false)
     } catch {
       let err = error as NSError
-      XCTAssertEqual(err.code, UserProfileDocument.decodingErrorCodeInvalid)
+      XCTAssertEqual(err.code, NSCoderReadCorruptError)
         
-      let customErrorCode = err.userInfo[UserProfileDocument.parseErrorKey] as? Int ?? -1
-      XCTAssertEqual(customErrorCode, UserProfileDocument.NYPLParseProfileErrorKey.dataCorrupted.rawValue)
+      guard let customErrorCode = err.userInfo[UserProfileDocument.parseErrorKey] as? Int else {
+        XCTFail()
+        return
+      }
+      XCTAssertEqual(customErrorCode, NYPLErrorLogger.ErrorCode.parseProfileDataCorrupted.rawValue)
     }
   }
     
@@ -224,10 +227,13 @@ class UserProfileDocumentTests: XCTestCase {
       XCTAssert(false)
     } catch {
       let err = error as NSError
-      XCTAssertEqual(err.code, UserProfileDocument.decodingErrorCodeNotFound)
+      XCTAssertEqual(err.code, NSCoderValueNotFoundError)
         
-      let customErrorCode = err.userInfo[UserProfileDocument.parseErrorKey] as? Int ?? -1
-      XCTAssertEqual(customErrorCode, UserProfileDocument.NYPLParseProfileErrorKey.keyNotFound.rawValue)
+      guard let customErrorCode = err.userInfo[UserProfileDocument.parseErrorKey] as? Int else {
+        XCTFail()
+        return
+      }
+      XCTAssertEqual(customErrorCode, NYPLErrorLogger.ErrorCode.parseProfileKeyNotFound.rawValue)
     }
   }
     
@@ -240,10 +246,13 @@ class UserProfileDocumentTests: XCTestCase {
       XCTAssert(false)
     } catch {
       let err = error as NSError
-      XCTAssertEqual(err.code, UserProfileDocument.decodingErrorCodeInvalid)
+      XCTAssertEqual(err.code, NSCoderReadCorruptError)
         
-      let customErrorCode = err.userInfo[UserProfileDocument.parseErrorKey] as? Int ?? -1
-      XCTAssertEqual(customErrorCode, UserProfileDocument.NYPLParseProfileErrorKey.typeMismatch.rawValue)
+      guard let customErrorCode = err.userInfo[UserProfileDocument.parseErrorKey] as? Int else {
+        XCTFail()
+        return
+      }
+      XCTAssertEqual(customErrorCode, NYPLErrorLogger.ErrorCode.parseProfileTypeMismatch.rawValue)
     }
   }
     
@@ -256,10 +265,13 @@ class UserProfileDocumentTests: XCTestCase {
       XCTAssert(false)
     } catch {
       let err = error as NSError
-      XCTAssertEqual(err.code, UserProfileDocument.decodingErrorCodeNotFound)
+      XCTAssertEqual(err.code, NSCoderValueNotFoundError)
         
-      let customErrorCode = err.userInfo[UserProfileDocument.parseErrorKey] as? Int ?? -1
-      XCTAssertEqual(customErrorCode, UserProfileDocument.NYPLParseProfileErrorKey.valueNotFound.rawValue)
+      guard let customErrorCode = err.userInfo[UserProfileDocument.parseErrorKey] as? Int else {
+        XCTFail()
+        return
+      }
+      XCTAssertEqual(customErrorCode, NYPLErrorLogger.ErrorCode.parseProfileValueNotFound.rawValue)
     }
   }
 }


### PR DESCRIPTION
**What's this do?**
Throw custom NSError when parsing UserProfileDocument, with unit tests
Log error detail to Crashlytics

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-2491](https://jira.nypl.org/browse/SIMPLY-2491?filter=-1)

**How should this be tested? / Do these changes have associated tests?**
Manually tested with dummy data since we are unable to reproduce the error

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@ErnestFan 