### PR TITLE
[SIMPLY-2677] Fixing incomplete implementation from SIMPLY-2339

### DIFF
--- a/Simplified/NYPLBookDetailTableView.swift
+++ b/Simplified/NYPLBookDetailTableView.swift
@@ -188,14 +188,6 @@ private let standardCellHeight: CGFloat = 44.0
     let lastStandardCell = self.standardCells.last
     let lastCellIsViewIssue = (lastStandardCell != nil) && (lastStandardCell! == self.viewIssueCell)
     
-    // Don't show "view issue" if there's no library support email
-    if AccountsManager.shared.currentAccount?.supportEmail == nil {
-      if lastCellIsViewIssue {
-        self.standardCells.removeLast()
-      }
-      return
-    }
-    
     // Visibility logic
     if NYPLProblemDocumentCacheManager.shared.getLastCachedDoc(self.book.identifier) == nil {
       if lastCellIsViewIssue {

--- a/Simplified/NYPLBookDetailsProblemDocumentViewController.swift
+++ b/Simplified/NYPLBookDetailsProblemDocumentViewController.swift
@@ -96,6 +96,7 @@
     self.submitButton = submitButton
     submitButton.translatesAutoresizingMaskIntoConstraints = false
     submitButton.setTitle("Send to Support", for: .normal)
+    submitButton.isEnabled = AccountsManager.shared.currentAccount?.supportEmail != nil
     submitButton.addTarget(self, action: #selector(submitButtonWasPressed), for: .touchDown)
     
     scrollView.addSubview(label)

--- a/Simplified/NYPLBookDetailsProblemDocumentViewController.swift
+++ b/Simplified/NYPLBookDetailsProblemDocumentViewController.swift
@@ -196,6 +196,6 @@
         body: body
       )
     }))
-    self.present(alert, animated: false, completion: nil)
+    self.present(alert, animated: true, completion: nil)
   }
 }

--- a/Simplified/NYPLBookDetailsProblemDocumentViewController.swift
+++ b/Simplified/NYPLBookDetailsProblemDocumentViewController.swift
@@ -171,6 +171,11 @@
   }
   
   func submitButtonWasPressed() {
+    guard let supportEmail = AccountsManager.shared.currentAccount?.supportEmail else {
+      Log.error(#file, "Missing support email for library \(AccountsManager.shared.currentAccountId ?? "")")
+      return
+    }
+    
     let alert = UIAlertController.init(title: "Report a Problem", message: "Are you sure you want to email this error log to \(AccountsManager.shared.currentAccount?.name ?? "library") support?", preferredStyle: .alert)
     alert.addAction(UIAlertAction.init(title: "Cancel", style: .cancel, handler: nil))
     alert.addAction(UIAlertAction.init(title: "Send email", style: .default, handler: { (action) in
@@ -185,10 +190,11 @@
         BookIdentifier:\n\(self.book?.identifier ?? "n/a")\n\n
       """
       ProblemReportEmail.sharedInstance.beginComposing(
-        to: AccountsManager.shared.currentAccount?.supportEmail ?? "gethelp@nypl.org",
+        to: supportEmail,
         presentingViewController: self,
         body: body
       )
     }))
+    self.present(alert, animated: false, completion: nil)
   }
 }


### PR DESCRIPTION
**What's this do?**
Fixes up a missing alert when attempting to report a problem doc.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2677

**How should this be tested? / Do these changes have associated tests?**
Somehow trigger a problem document for a book and then attempt to view and report the problem document.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@kyles-ep  for the alert but not for the email sending dialog because I don't have a physical device.