### PR TITLE
[Refactor] UIColor+LabelColor extension

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		148B1C2D21768EAA00FF64AB /* NYPLAEToolkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 148B1C1721710C6800FF64AB /* NYPLAEToolkit.framework */; };
 		148B1C2E21768EAA00FF64AB /* NYPLAudiobookToolkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 148B1C1C21710C6800FF64AB /* NYPLAudiobookToolkit.framework */; };
 		148B1C392176900F00FF64AB /* AudioEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 148B1C342176900E00FF64AB /* AudioEngine.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		179699D124131BA500EC309F /* UIColor+LabelColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179699D024131BA500EC309F /* UIColor+LabelColor.swift */; };
 		2D2B477C1D08F821007F7764 /* UpdateCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D2B47631D08F1ED007F7764 /* UpdateCheckTests.swift */; };
 		2D2B477E1D08F82C007F7764 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D382BD61D08BA99002C423D /* Log.swift */; };
 		2D2B47841D08F8E2007F7764 /* UpdateCheckUpToDate.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D2B47691D08F264007F7764 /* UpdateCheckUpToDate.json */; };
@@ -491,6 +492,7 @@
 		148B1C1721710C6800FF64AB /* NYPLAEToolkit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NYPLAEToolkit.framework; path = Carthage/Build/iOS/NYPLAEToolkit.framework; sourceTree = "<group>"; };
 		148B1C1C21710C6800FF64AB /* NYPLAudiobookToolkit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NYPLAudiobookToolkit.framework; path = Carthage/Build/iOS/NYPLAudiobookToolkit.framework; sourceTree = "<group>"; };
 		148B1C342176900E00FF64AB /* AudioEngine.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioEngine.framework; path = Carthage/Build/iOS/AudioEngine.framework; sourceTree = "<group>"; };
+		179699D024131BA500EC309F /* UIColor+LabelColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+LabelColor.swift"; sourceTree = "<group>"; };
 		2D2B47621D08F1ED007F7764 /* SimplyETests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SimplyETests-Bridging-Header.h"; sourceTree = "<group>"; };
 		2D2B47631D08F1ED007F7764 /* UpdateCheckTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateCheckTests.swift; sourceTree = "<group>"; };
 		2D2B47691D08F264007F7764 /* UpdateCheckUpToDate.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UpdateCheckUpToDate.json; sourceTree = "<group>"; };
@@ -794,6 +796,7 @@
 				081387591BC5767F003DEA6A /* UIButton+NYPLAppearanceAdditions.m */,
 				5DD567B422B97344001F0C83 /* Data+Base64.swift */,
 				5DD567AE22B95A30001F0C83 /* String+MD5.swift */,
+				179699D024131BA500EC309F /* UIColor+LabelColor.swift */,
 			);
 			name = Additions;
 			sourceTree = "<group>";
@@ -1745,6 +1748,7 @@
 				B51C1E0022861BAD003B49A5 /* OPDS2Link.swift in Sources */,
 				E6DA7EA01F2A718600CFBEC8 /* NYPLBookAuthor.swift in Sources */,
 				118A0B1B19915BDF00792DDE /* NYPLCatalogSearchViewController.m in Sources */,
+				179699D124131BA500EC309F /* UIColor+LabelColor.swift in Sources */,
 				A4E254FA1B0E610900193FE4 /* NYPLBasicAuth.m in Sources */,
 				1188F3E11A1ECC4B006B2F36 /* NYPLReaderSettings.m in Sources */,
 				A949984F2235826500CE4241 /* NYPLPDFViewControllerDelegate.swift in Sources */,

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -796,7 +796,6 @@
 				081387591BC5767F003DEA6A /* UIButton+NYPLAppearanceAdditions.m */,
 				5DD567B422B97344001F0C83 /* Data+Base64.swift */,
 				5DD567AE22B95A30001F0C83 /* String+MD5.swift */,
-				179699D024131BA500EC309F /* UIColor+LabelColor.swift */,
 			);
 			name = Additions;
 			sourceTree = "<group>";
@@ -1046,6 +1045,7 @@
 				7327A89223EE017300954748 /* NYPLMainThreadChecker.swift */,
 				111559EB19B8FA530003BE94 /* NYPLXML.h */,
 				111559EC19B8FA590003BE94 /* NYPLXML.m */,
