### PR TITLE
SIMPLY-2663 Remove call to QA library registry if using prod

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -2044,7 +2044,7 @@
 				INFOPLIST_FILE = "Simplified/Simplified-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.3.6;
+				MARKETING_VERSION = 3.3.7;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
@@ -2092,7 +2092,7 @@
 				INFOPLIST_FILE = "Simplified/Simplified-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.3.6;
+				MARKETING_VERSION = 3.3.7;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";

--- a/Simplified/Account.swift
+++ b/Simplified/Account.swift
@@ -1,3 +1,8 @@
+
+private let userAcceptedEULAKey          = "NYPLSettingsUserAcceptedEULA"
+private let userAboveAgeKey              = "NYPLSettingsUserAboveAgeKey"
+private let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
+
 // MARK: AccountDetails
 // Extra data that gets loaded from an OPDS2AuthenticationDocument,
 @objcMembers final class AccountDetails: NSObject {

--- a/Simplified/AccountsManager.swift
+++ b/Simplified/AccountsManager.swift
@@ -1,13 +1,11 @@
 import Foundation
 
 let currentAccountIdentifierKey  = "NYPLCurrentAccountIdentifier"
-let userAboveAgeKey              = "NYPLSettingsUserAboveAgeKey"
-let userAcceptedEULAKey          = "NYPLSettingsUserAcceptedEULA"
-let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
-let betaUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries/qa")!
-let prodUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries")!
-let betaUrlHash = betaUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
-let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+
+private let betaUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries/qa")!
+private let prodUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries")!
+private let betaUrlHash = betaUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
 
 /**
  Switchboard for fetching data, whether it's from a cache source or fresh from the endpoint.
@@ -28,16 +26,16 @@ func loadDataWithCache(url: URL, cacheUrl: URL, expiryUnit: Calendar.Component =
         return
       }
     }
-    
+
     if options.contains(.cacheOnly) {
       completion(nil)
       return
     }
   }
-  
+
   // Load data from the internet if either the cache wasn't recent enough (or preferred), or somehow failed to load
   let request = URLRequest.init(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 60)
-  
+
   let dataTask = URLSession.shared.dataTask(with: request) { (data, response, error) in
     guard let data = data, let response = response as? HTTPURLResponse, response.statusCode == 200 else {
       completion(nil)
@@ -67,21 +65,21 @@ func loadDataWithCache(url: URL, cacheUrl: URL, expiryUnit: Calendar.Component =
     static let strict_offline: LoadOptions = [.preferCache, .cacheOnly]
   }
 
-  static let shared = AccountsManager()
   static let NYPLAccountUUIDs = [
     "urn:uuid:065c0c11-0d0f-42a3-82e4-277b18786949",
     "urn:uuid:edef2358-9f6a-4ce6-b64f-9b351ec68ac4",
     "urn:uuid:56906f26-2c9a-4ae9-bd02-552557720b99"
   ]
   
+  static let shared = AccountsManager()
+
   // For Objective-C classes
   class func sharedInstance() -> AccountsManager {
-    return AccountsManager.shared
+    return shared
   }
   
-  let defaults: UserDefaults
   var accountSet: String
-  var accountSets = [String: [Account]]()
+  private var accountSets = [String: [Account]]()
   
   var accountsHaveLoaded: Bool {
     if let accounts = accountSets[accountSet] {
@@ -94,20 +92,20 @@ func loadDataWithCache(url: URL, cacheUrl: URL, expiryUnit: Calendar.Component =
   
   var currentAccount: Account? {
     get {
-      return account(defaults.string(forKey: currentAccountIdentifierKey) ?? "")
+      return account(UserDefaults.standard.string(forKey: currentAccountIdentifierKey) ?? "")
     }
     set {
-      defaults.set(newValue?.uuid, forKey: currentAccountIdentifierKey)
+      UserDefaults.standard.set(newValue?.uuid,
+                                forKey: currentAccountIdentifierKey)
       NotificationCenter.default.post(name: NSNotification.Name.NYPLCurrentAccountDidChange, object: nil)
     }
   }
   
   var currentAccountId: String? {
-    return defaults.string(forKey: currentAccountIdentifierKey)
+    return UserDefaults.standard.string(forKey: currentAccountIdentifierKey)
   }
 
-  fileprivate override init() {
-    self.defaults = UserDefaults.standard
+  private override init() {
     self.accountSet = NYPLSettings.shared.useBetaLibraries ? betaUrlHash : prodUrlHash
     
     super.init()
@@ -120,9 +118,6 @@ func loadDataWithCache(url: URL, cacheUrl: URL, expiryUnit: Calendar.Component =
     )
     DispatchQueue.main.async {
       self.loadCatalogs(options: .offline, completion: {_ in })
-    }
-    DispatchQueue.main.async {
-      self.loadCatalogs(options: .strict_offline, url: NYPLSettings.shared.useBetaLibraries ? prodUrl : betaUrl, completion: { _ in })
     }
   }
   
@@ -147,7 +142,7 @@ func loadDataWithCache(url: URL, cacheUrl: URL, expiryUnit: Calendar.Component =
    @param key the key for the completion handler list, since there are multiple
    @param success success indicator to pass on to each handler
    */
-  func callAndClearLoadingCompletionHandlers(key: String, _ success: Bool) {
+  private func callAndClearLoadingCompletionHandlers(key: String, _ success: Bool) {
     var handlers = [(Bool) -> ()]()
     completionHandlerAccessQueue.sync {
       if let h = loadingCompletionHandlers[key] {
@@ -160,18 +155,30 @@ func loadDataWithCache(url: URL, cacheUrl: URL, expiryUnit: Calendar.Component =
     }
   }
   
-  func libraryListCacheUrl(name: String) -> URL {
+  private func libraryListCacheUrl(name: String) -> URL {
     let applicationSupportUrl = try! FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
     let url = applicationSupportUrl.appendingPathComponent("library_list_\(name).json")
     return url
   }
-  
-  // Take the library list data (either from cache or the internet), load it into self.accounts, and load the auth document for the current account if necessary
+
+  /**
+   Take the library list data (either from cache or the internet), load it into
+   self.accounts, and load the auth document for the current account if
+   necessary.
+   - parameter data: The library list data.
+   - parameter options: Load options to determine the behaviour of this method.
+   - parameter key: ???
+   - parameter completion: Always invoked at the end no matter what, providing
+   `true` in case of success and `false` otherwise.
+   */
   private func loadCatalogs(data: Data, options: LoadOptions, key: String, completion: @escaping (Bool) -> ()) {
     do {
       let catalogsFeed = try OPDS2CatalogsFeed.fromData(data)
       let hadAccount = self.currentAccount != nil
       self.accountSets[key] = catalogsFeed.catalogs.map { Account(publication: $0) }
+
+      // note: `currentAccount` computed property feeds off of `accountSets`, so
+      // changing the `accountsSets` dictionary will also change `currentAccount`
       if hadAccount != (self.currentAccount != nil) {
         self.currentAccount?.loadAuthenticationDocument(completion: { (success) in
           if !success {
@@ -206,10 +213,8 @@ func loadDataWithCache(url: URL, cacheUrl: URL, expiryUnit: Calendar.Component =
     }
   }
   
-  func loadCatalogs(options: LoadOptions, url: URL? = nil, completion: @escaping (Bool) -> ()) {
-    let isBeta = NYPLSettings.shared.useBetaLibraries
-    let targetUrl = url != nil ? url! :
-      isBeta ? betaUrl : prodUrl
+  func loadCatalogs(options: LoadOptions, completion: @escaping (Bool) -> ()) {
+    let targetUrl = NYPLSettings.shared.useBetaLibraries ? betaUrl : prodUrl
     let hash = targetUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
     
     let wasAlreadyLoading = addLoadingCompletionHandler(key: hash, completion)
@@ -219,7 +224,9 @@ func loadDataWithCache(url: URL, cacheUrl: URL, expiryUnit: Calendar.Component =
     
     let cacheUrl = libraryListCacheUrl(name: hash)
     
-    loadDataWithCache(url: targetUrl, cacheUrl: cacheUrl, options: options) { (data) in
+    loadDataWithCache(url: targetUrl,
+                      cacheUrl: cacheUrl,
+                      options: options) { data in
       if let data = data {
         self.loadCatalogs(data: data, options: options, key: hash) { (success) in
           self.callAndClearLoadingCompletionHandlers(key: hash, success)


### PR DESCRIPTION
**What's this do?**
This removes a call to the QA library registry if the user is set to use the production library registry. Viceversa, it also removes a call to prod registry when using the QA registry. Essentially, load one or other but never both at the same time. So it should cut library registry times in half.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2663

**How should this be tested? / Do these changes have associated tests?**
You can use a proxy to monitor the network traffic and verify the QA library registry is not being hit. If you enable the QA libraries, you should not see the Prod servers being hit.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Improved docs.

**Did someone actually run this code to verify it works?**
@ettore 