### PR TITLE
SIMPLY-2473 Refactor reader settings view for R2 usage

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -181,6 +181,8 @@
 		733527A524172BD6009E3F19 /* ReaderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733527A424172BD6009E3F19 /* ReaderFactory.swift */; };
 		733DEC9024108D8D008C74BC /* DRMLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733DEC8B24108D8D008C74BC /* DRMLibraryService.swift */; };
 		733DEC92241090C7008C74BC /* NYPLReaderExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733DEC91241090C7008C74BC /* NYPLReaderExtensions.swift */; };
+		734917D1242D77D800059AA5 /* NYPLUserSettingsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734917D0242D77D800059AA5 /* NYPLUserSettingsVC.swift */; };
+		734917DA242EB79700059AA5 /* NYPLR1R2UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734917D9242EB79700059AA5 /* NYPLR1R2UserSettings.swift */; };
 		7360891C240DFBF7007EE66F /* NYPLErrorLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7CF8B422C3FC06007CAA34 /* NYPLErrorLogger.swift */; };
 		738EF2D02405E38800F388FB /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 738EF2CB2405E38800F388FB /* GoogleService-Info.plist */; };
 		738EF2DB2405EA6000F388FB /* Firebase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 738EF2D22405EA5F00F388FB /* Firebase.framework */; };
@@ -604,6 +606,8 @@
 		733527A424172BD6009E3F19 /* ReaderFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderFactory.swift; sourceTree = "<group>"; };
 		733DEC8B24108D8D008C74BC /* DRMLibraryService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DRMLibraryService.swift; sourceTree = "<group>"; };
 		733DEC91241090C7008C74BC /* NYPLReaderExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLReaderExtensions.swift; sourceTree = "<group>"; };
+		734917D0242D77D800059AA5 /* NYPLUserSettingsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserSettingsVC.swift; sourceTree = "<group>"; };
+		734917D9242EB79700059AA5 /* NYPLR1R2UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLR1R2UserSettings.swift; sourceTree = "<group>"; };
 		738EF2CB2405E38800F388FB /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		738EF2D12405E3D900F388FB /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = SOURCE_ROOT; };
 		738EF2D22405EA5F00F388FB /* Firebase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Firebase.framework; path = Carthage/Build/iOS/Firebase.framework; sourceTree = "<group>"; };
@@ -1177,6 +1181,8 @@
 		73F71358241723B100C63B81 /* User Settings */ = {
 			isa = PBXGroup;
 			children = (
+				734917D0242D77D800059AA5 /* NYPLUserSettingsVC.swift */,
+				734917D9242EB79700059AA5 /* NYPLR1R2UserSettings.swift */,
 				73F7135B241723B100C63B81 /* UserSettingsTableViewController.swift */,
 				73F7135C241723B100C63B81 /* AdvancedSettingsViewController.swift */,
 				73F7135F241723B100C63B81 /* UserSettingsNavigationController.swift */,
@@ -1822,6 +1828,7 @@
 				2D382BD71D08BA99002C423D /* Log.swift in Sources */,
 				11616E11196B0531003D60D9 /* NYPLBookRegistry.m in Sources */,
 				081387571BC574DA003DEA6A /* UILabel+NYPLAppearanceAdditions.m in Sources */,
+				734917D1242D77D800059AA5 /* NYPLUserSettingsVC.swift in Sources */,
 				11369D48199527C200BB11F8 /* NYPLJSON.m in Sources */,
 				7327A89323EE017300954748 /* NYPLMainThreadChecker.swift in Sources */,
 				116A5EB91947B57500491A21 /* NYPLConfiguration.m in Sources */,
@@ -1913,6 +1920,7 @@
 				E627B554216D4A9700A7D1D5 /* NYPLBookContentType.m in Sources */,
 				73A229A0240F3BEB006B9EAD /* LibraryModule.swift in Sources */,
 				2D754BC22002F1B10061D34F /* NYPLOPDSIndirectAcquisition.m in Sources */,
+				734917DA242EB79700059AA5 /* NYPLR1R2UserSettings.swift in Sources */,
 				116A5EB3194767DC00491A21 /* NYPLMyBooksViewController.m in Sources */,
 				E6B3269F1EE066DE00DB877A /* NYPLBookDetailTableView.swift in Sources */,
 				8CC26F832370C1DF0000D8E1 /* Account.swift in Sources */,

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -214,7 +214,7 @@
 		73A229AD2410221E006B9EAD /* EPUBModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A229AC2410221E006B9EAD /* EPUBModule.swift */; };
 		73A229AF24102272006B9EAD /* ReaderFormatModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A229AE24102272006B9EAD /* ReaderFormatModule.swift */; };
 		73A3EAED2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 73A3EAEC2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m */; };
-		73F713562417200F00C63B81 /* EPUBViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F713502417200F00C63B81 /* EPUBViewController.swift */; };
+		73F713562417200F00C63B81 /* NYPLEPUBViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F713502417200F00C63B81 /* NYPLEPUBViewController.swift */; };
 		73F713572417200F00C63B81 /* ReaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F713552417200F00C63B81 /* ReaderViewController.swift */; };
 		73F71361241723B100C63B81 /* UserSettings.strings in Resources */ = {isa = PBXBuildFile; fileRef = 73F71359241723B100C63B81 /* UserSettings.strings */; };
 		73F71362241723B100C63B81 /* UserSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F7135B241723B100C63B81 /* UserSettingsTableViewController.swift */; };
@@ -648,7 +648,7 @@
 		73DA43A62404BA5600985482 /* build-carthage.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "build-carthage.sh"; sourceTree = SOURCE_ROOT; };
 		73DA43A72404BA5600985482 /* build_curl.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = build_curl.sh; sourceTree = SOURCE_ROOT; };
 		73DA43A82404BA5600985482 /* build-openssl-curl.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "build-openssl-curl.sh"; sourceTree = SOURCE_ROOT; };
-		73F713502417200F00C63B81 /* EPUBViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EPUBViewController.swift; path = Simplified/Reader2/UI/EPUBViewController.swift; sourceTree = SOURCE_ROOT; };
+		73F713502417200F00C63B81 /* NYPLEPUBViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NYPLEPUBViewController.swift; path = Simplified/Reader2/UI/NYPLEPUBViewController.swift; sourceTree = SOURCE_ROOT; };
 		73F713552417200F00C63B81 /* ReaderViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReaderViewController.swift; path = Simplified/Reader2/UI/ReaderViewController.swift; sourceTree = SOURCE_ROOT; };
 		73F7135A241723B100C63B81 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/UserSettings.strings; sourceTree = "<group>"; };
 		73F7135B241723B100C63B81 /* UserSettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserSettingsTableViewController.swift; sourceTree = "<group>"; };
@@ -1198,7 +1198,7 @@
 			isa = PBXGroup;
 			children = (
 				73F713552417200F00C63B81 /* ReaderViewController.swift */,
-				73F713502417200F00C63B81 /* EPUBViewController.swift */,
+				73F713502417200F00C63B81 /* NYPLEPUBViewController.swift */,
 				733527A424172BD6009E3F19 /* ReaderFactory.swift */,
 				73F713672417240100C63B81 /* UIViewController+NYPL.swift */,
 				73F713692417243200C63B81 /* AssociatedColors.swift */,
@@ -1948,7 +1948,7 @@
 				085D31DF1BE3CD3C007F7672 /* NSURLRequest+NYPLURLRequestAdditions.m in Sources */,
 				11548C0B1939136C009DBF2E /* NYPLRootTabBarController.m in Sources */,
 				E63F2C6C1EAA81B3002B6373 /* ExtendedNavBarView.swift in Sources */,
-				73F713562417200F00C63B81 /* EPUBViewController.swift in Sources */,
+				73F713562417200F00C63B81 /* NYPLEPUBViewController.swift in Sources */,
 				B51C1E0022861BAD003B49A5 /* OPDS2Link.swift in Sources */,
 				E6DA7EA01F2A718600CFBEC8 /* NYPLBookAuthor.swift in Sources */,
 				118A0B1B19915BDF00792DDE /* NYPLCatalogSearchViewController.m in Sources */,

