### PR TITLE
Upgrade to ADEPT wrapper 1.0.2 + minor carthage improvements

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 binary "Crashlytics.json" "3.14.0"
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "6.17.0"
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "6.18.0"
 github "NYPL-Simplified/CardCreator-iOS" "v1.1.2"
 github "NYPL-Simplified/NYPLAEToolkit" "27c08e76cb46985f7861cce50782972b8e05e6fa"
 github "NYPL-Simplified/NYPLAudiobookToolkit" "010c2b066c51672fc0bbb4abac485b0cdde1025e"

--- a/README.md
+++ b/README.md
@@ -28,11 +28,15 @@ git submodule update --init --recursive
 
 To build all Carthage dependencies from scratch you can use the following script. Note that this will wipe the Carthage folder if you already have it:
 ```bash
-build-carthage.sh <Debug | Release>
+./build-carthage.sh <Debug | Release>
+```
+To run a `carthage update`, use the following script to avoid AudioEngine errors. Note, this will rebuild all Carthage dependencies:
+```bash
+./carthage-update-simplye.sh <Debug | Release>
 ```
 To build OpenSSL and cURL from scratch, you can use the following script:
 ```bash
-build-openssl-curl.sh
+./build-openssl-curl.sh
 ```
 Both scripts must be run from the Simplified-iOS repo root.
 

--- a/build-carthage.sh
+++ b/build-carthage.sh
@@ -72,4 +72,5 @@ cp -R AudioEngine/$AE_BUILD_CONFIG/AudioEngine.framework Build/iOS
 sed -i '' '/binary "AudioEngine.json".*/d' Checkouts/NYPLAEToolkit/Cartfile
 sed -i '' '/binary "AudioEngine.json".*/d' Checkouts/NYPLAEToolkit/Cartfile.resolved
 cd ..
+sed -i '' '/binary "AudioEngine.json".*/d' Cartfile.resolved
 carthage build --platform ios

--- a/carthage-update-simplye.sh
+++ b/carthage-update-simplye.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+  echo "Please specify which AudioEngine configuration you would like to use:"
+  echo "    $0 [Debug | Release]"
+  exit 1
+fi
+
+AE_BUILD_CONFIG=$1
+
+carthage update --no-build
+
+./build-carthage.sh $AE_BUILD_CONFIG


### PR DESCRIPTION
**What's this do?**
Updates to latest NYPL's iOS wrapper for Adobe ADEPT lib and latest Firebase Crashlytics. Also adds a script to run carthage update without errors related to AudioEngine.

**Why are we doing this? (w/ JIRA link if applicable)**
Running a normal `carthage update` would inevitably cause errors related to AudioEngine, so I added a little script that can do that and rebuild. The Crashlytics upgrade fixes some occasional linker build issues. The upgrade for the DRM wrapper fixes some warnings that recently popped up.

**How should this be tested? / Do these changes have associated tests?**
Not necessary. These are very minor upgrades. I did verify Crashlytics reporting is still working.

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 