+				179699D024131BA500EC309F /* UIColor+LabelColor.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -740,17 +740,9 @@ completionHandler:(void (^)(void))handler
     } else {
       self.usernameTextField.text = nil;
       self.usernameTextField.enabled = YES;
-      if (@available(iOS 13.0, *)) {
-        self.usernameTextField.textColor = [UIColor labelColor];
-      } else {
-        self.usernameTextField.textColor = [UIColor blackColor];
-      }
+      self.usernameTextField.textColor = [UIColor defaultLabelColor];
       self.PINTextField.text = nil;
-      if (@available(iOS 13.0, *)) {
-        self.PINTextField.textColor = [UIColor labelColor];
-      } else {
-        self.PINTextField.textColor = [UIColor blackColor];
-      }
+      self.PINTextField.textColor = [UIColor defaultLabelColor];
     }
     
     [self.tableView reloadData];

--- a/Simplified/NYPLBookDetailView.m
+++ b/Simplified/NYPLBookDetailView.m
@@ -197,9 +197,7 @@ static NSString *DetailHTMLTemplate = nil;
     NSAttributedString *atrString = [[NSAttributedString alloc] initWithData:htmlData options:attributes documentAttributes:nil error:nil];
     self.summaryTextView.attributedText = atrString;
 
-    if (@available(iOS 13, *)) {
-      self.summaryTextView.textColor = UIColor.labelColor;
-    }
+    self.summaryTextView.textColor = UIColor.defaultLabelColor;
   }];
 
   self.readMoreLabel = [[UIButton alloc] init];

--- a/Simplified/NYPLConfiguration.m
+++ b/Simplified/NYPLConfiguration.m
@@ -55,10 +55,7 @@
   if (account.details.mainColor) {
     return [NYPLAppTheme themeColorFromStringWithName:account.details.mainColor];
   } else {
-    if (@available(iOS 13, *)) {
-      return [UIColor labelColor];
-    }
-    return [UIColor blackColor];
+    return [UIColor defaultLabelColor];
   }
 }
 

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -1048,11 +1048,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       
       UIImageView *accessoryView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:(self.selectedAccount.details.userAboveAgeLimit ? @"CheckboxOn" : @"CheckboxOff")]];
       accessoryView.image = [accessoryView.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-      if (@available(iOS 13, *)) {
-        accessoryView.tintColor = [UIColor labelColor];
-      } else {
-        accessoryView.tintColor = [UIColor blackColor];
-      }
+      accessoryView.tintColor = [UIColor defaultLabelColor];
       self.ageCheckCell.accessoryView = accessoryView;
       
       self.ageCheckCell.selectionStyle = UITableViewCellSelectionStyleNone;
@@ -1276,11 +1272,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
                     initWithString:NSLocalizedString(@"SigningInAgree", nil) attributes:linkAttributes];
     } else {
       NSDictionary *attrs;
-      if (@available(iOS 13.0, *)) {
-        attrs = @{ NSForegroundColorAttributeName : [UIColor labelColor] };
-      } else {
-        attrs = @{ NSForegroundColorAttributeName : [UIColor blackColor] };
-      }
+      attrs = @{ NSForegroundColorAttributeName : [UIColor defaultLabelColor] };
       eulaString = [[NSMutableAttributedString alloc]
                     initWithString:NSLocalizedString(@"SettingsAccountSyncFooterTitle",
                                                      @"Explain to the user they can save their bookmarks in the cloud across all their devices.")
@@ -1446,17 +1438,9 @@ replacementString:(NSString *)string
     } else {
       self.usernameTextField.text = nil;
       self.usernameTextField.enabled = YES;
-      if (@available(iOS 13.0, *)) {
-        self.usernameTextField.textColor = [UIColor labelColor];
-      } else {
-        self.usernameTextField.textColor = [UIColor blackColor];
-      }
+      self.usernameTextField.textColor = [UIColor defaultLabelColor];
       self.PINTextField.text = nil;
-      if (@available(iOS 13.0, *)) {
-        self.PINTextField.textColor = [UIColor labelColor];
-      } else {
-        self.PINTextField.textColor = [UIColor blackColor];
-      }
+      self.PINTextField.textColor = [UIColor defaultLabelColor];
       self.barcodeScanButton.hidden = NO;
     }
     

--- a/Simplified/UIColor+LabelColor.swift
+++ b/Simplified/UIColor+LabelColor.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+@objc extension UIColor {
+  @objc class public func defaultLabelColor() -> UIColor {
+    if #available(iOS 13, *) {
+      return UIColor.label;
+    } else {
+      return UIColor.black;
+    }
+  }
+}

--- a/Simplified/Utilities/UIColor+LabelColor.swift
+++ b/Simplified/Utilities/UIColor+LabelColor.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-@objc extension UIColor {
+extension UIColor {
   @objc class public func defaultLabelColor() -> UIColor {
     if #available(iOS 13, *) {
       return UIColor.label;


### PR DESCRIPTION
**What's this do?**
Refactor the usage of UIColor.label into an extension

**Why are we doing this? (w/ JIRA link if applicable)**
See [PR 1096](https://github.com/NYPL-Simplified/Simplified-iOS/pull/1096)

**How should this be tested? / Do these changes have associated tests?**
Checked the text color in simulator in both normal and dark mode, nothing changed

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@ErnestFan 