--- a/Simplified/NYPLReaderSettings.h
+++ b/Simplified/NYPLReaderSettings.h
@@ -29,43 +29,36 @@ typedef NS_ENUM(NSInteger, NYPLReaderSettingsMediaOverlaysEnableClick) {
   NYPLReaderSettingsMediaOverlaysEnableClickFalse = 1
 };
 
-static NSString *const NYPLReaderSettingsColorSchemeDidChangeNotification =
-  @"NYPLReaderSettingsColorSchemeDidChange";
-
-static NSString *const NYPLReaderSettingsFontFaceDidChangeNotification =
-  @"NYPLReaderSettingsFontFaceDidChange";
-
-static NSString *const NYPLReaderSettingsFontSizeDidChangeNotification =
-  @"NYPLReaderSettingsFontSizeDidChange";
-
-static NSString *const NYPLReaderSettingsMediaClickOverlayAlwaysEnableDidChangeNotification =
-@"NYPLReaderSettingsMediaClickOverlayAlwaysEnableDidChangeNotification";
+extern NSString * _Nonnull const NYPLReaderSettingsColorSchemeDidChangeNotification;
+extern NSString * _Nonnull const NYPLReaderSettingsFontFaceDidChangeNotification;
+extern NSString * _Nonnull const NYPLReaderSettingsFontSizeDidChangeNotification;
+extern NSString * _Nonnull const NYPLReaderSettingsMediaClickOverlayAlwaysEnableDidChangeNotification;
 
 
 // Returns |YES| if output was set properly, else |NO| due to already being at the smallest size.
 BOOL NYPLReaderSettingsDecreasedFontSize(NYPLReaderSettingsFontSize input,
-                                         NYPLReaderSettingsFontSize *output);
+                                         NYPLReaderSettingsFontSize * _Nullable output);
 
 // Returns |YES| if output was set properly, else |NO| due to already being at the largest size.
 BOOL NYPLReaderSettingsIncreasedFontSize(NYPLReaderSettingsFontSize input,
-                                         NYPLReaderSettingsFontSize *output);
+                                         NYPLReaderSettingsFontSize * _Nullable output);
 
 @interface NYPLReaderSettings : NSObject
 
-+ (NYPLReaderSettings *)sharedSettings;
++ (nonnull NYPLReaderSettings *)sharedSettings;
 
-@property (nonatomic, readonly) UIColor *backgroundColor;
-@property (nonatomic, readonly) UIColor *backgroundMediaOverlayHighlightColor;
+@property (nonnull, nonatomic, readonly) UIColor *backgroundColor;
+@property (nonnull, nonatomic, readonly) UIColor *backgroundMediaOverlayHighlightColor;
 @property (nonatomic) NYPLReaderSettingsColorScheme colorScheme;
 @property (nonatomic) NYPLReaderSettingsFontFace fontFace;
 @property (nonatomic) NYPLReaderSettingsFontSize fontSize;
 @property (nonatomic) NYPLReaderSettingsMediaOverlaysEnableClick mediaOverlaysEnableClick;
-@property (nonatomic, readonly) UIColor *foregroundColor;
+@property (nonnull, nonatomic, readonly) UIColor *foregroundColor;
 
 - (void)save;
 
-- (NSArray *)readiumStylesRepresentation;
+- (nonnull NSArray *)readiumStylesRepresentation;
 
-- (NSDictionary *)readiumSettingsRepresentation;
+- (nonnull NSDictionary *)readiumSettingsRepresentation;
 
 @end

--- a/Simplified/NYPLReaderSettings.h
+++ b/Simplified/NYPLReaderSettings.h
@@ -21,7 +21,8 @@ typedef NS_ENUM(NSInteger, NYPLReaderSettingsFontSize) {
   NYPLReaderSettingsFontSizeLarge = 4,
   NYPLReaderSettingsFontSizeXLarge = 5,
   NYPLReaderSettingsFontSizeXXLarge = 6,
-  NYPLReaderSettingsFontSizeXXXLarge = 7
+  NYPLReaderSettingsFontSizeXXXLarge = 7,
+  NYPLReaderSettingsFontSizeLargest = 7
 };
 
 typedef NS_ENUM(NSInteger, NYPLReaderSettingsMediaOverlaysEnableClick) {

--- a/Simplified/NYPLReaderSettings.m
+++ b/Simplified/NYPLReaderSettings.m
@@ -366,6 +366,7 @@ static NSString *const MediaOverlaysEnableClick = @"mediaOverlaysEnableClick";
     case NYPLReaderSettingsColorSchemeBlackOnWhite:
       return [NYPLConfiguration readerBackgroundColor];
     case NYPLReaderSettingsColorSchemeWhiteOnBlack:
+    default:
       return [NYPLConfiguration readerBackgroundDarkColor];
   }
 }
@@ -378,6 +379,7 @@ static NSString *const MediaOverlaysEnableClick = @"mediaOverlaysEnableClick";
     case NYPLReaderSettingsColorSchemeBlackOnWhite:
       return [NYPLConfiguration backgroundMediaOverlayHighlightColor];
     case NYPLReaderSettingsColorSchemeWhiteOnBlack:
+    default:
       return [NYPLConfiguration backgroundMediaOverlayHighlightDarkColor];
   }
 }
@@ -390,6 +392,7 @@ static NSString *const MediaOverlaysEnableClick = @"mediaOverlaysEnableClick";
     case NYPLReaderSettingsColorSchemeBlackOnWhite:
       return [UIColor blackColor];
     case NYPLReaderSettingsColorSchemeWhiteOnBlack:
+    default:
       return [UIColor whiteColor];
   }
 }

--- a/Simplified/NYPLReaderSettings.m
+++ b/Simplified/NYPLReaderSettings.m
@@ -6,6 +6,18 @@
 
 #import "SimplyE-Swift.h"
 
+NSString *const NYPLReaderSettingsColorSchemeDidChangeNotification =
+@"NYPLReaderSettingsColorSchemeDidChange";
+
+NSString *const NYPLReaderSettingsFontFaceDidChangeNotification =
+@"NYPLReaderSettingsFontFaceDidChange";
+
+NSString *const NYPLReaderSettingsFontSizeDidChangeNotification =
+@"NYPLReaderSettingsFontSizeDidChange";
+
+NSString *const NYPLReaderSettingsMediaClickOverlayAlwaysEnableDidChangeNotification =
+@"NYPLReaderSettingsMediaClickOverlayAlwaysEnableDidChangeNotification";
+
 BOOL NYPLReaderSettingsDecreasedFontSize(NYPLReaderSettingsFontSize const input,
                                          NYPLReaderSettingsFontSize *const output)
 {

--- a/Simplified/NYPLReaderSettingsView.h
+++ b/Simplified/NYPLReaderSettingsView.h
@@ -2,39 +2,49 @@
 
 @class NYPLReaderSettingsView;
 
+//==============================================================================
+
+typedef NS_ENUM(NSUInteger, NYPLReaderFontSizeChange) {
+  NYPLReaderFontSizeChangeIncrease,
+  NYPLReaderFontSizeChangeDecrease,
+};
+
 @protocol NYPLReaderSettingsViewDelegate
 
-- (void)readerSettingsView:(NYPLReaderSettingsView *)readerSettingsView
+- (void)readerSettingsView:(nonnull NYPLReaderSettingsView *)readerSettingsView
        didSelectBrightness:(CGFloat)brightness;
 
-- (void)readerSettingsView:(NYPLReaderSettingsView *)readerSettingsView
+- (void)readerSettingsView:(nonnull NYPLReaderSettingsView *)readerSettingsView
       didSelectColorScheme:(NYPLReaderSettingsColorScheme)colorScheme;
 
-- (void)readerSettingsView:(NYPLReaderSettingsView *)readerSettingsView
-         didSelectFontSize:(NYPLReaderSettingsFontSize)fontSize;
+- (NYPLReaderSettingsFontSize)readerSettingsView:(nonnull NYPLReaderSettingsView *)view
+                               didChangeFontSize:(NYPLReaderFontSizeChange)change;
 
-- (void)readerSettingsView:(NYPLReaderSettingsView *)readerSettingsView
+- (void)readerSettingsView:(nonnull NYPLReaderSettingsView *)readerSettingsView
          didSelectFontFace:(NYPLReaderSettingsFontFace)fontFace;
 
-- (void)readerSettingsView:(NYPLReaderSettingsView *)readerSettingsView
+- (void)readerSettingsView:(nonnull NYPLReaderSettingsView *)readerSettingsView
     didSelectMediaOverlaysEnableClick:(NYPLReaderSettingsMediaOverlaysEnableClick)fontFace;
 @end
 
+//==============================================================================
+/**
+ This class observes brightness change notifications from UIScreen and reflects
+ them visually. It does not, however, change the screen's brightness itself.
+ Objects that use this view should implement its delegate and forward
+ brightness changes to a UIScreen instance as appropriate.
+ */
 @interface NYPLReaderSettingsView : UIView
 
-// This class observes brightness change notifications from UIScreen and reflects them visually. It
-// does not, however, change the screen's brightness itself. Objects that use this view should
-// implement its delegate and forward brightness changes to a UIScreen instance as appropriate.
 @property (nonatomic) NYPLReaderSettingsColorScheme colorScheme;
-@property (nonatomic, weak) id<NYPLReaderSettingsViewDelegate> delegate;
+@property (nonatomic, weak, nullable) id<NYPLReaderSettingsViewDelegate> delegate;
 @property (nonatomic) NYPLReaderSettingsFontSize fontSize;
 @property (nonatomic) NYPLReaderSettingsFontFace fontFace;
 
-+ (id)new NS_UNAVAILABLE;
-- (id)init NS_UNAVAILABLE;
-- (id)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
-- (id)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
-
-- (instancetype)initWithWidth:(CGFloat)width;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)init NS_UNAVAILABLE;
+- (nonnull instancetype)initWithCoder:(nonnull NSCoder *)aDecoder NS_UNAVAILABLE;
+- (nonnull instancetype)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
+- (nonnull instancetype)initWithWidth:(CGFloat)width;
 
 @end

--- a/Simplified/NYPLReaderSettingsView.m
+++ b/Simplified/NYPLReaderSettingsView.m
@@ -538,30 +538,26 @@
 
 - (void)didSelectDecrease
 {
-  NYPLReaderSettingsFontSize newFontSize;
-  
-  if(!NYPLReaderSettingsDecreasedFontSize(self.fontSize, &newFontSize)) {
-    NYPLLOG(@"Ignorning attempt to set font size below the minimum.");
+  if (self.fontSize == NYPLReaderSettingsFontSizeSmallest) {
+    NYPLLOG(@"Ignoring attempt to set font size below the minimum.");
     return;
   }
-  
-  self.fontSize = newFontSize;
-  
-  [self.delegate readerSettingsView:self didSelectFontSize:self.fontSize];
+
+  self.fontSize = [self.delegate
+                   readerSettingsView:self
+                   didChangeFontSize:NYPLReaderFontSizeChangeDecrease];
 }
 
 - (void)didSelectIncrease
 {
-  NYPLReaderSettingsFontSize newFontSize;
-  
-  if(!NYPLReaderSettingsIncreasedFontSize(self.fontSize, &newFontSize)) {
-    NYPLLOG(@"Ignorning attempt to set font size above the maximum.");
+  if (self.fontSize == NYPLReaderSettingsFontSizeXXXLarge) {
+    NYPLLOG(@"Ignoring attempt to set font size above the max.");
     return;
   }
-  
-  self.fontSize = newFontSize;
-  
-  [self.delegate readerSettingsView:self didSelectFontSize:self.fontSize];
+
+  self.fontSize = [self.delegate
+                   readerSettingsView:self
+                   didChangeFontSize:NYPLReaderFontSizeChangeIncrease];
 }
 
 - (void)updateLineViews

--- a/Simplified/NYPLReaderSettingsView.m
+++ b/Simplified/NYPLReaderSettingsView.m
@@ -45,17 +45,20 @@
   NSDictionary *noUnderlineAttribute = @{NSUnderlineStyleAttributeName: @(NSUnderlineStyleNone)};
   
   self.sansButton = [UIButton buttonWithType:UIButtonTypeCustom];
-  
-  
   self.sansButton.accessibilityLabel = [[NSString alloc] initWithFormat:NSLocalizedString(@"SansFont", nil)];
   self.sansButton.backgroundColor = [NYPLConfiguration backgroundColor];
   [self.sansButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
   self.sansButton.titleLabel.font = [UIFont fontWithName:@"Helvetica" size:24];
-  [self.sansButton setAttributedTitle:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"AlphabetFontType", nil)
-                                                                      attributes:noUnderlineAttribute] forState:UIControlStateNormal];
-  
-  [self.sansButton setAttributedTitle:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"AlphabetFontType", nil)
-                                                                      attributes:underlineAttribute] forState:UIControlStateDisabled];
+  [self.sansButton
+   setAttributedTitle:[[NSAttributedString alloc]
+                       initWithString:NSLocalizedString(@"AlphabetFontType", nil)
+                       attributes:noUnderlineAttribute]
+   forState:UIControlStateNormal];
+  [self.sansButton
+   setAttributedTitle:[[NSAttributedString alloc]
+                       initWithString:NSLocalizedString(@"AlphabetFontType", nil)
+                       attributes:underlineAttribute]
+   forState:UIControlStateDisabled];
   
   [self.sansButton addTarget:self
                       action:@selector(didSelectSans)
@@ -68,13 +71,17 @@
   self.serifButton.backgroundColor = [NYPLConfiguration backgroundColor];
   [self.serifButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
   self.serifButton.titleLabel.font = [UIFont fontWithName:@"Georgia" size:24];
-  [self.serifButton setAttributedTitle:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"AlphabetFontType", nil)
-                                                                      attributes:noUnderlineAttribute] forState:UIControlStateNormal];
-  
-  [self.serifButton setAttributedTitle:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"AlphabetFontType", nil)
-                                                                      attributes:underlineAttribute] forState:UIControlStateDisabled];
+  [self.serifButton
+   setAttributedTitle:[[NSAttributedString alloc]
+                       initWithString:NSLocalizedString(@"AlphabetFontType", nil)
+                       attributes:noUnderlineAttribute]
+   forState:UIControlStateNormal];
+  [self.serifButton
+   setAttributedTitle:[[NSAttributedString alloc]
+                       initWithString:NSLocalizedString(@"AlphabetFontType", nil)
+                       attributes:underlineAttribute]
+   forState:UIControlStateDisabled];
 
-  
   [self.serifButton addTarget:self
                        action:@selector(didSelectSerif)
              forControlEvents:UIControlEventTouchUpInside];
@@ -86,12 +93,16 @@
   self.openDyslexicButton.backgroundColor = [NYPLConfiguration backgroundColor];
   [self.openDyslexicButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
   self.openDyslexicButton.titleLabel.font = [UIFont fontWithName:@"OpenDyslexic3" size:20];
-  [self.openDyslexicButton setAttributedTitle:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"AlphabetFontType", nil)
-                                                                       attributes:noUnderlineAttribute] forState:UIControlStateNormal];
-  
-  [self.openDyslexicButton setAttributedTitle:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"AlphabetFontType", nil)
-                                                                       attributes:underlineAttribute] forState:UIControlStateDisabled];
-
+  [self.openDyslexicButton
+   setAttributedTitle:[[NSAttributedString alloc]
+                       initWithString:NSLocalizedString(@"AlphabetFontType", nil)
+                       attributes:noUnderlineAttribute]
+   forState:UIControlStateNormal];
+  [self.openDyslexicButton
+   setAttributedTitle:[[NSAttributedString alloc]
+                       initWithString:NSLocalizedString(@"AlphabetFontType", nil)
+                       attributes:underlineAttribute]
+   forState:UIControlStateDisabled];
   [self.openDyslexicButton setTitleEdgeInsets:UIEdgeInsetsMake(-4.0f, 0.0f, 0.0f, 0.0f)];
   [self.openDyslexicButton addTarget:self
                        action:@selector(didSelectOpenDyslexic)
@@ -105,12 +116,16 @@
   NSDictionary *whiteColourWithoutUnderline = @{NSUnderlineStyleAttributeName: @(NSUnderlineStyleNone), NSForegroundColorAttributeName : [UIColor whiteColor] };
   NSDictionary *whiteColourWithUnderline = @{NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle), NSForegroundColorAttributeName : [UIColor whiteColor] };
   
-  [self.whiteOnBlackButton setAttributedTitle:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"AlphabetFontStyle", nil)
-                                                                              attributes:whiteColourWithoutUnderline] forState:UIControlStateNormal];
-  
-  [self.whiteOnBlackButton setAttributedTitle:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"AlphabetFontStyle", nil)
-                                                                              attributes:whiteColourWithUnderline] forState:UIControlStateDisabled];
-  
+  [self.whiteOnBlackButton
+   setAttributedTitle:[[NSAttributedString alloc]
+                       initWithString:NSLocalizedString(@"AlphabetFontStyle", nil)
+                       attributes:whiteColourWithoutUnderline]
+   forState:UIControlStateNormal];
+  [self.whiteOnBlackButton
+   setAttributedTitle:[[NSAttributedString alloc]
+                       initWithString:NSLocalizedString(@"AlphabetFontStyle", nil)
+                       attributes:whiteColourWithUnderline]
+   forState:UIControlStateDisabled];
   self.whiteOnBlackButton.titleLabel.font = [UIFont systemFontOfSize:18];
   [self.whiteOnBlackButton addTarget:self
                               action:@selector(didSelectWhiteOnBlack)
@@ -223,54 +238,58 @@
 
 - (void)layoutSubviews
 {
-  CGFloat const padding = 20;
+  [super layoutSubviews];
+
+  CGFloat const padding = 10;
+  CGFloat const topPadding = 16;
   CGFloat const innerWidth = CGRectGetWidth(self.frame) - padding * 2;
+  CGFloat const rowHeight = round((CGRectGetHeight(self.frame) - topPadding) / 4.0);
   
   self.sansButton.frame = CGRectMake(padding,
-                                        0,
+                                     topPadding,
                                      round(innerWidth / 3.0),
-                                     CGRectGetHeight(self.frame) / 4.0);
+                                     rowHeight);
   
   self.serifButton.frame = CGRectMake(CGRectGetMaxX(self.sansButton.frame),
-                                      0,
+                                      topPadding,
                                       round(innerWidth / 3.0),
-                                      CGRectGetHeight(self.frame) / 4.0);
+                                      rowHeight);
 
   self.openDyslexicButton.frame = CGRectMake(CGRectGetMaxX(self.serifButton.frame),
-                                      0,
-                                      round(innerWidth / 3.0),
-                                      CGRectGetHeight(self.frame) / 4.0);
+                                             topPadding,
+                                             round(innerWidth / 3.0),
+                                             rowHeight);
   
   self.whiteOnBlackButton.frame = CGRectMake(padding,
                                              CGRectGetMaxY(self.serifButton.frame),
                                              round(innerWidth / 3.0),
-                                             CGRectGetHeight(self.frame) / 4.0);
+                                             rowHeight);
   
   self.blackOnSepiaButton.frame = CGRectMake(CGRectGetMaxX(self.whiteOnBlackButton.frame),
                                              CGRectGetMaxY(self.serifButton.frame),
                                              round(innerWidth / 3.0),
-                                             CGRectGetHeight(self.frame) / 4.0);
+                                             rowHeight);
   
   self.blackOnWhiteButton.frame = CGRectMake(CGRectGetMaxX(self.blackOnSepiaButton.frame),
                                              CGRectGetMaxY(self.serifButton.frame),
                                              (CGRectGetWidth(self.frame) - padding -
                                               CGRectGetMaxX(self.blackOnSepiaButton.frame)),
-                                             CGRectGetHeight(self.frame) / 4.0);
+                                             rowHeight);
   
   self.decreaseButton.frame = CGRectMake(padding,
                                          CGRectGetMaxY(self.whiteOnBlackButton.frame),
                                          innerWidth / 2.0,
-                                         CGRectGetHeight(self.frame) / 4.0);
+                                         rowHeight);
   
   self.increaseButton.frame = CGRectMake(CGRectGetMaxX(self.decreaseButton.frame),
                                          CGRectGetMaxY(self.whiteOnBlackButton.frame),
                                          innerWidth / 2.0,
-                                         CGRectGetHeight(self.frame) / 4.0);
+                                         rowHeight);
   
   self.brightnessView.frame = CGRectMake(padding,
                                          CGRectGetMaxY(self.decreaseButton.frame),
                                          innerWidth,
-                                         CGRectGetHeight(self.frame) / 4.0);
+                                         rowHeight);
   
   self.brightnessLowImageView.frame =
     CGRectMake(0,
@@ -306,7 +325,7 @@
 - (CGSize)sizeThatFits:(CGSize)size
 {
   CGFloat const defaultWidth = 320;
-  CGFloat const defaultHeight = 200;
+  CGFloat const defaultHeight = 240;
 
   if(CGSizeEqualToSize(size, CGSizeZero)) {
     return CGSizeMake(defaultWidth, defaultHeight);
@@ -554,96 +573,85 @@
   [self.lineViews removeAllObjects];
   
   CGFloat const thin = 1.0 / [UIScreen mainScreen].scale;
-  
-  if (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
-    UIView *const line = [[UIView alloc]
-                          initWithFrame:CGRectMake(CGRectGetMinX(self.sansButton.frame),
-                                                   CGRectGetMinY(self.sansButton.frame),
-                                                   (CGRectGetMaxX(self.openDyslexicButton.frame) -
-                                                   CGRectGetMinX(self.sansButton.frame)),
-                                                   thin)];
-    [line setBackgroundColor:[UIColor lightGrayColor]];
-    [self addSubview:line];
-  }
-    
+
   {
-    UIView *const line = [[UIView alloc]
-                          initWithFrame:CGRectMake(CGRectGetMinX(self.openDyslexicButton.frame),
-                                                   CGRectGetMinY(self.openDyslexicButton.frame),
-                                                   thin,
-                                                   CGRectGetHeight(self.openDyslexicButton.frame))];
+    UIView *const line = [[UIView alloc] initWithFrame:
+                          CGRectMake(CGRectGetMinX(self.openDyslexicButton.frame),
+                                     CGRectGetMinY(self.openDyslexicButton.frame),
+                                     thin,
+                                     CGRectGetHeight(self.openDyslexicButton.frame))];
     [line setBackgroundColor:[UIColor lightGrayColor]];
     [self addSubview:line];
   }
 
   {
-    UIView *const line = [[UIView alloc]
-                           initWithFrame:CGRectMake(CGRectGetMinX(self.whiteOnBlackButton.frame),
-                                                    CGRectGetMinY(self.whiteOnBlackButton.frame),
-                                                    (CGRectGetMaxX(self.blackOnWhiteButton.frame) -
-                                                     CGRectGetMinX(self.whiteOnBlackButton.frame)),
-                                                    thin)];
+    UIView *const line = [[UIView alloc] initWithFrame:
+                          CGRectMake(CGRectGetMinX(self.whiteOnBlackButton.frame),
+                                     CGRectGetMinY(self.whiteOnBlackButton.frame),
+                                     (CGRectGetMaxX(self.blackOnWhiteButton.frame) -
+                                      CGRectGetMinX(self.whiteOnBlackButton.frame)),
+                                     thin)];
     [line setBackgroundColor:[UIColor lightGrayColor]];
     [self addSubview:line];
   }
   
   {
-    UIView *const line = [[UIView alloc]
-                          initWithFrame:CGRectMake(CGRectGetMinX(self.decreaseButton.frame),
-                                                   CGRectGetMinY(self.decreaseButton.frame),
-                                                   (CGRectGetMaxX(self.increaseButton.frame)
-                                                    - CGRectGetMinX(self.decreaseButton.frame)),
-                                                   thin)];
+    UIView *const line = [[UIView alloc] initWithFrame:
+                          CGRectMake(CGRectGetMinX(self.decreaseButton.frame),
+                                     CGRectGetMinY(self.decreaseButton.frame),
+                                     (CGRectGetMaxX(self.increaseButton.frame)
+                                      - CGRectGetMinX(self.decreaseButton.frame)),
+                                     thin)];
     [line setBackgroundColor:[UIColor lightGrayColor]];
     [self addSubview:line];
   }
   
   {
-    UIView *const line = [[UIView alloc]
-                          initWithFrame:CGRectMake(CGRectGetMinX(self.brightnessView.frame),
-                                                   CGRectGetMinY(self.brightnessView.frame),
-                                                   CGRectGetWidth(self.brightnessView.frame),
-                                                   thin)];
+    UIView *const line = [[UIView alloc] initWithFrame:
+                          CGRectMake(CGRectGetMinX(self.brightnessView.frame),
+                                     CGRectGetMinY(self.brightnessView.frame),
+                                     CGRectGetWidth(self.brightnessView.frame),
+                                     thin)];
     [line setBackgroundColor:[UIColor lightGrayColor]];
     [self addSubview:line];
   }
   
   {
-    UIView *const line = [[UIView alloc]
-                          initWithFrame:CGRectMake(CGRectGetMinX(self.serifButton.frame),
-                                                   CGRectGetMinY(self.serifButton.frame),
-                                                   thin,
-                                                   CGRectGetHeight(self.serifButton.frame))];
+    UIView *const line = [[UIView alloc] initWithFrame:
+                          CGRectMake(CGRectGetMinX(self.serifButton.frame),
+                                     CGRectGetMinY(self.serifButton.frame),
+                                     thin,
+                                     CGRectGetHeight(self.serifButton.frame))];
     [line setBackgroundColor:[UIColor lightGrayColor]];
     [self addSubview:line];
   }
   
   {
-    UIView *const line = [[UIView alloc]
-                          initWithFrame:CGRectMake(CGRectGetMinX(self.blackOnSepiaButton.frame),
-                                                   CGRectGetMinY(self.blackOnSepiaButton.frame),
-                                                   thin,
-                                                   CGRectGetHeight(self.blackOnSepiaButton.frame))];
+    UIView *const line = [[UIView alloc] initWithFrame:
+                          CGRectMake(CGRectGetMinX(self.blackOnSepiaButton.frame),
+                                     CGRectGetMinY(self.blackOnSepiaButton.frame),
+                                     thin,
+                                     CGRectGetHeight(self.blackOnSepiaButton.frame))];
     [line setBackgroundColor:[UIColor lightGrayColor]];
     [self addSubview:line];
   }
 
   {
-    UIView *const line = [[UIView alloc]
-                          initWithFrame:CGRectMake(CGRectGetMinX(self.blackOnWhiteButton.frame),
-                                                   CGRectGetMinY(self.blackOnWhiteButton.frame),
-                                                   thin,
-                                                   CGRectGetHeight(self.blackOnWhiteButton.frame))];
+    UIView *const line = [[UIView alloc] initWithFrame:
+                          CGRectMake(CGRectGetMinX(self.blackOnWhiteButton.frame),
+                                     CGRectGetMinY(self.blackOnWhiteButton.frame),
+                                     thin,
+                                     CGRectGetHeight(self.blackOnWhiteButton.frame))];
     [line setBackgroundColor:[UIColor lightGrayColor]];
     [self addSubview:line];
   }
   
   {
-    UIView *const line = [[UIView alloc]
-                          initWithFrame:CGRectMake(CGRectGetMinX(self.increaseButton.frame),
-                                                   CGRectGetMinY(self.increaseButton.frame),
-                                                   thin,
-                                                   CGRectGetHeight(self.increaseButton.frame))];
+    UIView *const line = [[UIView alloc] initWithFrame:
+                          CGRectMake(CGRectGetMinX(self.increaseButton.frame),
+                                     CGRectGetMinY(self.increaseButton.frame),
+                                     thin,
+                                     CGRectGetHeight(self.increaseButton.frame))];
     [line setBackgroundColor:[UIColor lightGrayColor]];
     [self addSubview:line];
   }

--- a/Simplified/NYPLReaderViewController.m
+++ b/Simplified/NYPLReaderViewController.m
@@ -20,7 +20,7 @@
 #define EDGE_OF_SCREEN_POINT_FRACTION    0.2
 
 @interface NYPLReaderViewController ()
-  <NYPLReaderSettingsViewDelegate, NYPLReaderTOCViewControllerDelegate, NYPLReaderRendererDelegate, UIPopoverPresentationControllerDelegate>
+  <NYPLUserSettingsReaderDelegate, NYPLReaderTOCViewControllerDelegate, NYPLReaderRendererDelegate, UIPopoverPresentationControllerDelegate>
 
 @property (nonatomic) UIViewController *activePopoverController;
 @property (nonatomic) NSString *bookIdentifier;
@@ -56,42 +56,6 @@ typedef NS_ENUM(NSInteger, NYPLReaderViewControllerDirection) {
 };
 
 @implementation NYPLReaderViewController
-
-- (void)applyCurrentSettings
-{
-  self.navigationController.navigationBar.barTintColor =
-    [NYPLReaderSettings sharedSettings].backgroundColor;
-
-  self.activePopoverController.view.backgroundColor =
-  [NYPLReaderSettings sharedSettings].backgroundColor;
-  
-  switch([NYPLReaderSettings sharedSettings].colorScheme) {
-    case NYPLReaderSettingsColorSchemeBlackOnSepia:
-      self.activityIndicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleGray;
-      self.navigationController.navigationBar.barStyle = UIBarStyleDefault;
-      self.bottomViewImageView.backgroundColor = [NYPLConfiguration readerBackgroundSepiaColor];
-      self.bottomViewImageViewTopBorder.backgroundColor = [UIColor lightGrayColor];
-      self.headerViewLabel.textColor = [UIColor darkGrayColor];
-      self.footerViewLabel.textColor = [UIColor darkGrayColor];
-      break;
-    case NYPLReaderSettingsColorSchemeBlackOnWhite:
-      self.activityIndicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleGray;
-      self.navigationController.navigationBar.barStyle = UIBarStyleDefault;
-      self.bottomViewImageView.backgroundColor = [NYPLConfiguration readerBackgroundColor];
-      self.bottomViewImageViewTopBorder.backgroundColor = [UIColor lightGrayColor];
-      self.headerViewLabel.textColor = [UIColor darkGrayColor];
-      self.footerViewLabel.textColor = [UIColor darkGrayColor];
-      break;
-    case NYPLReaderSettingsColorSchemeWhiteOnBlack:
-      self.activityIndicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhite;
-      self.navigationController.navigationBar.barStyle = UIBarStyleBlack;
-      self.bottomViewImageView.backgroundColor = [NYPLConfiguration readerBackgroundDarkColor];
-      self.bottomViewImageViewTopBorder.backgroundColor = [UIColor darkGrayColor];
-      self.headerViewLabel.textColor = [UIColor colorWithWhite: 0.80 alpha:1];
-      self.footerViewLabel.textColor = [UIColor colorWithWhite: 0.80 alpha:1];
-      break;
-  }
-}
 
 - (instancetype)initWithBookIdentifier:(NSString *const)bookIdentifier
 {
@@ -627,42 +591,54 @@ didRequestSyncBookmarksWithCompletion:(void (^)(BOOL, NSArray<NYPLReadiumBookmar
   [self.rendererView.syncManager syncBookmarksWithCompletion:completion];
 }
 
-#pragma mark NYPLReaderSettingsViewDelegate
+#pragma mark NYPLUserSettingsReaderDelegate
 
-- (void)readerSettingsView:(__attribute__((unused)) NYPLReaderSettingsView *)readerSettingsView
-       didSelectBrightness:(CGFloat const)brightness
+- (void)applyCurrentSettings
 {
-  [UIScreen mainScreen].brightness = brightness;
+  self.navigationController.navigationBar.barTintColor =
+  [NYPLReaderSettings sharedSettings].backgroundColor;
+
+  self.activePopoverController.view.backgroundColor =
+  [NYPLReaderSettings sharedSettings].backgroundColor;
+
+  switch([NYPLReaderSettings sharedSettings].colorScheme) {
+    case NYPLReaderSettingsColorSchemeBlackOnSepia:
+      self.activityIndicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleGray;
+      self.navigationController.navigationBar.barStyle = UIBarStyleDefault;
+      self.bottomViewImageView.backgroundColor = [NYPLConfiguration readerBackgroundSepiaColor];
+      self.bottomViewImageViewTopBorder.backgroundColor = [UIColor lightGrayColor];
+      self.headerViewLabel.textColor = [UIColor darkGrayColor];
+      self.footerViewLabel.textColor = [UIColor darkGrayColor];
+      break;
+
+    case NYPLReaderSettingsColorSchemeBlackOnWhite:
+      self.activityIndicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleGray;
+      self.navigationController.navigationBar.barStyle = UIBarStyleDefault;
+      self.bottomViewImageView.backgroundColor = [NYPLConfiguration readerBackgroundColor];
+      self.bottomViewImageViewTopBorder.backgroundColor = [UIColor lightGrayColor];
+      self.headerViewLabel.textColor = [UIColor darkGrayColor];
+      self.footerViewLabel.textColor = [UIColor darkGrayColor];
+      break;
+
+    case NYPLReaderSettingsColorSchemeWhiteOnBlack:
+      self.activityIndicatorView.activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhite;
+      self.navigationController.navigationBar.barStyle = UIBarStyleBlack;
+      self.bottomViewImageView.backgroundColor = [NYPLConfiguration readerBackgroundDarkColor];
+      self.bottomViewImageViewTopBorder.backgroundColor = [UIColor darkGrayColor];
+      self.headerViewLabel.textColor = [UIColor colorWithWhite: 0.80 alpha:1];
+      self.footerViewLabel.textColor = [UIColor colorWithWhite: 0.80 alpha:1];
+      break;
+  }
 }
 
-- (void)readerSettingsView:(__attribute__((unused)) NYPLReaderSettingsView *)readerSettingsView
-      didSelectColorScheme:(NYPLReaderSettingsColorScheme const)colorScheme
+- (NYPLR1R2UserSettings *)userSettings
 {
-  [NYPLReaderSettings sharedSettings].colorScheme = colorScheme;
-  
-  [self applyCurrentSettings];
+  return [[NYPLR1R2UserSettings alloc] init];
 }
 
-- (void)readerSettingsView:(__attribute__((unused)) NYPLReaderSettingsView *)readerSettingsView
-         didSelectFontSize:(NYPLReaderSettingsFontSize const)fontSize
+- (void)setUIColorForR2:(__attribute__((unused)) NSInteger)appearanceIndex
 {
-  [NYPLReaderSettings sharedSettings].fontSize = fontSize;
-  
-  [self applyCurrentSettings];
-}
-
-- (void)readerSettingsView:(__attribute__((unused)) NYPLReaderSettingsView *)readerSettingsView
-         didSelectFontFace:(NYPLReaderSettingsFontFace)fontFace
-{
-  [NYPLReaderSettings sharedSettings].fontFace = fontFace;
-  
-  [self applyCurrentSettings];
-}
-
--(void)readerSettingsView:(__attribute__((unused)) NYPLReaderSettingsView *)readerSettingsView
-      didSelectMediaOverlaysEnableClick:(NYPLReaderSettingsMediaOverlaysEnableClick) mediaOverlaysEnableClick {
-  [NYPLReaderSettings sharedSettings].mediaOverlaysEnableClick = mediaOverlaysEnableClick;
-  [self applyCurrentSettings];
+  // nothing to do since this delegate method is only for Readium 2
 }
 
 #pragma mark UIPopoverPresentationControllerDelegate
@@ -735,33 +711,19 @@ traitCollection:(__attribute__((unused)) UITraitCollection *)traitCollection
 
 - (void)didSelectSettings
 {
-  CGFloat const width =
-  (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad &&
-   self.traitCollection.horizontalSizeClass != UIUserInterfaceSizeClassCompact)
-  ? 320 : 300;
-  
-  NYPLReaderSettingsView *const readerSettingsView =
-  [[NYPLReaderSettingsView alloc] initWithWidth:width];
-  readerSettingsView.delegate = self;
-  readerSettingsView.colorScheme = [NYPLReaderSettings sharedSettings].colorScheme;
-  readerSettingsView.fontSize = [NYPLReaderSettings sharedSettings].fontSize;
-  readerSettingsView.fontFace = [NYPLReaderSettings sharedSettings].fontFace;
-  
-  UIViewController *const vc = [[UIViewController alloc] init];
-  vc.view = readerSettingsView;
-  vc.preferredContentSize = vc.view.bounds.size;
   if (self.activePopoverController && self.activePopoverController == self.presentedViewController) {
     [self dismissViewControllerAnimated:NO completion:nil];
   }
+
+  NYPLUserSettingsVC *vc = [[NYPLUserSettingsVC alloc] initWithDelegate:self];
   self.activePopoverController = vc;
-  vc.view.backgroundColor = [NYPLReaderSettings sharedSettings].backgroundColor;
-  self.activePopoverController.modalPresentationStyle = UIModalPresentationPopover;
-  self.activePopoverController.popoverPresentationController.delegate = self;
-  self.activePopoverController.popoverPresentationController.barButtonItem = self.settingsBarButtonItem;
-  [self presentViewController:self.activePopoverController animated:YES completion:^{
+  vc.modalPresentationStyle = UIModalPresentationPopover;
+  vc.popoverPresentationController.delegate = self;
+  vc.popoverPresentationController.barButtonItem = self.settingsBarButtonItem;
+  [self presentViewController:vc animated:YES completion:^{
     vc.popoverPresentationController.passthroughViews = nil;
   }];
-  UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, self.activePopoverController);
+  UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, vc);
 }
 
 - (void)didSelectContents

--- a/Simplified/Reader2/Internal/EPUBModule.swift
+++ b/Simplified/Reader2/Internal/EPUBModule.swift
@@ -35,10 +35,10 @@ final class EPUBModule: ReaderFormatModule {
       throw ReaderError.epubNotValid
     }
     
-    let epubVC = EPUBViewController(publication: publication,
-                                    book: book,
-                                    drm: drm,
-                                    resourcesServer: resourcesServer)
+    let epubVC = NYPLEPUBViewController(publication: publication,
+                                        book: book,
+                                        drm: drm,
+                                        resourcesServer: resourcesServer)
     epubVC.moduleDelegate = delegate
     return epubVC
   }

--- a/Simplified/Reader2/UI/NYPLEPUBViewController.swift
+++ b/Simplified/Reader2/UI/NYPLEPUBViewController.swift
@@ -1,6 +1,5 @@
 //
-//  EPUBViewController.swift
-//  r2-testapp-swift
+//  NYPLEPUBViewController.swift
 //
 //  Created by Alexandre Camilleri on 7/3/17.
 //
@@ -14,7 +13,7 @@ import UIKit
 import R2Shared
 import R2Navigator
 
-class EPUBViewController: ReaderViewController {
+class NYPLEPUBViewController: ReaderViewController {
   
   var popoverUserconfigurationAnchor: UIBarButtonItem?
 
@@ -133,7 +132,7 @@ class EPUBViewController: ReaderViewController {
 
 // MARK: - NYPLUserSettingsReaderDelegate
 
-extension EPUBViewController: NYPLUserSettingsReaderDelegate {
+extension NYPLEPUBViewController: NYPLUserSettingsReaderDelegate {
   var userSettings: NYPLR1R2UserSettings {
     return NYPLR1R2UserSettings(r2UserSettings: epubNavigator.userSettings)
   }
@@ -158,12 +157,12 @@ extension EPUBViewController: NYPLUserSettingsReaderDelegate {
 
 // MARK: - EPUBNavigatorDelegate
 
-extension EPUBViewController: EPUBNavigatorDelegate {
+extension NYPLEPUBViewController: EPUBNavigatorDelegate {
 }
 
 // MARK: - UIGestureRecognizerDelegate
 
-extension EPUBViewController: UIGestureRecognizerDelegate {
+extension NYPLEPUBViewController: UIGestureRecognizerDelegate {
   func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
     return true
   }
@@ -171,7 +170,7 @@ extension EPUBViewController: UIGestureRecognizerDelegate {
 
 // MARK: - UIPopoverPresentationControllerDelegate
 
-extension EPUBViewController: UIPopoverPresentationControllerDelegate {
+extension NYPLEPUBViewController: UIPopoverPresentationControllerDelegate {
   // Prevent the popOver to be presented fullscreen on iPhones.
   func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle
   {

--- a/Simplified/Reader2/UI/User Settings/NYPLR1R2UserSettings.swift
+++ b/Simplified/Reader2/UI/User Settings/NYPLR1R2UserSettings.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import R2Navigator
+import R2Shared
 
 /// Wrapper class for Readium 1 and Readium 2 reader user settings.
 class NYPLR1R2UserSettings: NSObject {
@@ -28,33 +29,17 @@ class NYPLR1R2UserSettings: NSObject {
     super.init()
   }
 
-//  /// Converts the R2 font size value to a R1 value we can use in SimplyE.
-//  func r1FontSize() -> NYPLReaderSettingsFontSize {
-//    guard let r2FontSize = r2UserSettings?.userProperties.getProperty(reference: ReadiumCSSReference.fontSize.rawValue) as? Incrementable else {
-//      return .normal
-//    }
-//
-//    // R2 values may reach the bounds min / max values
-//    let r2Range = r2FontSize.max - r2FontSize.min
-//
-//    // convert R2 value inside the [0...1] range
-//    let percValue: Float = {
-//      let val = (r2FontSize.value - r2FontSize.min)
-//      if val < 0 {
-//        return r2FontSize.min
-//      }
-//      return val / r2Range
-//    }()
-//
-//    // range between 0...7 inclusive
-//    let r1Range = Float(NYPLReaderSettingsFontSizeMaxValue)
-//    let r1Value = Int(round(percValue * r1Range))
-//
-//    // sanity check
-//    if r1Value > NYPLReaderSettingsFontSize.xxxLarge.rawValue {
-//      return NYPLReaderSettingsFontSize.xxxLarge
-//    }
-//
-//    return NYPLReaderSettingsFontSize(rawValue: r1Value) ?? .normal
-//  }
+  func modifyR2FontSize(fromR1 r1Value: NYPLReaderSettingsFontSize) {
+    guard let r2FontSize = r2UserSettings?.userProperties.getProperty(reference: ReadiumCSSReference.fontSize.rawValue) as? Incrementable else {
+      return
+    }
+
+    // convert R1 value into the [0...1] range
+    let r1Range = Float(NYPLReaderSettingsFontSize.largest.rawValue - NYPLReaderSettingsFontSize.smallest.rawValue)
+    let percValue = Float(r1Value.rawValue - NYPLReaderSettingsFontSize.smallest.rawValue) / r1Range
+
+    // convert the percentage range into R2
+    let r2Range = r2FontSize.max - r2FontSize.min
+    r2FontSize.value = r2FontSize.min + percValue * r2Range
+  }
 }

--- a/Simplified/Reader2/UI/User Settings/NYPLR1R2UserSettings.swift
+++ b/Simplified/Reader2/UI/User Settings/NYPLR1R2UserSettings.swift
@@ -1,0 +1,60 @@
+//
+//  NYPLR1R2UserSettings.swift
+//  SimplyE
+//
+//  Created by Ettore Pasquini on 3/27/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+import R2Navigator
+
+/// Wrapper class for Readium 1 and Readium 2 reader user settings.
+class NYPLR1R2UserSettings: NSObject {
+  @objc let r1UserSettings: NYPLReaderSettings
+  let r2UserSettings: UserSettings?
+
+  /// Use this convenience initializer only if calling from ObjC.
+  @objc override convenience init() {
+    self.init(r2UserSettings: nil)
+  }
+
+  /// Designated initializer.
+  /// - Parameter r2UserSettings: Readium 2 user settings. This typically comes
+  /// from the R2Navigator classes such as EPUBNavigatorViewController.
+  init(r2UserSettings: UserSettings?) {
+    self.r1UserSettings = NYPLReaderSettings.shared()
+    self.r2UserSettings = r2UserSettings
+    super.init()
+  }
+
+//  /// Converts the R2 font size value to a R1 value we can use in SimplyE.
+//  func r1FontSize() -> NYPLReaderSettingsFontSize {
+//    guard let r2FontSize = r2UserSettings?.userProperties.getProperty(reference: ReadiumCSSReference.fontSize.rawValue) as? Incrementable else {
+//      return .normal
+//    }
+//
+//    // R2 values may reach the bounds min / max values
+//    let r2Range = r2FontSize.max - r2FontSize.min
+//
+//    // convert R2 value inside the [0...1] range
+//    let percValue: Float = {
+//      let val = (r2FontSize.value - r2FontSize.min)
+//      if val < 0 {
+//        return r2FontSize.min
+//      }
+//      return val / r2Range
+//    }()
+//
+//    // range between 0...7 inclusive
+//    let r1Range = Float(NYPLReaderSettingsFontSizeMaxValue)
+//    let r1Value = Int(round(percValue * r1Range))
+//
+//    // sanity check
+//    if r1Value > NYPLReaderSettingsFontSize.xxxLarge.rawValue {
+//      return NYPLReaderSettingsFontSize.xxxLarge
+//    }
+//
+//    return NYPLReaderSettingsFontSize(rawValue: r1Value) ?? .normal
+//  }
+}

--- a/Simplified/Reader2/UI/User Settings/NYPLUserSettingsVC.swift
+++ b/Simplified/Reader2/UI/User Settings/NYPLUserSettingsVC.swift
@@ -1,0 +1,130 @@
+//
+//  NYPLUserSettingsVC.swift
+//  SimplyE
+//
+//  Created by Ettore Pasquini on 3/26/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import UIKit
+import R2Shared
+import R2Navigator
+
+//==============================================================================
+
+/// This protocol describes the interface necessary to the UserSettings UI code
+/// to interact with a reader system. This protocol can be used for both
+/// Readium 1 or Readium 2.
+@objc protocol NYPLUserSettingsReaderDelegate: NSObjectProtocol {
+
+  /// Apply the user settings to the reader screen
+  func applyCurrentSettings()
+
+  /// Obtain the current user settings
+  var userSettings: NYPLR1R2UserSettings { get }
+
+  /// Only used by R2-related code to update the appearance.
+  /// - Parameter appearanceIndex: Value corresponding to a UserProperty index
+  /// property for the appearance settings.
+  /// - TODO: SIMPLY-2604
+  func setUIColor(forR2 appearanceIndex: Int)
+}
+
+//==============================================================================
+
+/// A view controller to handle the logic related to the user settings UI
+/// events described by `NYPLReaderSettingsViewDelegate`. This class takes care
+/// of translating those UI events into changes to both Readium 1 and Readium 2
+/// systems, which handle user settings in different / incompatible ways.
+/// The "output" of this class is to eventually call
+@objc class NYPLUserSettingsVC: UIViewController {
+
+  weak var delegate: NYPLUserSettingsReaderDelegate?
+  var userSettings: NYPLR1R2UserSettings?
+
+  /// The designated initializer.
+  /// - Parameter delegate: The object responsible to handle callbacks in
+  /// response to User Settings UI changes.
+  @objc init(delegate: NYPLUserSettingsReaderDelegate) {
+    super.init(nibName: nil, bundle: nil)
+    self.delegate = delegate
+    self.userSettings = delegate.userSettings
+  }
+
+  /// Instantiting this class in a xib/storyboard is not supported.
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) not implemented")
+  }
+
+  override func loadView() {
+    let view = NYPLReaderSettingsView(width: 300)
+    view.delegate = self
+    view.colorScheme = NYPLReaderSettings.shared().colorScheme
+    view.fontSize = NYPLReaderSettings.shared().fontSize
+    view.fontFace = NYPLReaderSettings.shared().fontFace
+    view.backgroundColor = NYPLReaderSettings.shared().backgroundColor
+    self.view = view;
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.preferredContentSize = self.view.bounds.size
+  }
+}
+
+// MARK: - NYPLReaderSettingsViewDelegate
+
+extension NYPLUserSettingsVC: NYPLReaderSettingsViewDelegate {
+  func readerSettingsView(_ readerSettingsView: NYPLReaderSettingsView,
+                          didSelectBrightness brightness: CGFloat) {
+    UIScreen.main.brightness = brightness
+  }
+
+  func readerSettingsView(_ readerSettingsView: NYPLReaderSettingsView,
+                          didSelect colorScheme: NYPLReaderSettingsColorScheme) {
+    userSettings?.r1UserSettings.colorScheme = colorScheme
+    delegate?.applyCurrentSettings()
+  }
+
+  func readerSettingsView(_ settingsView: NYPLReaderSettingsView,
+                          didChangeFontSize change: NYPLReaderFontSizeChange) -> NYPLReaderSettingsFontSize {
+    //  R1
+    var newSize = settingsView.fontSize
+    let r1Changed = NYPLReaderSettingsIncreasedFontSize(settingsView.fontSize,
+                                                      &newSize)
+    if r1Changed {
+      userSettings?.r1UserSettings.fontSize = newSize
+    }
+
+    // R2
+    if let fontSize = userSettings?.r2UserSettings?.userProperties.getProperty(reference: ReadiumCSSReference.fontSize.rawValue) as? Incrementable {
+
+      // Note, R2's `increment`/`decrement` functions do bound checks, so e.g.
+      // calling `increment` when fontSize is already the max results in a no-op
+      switch change {
+      case .increase:
+        fontSize.increment()
+      case .decrease:
+        fontSize.decrement()
+      }
+
+      delegate?.applyCurrentSettings()
+    } else if r1Changed {
+      delegate?.applyCurrentSettings()
+    }
+
+    return newSize
+  }
+
+  func readerSettingsView(_ readerSettingsView: NYPLReaderSettingsView,
+                          didSelect fontFace: NYPLReaderSettingsFontFace) {
+    userSettings?.r1UserSettings.fontFace = fontFace
+    delegate?.applyCurrentSettings()
+  }
+
+  func readerSettingsView(_ readerSettingsView: NYPLReaderSettingsView,
+                          didSelect flag: NYPLReaderSettingsMediaOverlaysEnableClick) {
+    userSettings?.r1UserSettings.mediaOverlaysEnableClick = flag
+    delegate?.applyCurrentSettings()
+  }
+}

--- a/Simplified/Reader2/UI/User Settings/UserSettingsNavigationController.swift
+++ b/Simplified/Reader2/UI/User Settings/UserSettingsNavigationController.swift
@@ -14,15 +14,12 @@ import UIKit
 import R2Navigator
 import R2Shared
 
-protocol UserSettingsNavigationControllerDelegate: class {
-  func getUserSettings() -> UserSettings
-  func updateUserSettingsStyle()
-  func setUIColor(for appearance: UserProperty)
-}
-
+// TODO: SIMPLY-2656
+// This class should be removed once we are done with R2 work. The only reason
+// it's here is to provide help during R2 integration into SimplyE.
 internal class UserSettingsNavigationController: UINavigationController {
 
-  weak var usdelegate: UserSettingsNavigationControllerDelegate!
+  weak var usdelegate: NYPLUserSettingsReaderDelegate!
   var userSettings: UserSettings!
   weak var publication: Publication?
 
@@ -34,7 +31,7 @@ internal class UserSettingsNavigationController: UINavigationController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    userSettings = usdelegate.getUserSettings()
+    userSettings = usdelegate.userSettings.r2UserSettings
 
     userSettingsTableViewController.modalPresentationStyle = .popover
     userSettingsTableViewController.delegate = self
@@ -52,7 +49,7 @@ internal class UserSettingsNavigationController: UINavigationController {
   func publisherSettingsDidChange() {
     if let publisherDefault = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.publisherDefault.rawValue) as? Switchable {
       publisherDefault.switchValue()
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 }
@@ -69,19 +66,14 @@ extension UserSettingsNavigationController: UserSettingsDelegate {
       } else {
         fontSize.decrement()
       }
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 
   /// Appearance
 
   func appearanceDidChange(to appearanceIndex: Int) {
-    if let appearance = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.appearance.rawValue) as? Enumerable {
-      appearance.index = appearanceIndex
-      usdelegate?.updateUserSettingsStyle()
-      // Change view appearance.
-      usdelegate?.setUIColor(for: appearance)
-    }
+    usdelegate?.setUIColor(forR2: appearanceIndex)
   }
 
   /// Vertical scroll
@@ -89,7 +81,7 @@ extension UserSettingsNavigationController: UserSettingsDelegate {
   func scrollModeDidChange() {
     if let scroll = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.scroll.rawValue) as? Switchable {
       scroll.switchValue()
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 
@@ -126,7 +118,7 @@ extension UserSettingsNavigationController: FontSelectionDelegate {
         fontOverride.on = false
       }
       userSettingsTableViewController.setSelectedFontLabel(to: fontFamily.toString())
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 }
@@ -139,7 +131,7 @@ extension UserSettingsNavigationController: AdvancedSettingsDelegate {
   func textAlignementDidChange(to textAlignmentIndex: Int) {
     if let textAlignment = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.textAlignment.rawValue) as? Enumerable {
       textAlignment.index = textAlignmentIndex
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 
@@ -147,14 +139,14 @@ extension UserSettingsNavigationController: AdvancedSettingsDelegate {
   func incrementWordSpacing() {
     if let wordSpacing = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.wordSpacing.rawValue) as? Incrementable {
       wordSpacing.increment()
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 
   func decrementWordSpacing() {
     if let wordSpacing = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.wordSpacing.rawValue) as? Incrementable {
       wordSpacing.decrement()
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 
@@ -169,14 +161,14 @@ extension UserSettingsNavigationController: AdvancedSettingsDelegate {
   func incrementLetterSpacing() {
     if let letterSpacing = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.letterSpacing.rawValue) as? Incrementable {
       letterSpacing.increment()
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 
   func decrementLetterSpacing() {
     if let letterSpacing = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.letterSpacing.rawValue) as? Incrementable {
       letterSpacing.decrement()
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 
@@ -191,7 +183,7 @@ extension UserSettingsNavigationController: AdvancedSettingsDelegate {
   func columnCountDidChange(to columnCountIndex: Int) {
     if let columnCount = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.columnCount.rawValue) as? Enumerable {
       columnCount.index = columnCountIndex
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 
@@ -200,14 +192,14 @@ extension UserSettingsNavigationController: AdvancedSettingsDelegate {
   func incrementPageMargins() {
     if let pageMargins = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.pageMargins.rawValue) as? Incrementable {
       pageMargins.increment()
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 
   func decrementPageMargins() {
     if let pageMargins = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.pageMargins.rawValue) as? Incrementable {
       pageMargins.decrement()
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 
@@ -222,14 +214,14 @@ extension UserSettingsNavigationController: AdvancedSettingsDelegate {
   func incrementLineHeight() {
     if let lineHeight = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.lineHeight.rawValue) as? Incrementable {
       lineHeight.increment()
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 
   func decrementLineHeight() {
     if let lineHeight = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.lineHeight.rawValue) as? Incrementable {
       lineHeight.decrement()
-      usdelegate?.updateUserSettingsStyle()
+      usdelegate?.applyCurrentSettings()
     }
   }
 

--- a/Simplified/SimplyE-Bridging-Header.h
+++ b/Simplified/SimplyE-Bridging-Header.h
@@ -31,6 +31,8 @@
 #import "NYPLHoldsNavigationController.h"
 #import "NYPLMyBooksDownloadCenter.h"
 #import "NYPLBookLocation.h"
+#import "NYPLReaderSettings.h"
+#import "NYPLReaderSettingsView.h"
 #if FEATURE_DRM_CONNECTOR
 #import "ADEPT/NYPLADEPTErrors.h"
 #import "ADEPT/NYPLADEPT.h"


### PR DESCRIPTION
**What's this do?**
It refactors our reader settings view so that it can be used with the R2 reader. It also makes it so that the settings view opens as a drop-down menu from the top navigation bar on all platforms, and synchronizes font size changes between R1 and R2.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2473

**How should this be tested? / Do these changes have associated tests?**
- Open a book from the SimplyE collection that you previously downloaded with R1 (using 3.3.7).
- The book should open with the previously set font size.
- Tapping on the "TT" user settings button on the top right should display our usual UI instead of the one from the R2 test app. 
- Brightness and font size adjustments should work and persist once you close the reader or the app.
- Font typeface and color scheme do not currently work (this is tracked in separate tickets).

**Dependencies for merging? Releasing to production?**
This will merge into our Readium2 feature branch.

**Has the application documentation been updated for these changes?**
Only inside the app.

**Did someone actually run this code to verify it works?**
@ettore 