### PR TITLE
SIMPLY-2691 More Crashlytics logging and fix a couple minor regressions

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		732F929323ECB51F0099244C /* NYPLBackgroundExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732F929223ECB51F0099244C /* NYPLBackgroundExecutor.swift */; };
 		733875652423E1B0000FEB67 /* NYPLNetworkExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733875642423E1B0000FEB67 /* NYPLNetworkExecutor.swift */; };
 		733875672423E540000FEB67 /* NYPLCaching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733875662423E540000FEB67 /* NYPLCaching.swift */; };
+		735F41A3243E381D00046182 /* String+NYPLAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735F41A2243E381D00046182 /* String+NYPLAdditionsTests.swift */; };
 		735FED262427494900144C97 /* NYPLNetworkResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735FED252427494900144C97 /* NYPLNetworkResponder.swift */; };
 		7384C800242BB43400D5F960 /* NYPLCachingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7384C7FF242BB43300D5F960 /* NYPLCachingTests.swift */; };
 		7384C802242BCC4800D5F960 /* Date+NYPLAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7384C801242BCC4800D5F960 /* Date+NYPLAdditions.swift */; };
@@ -567,6 +568,7 @@
 		732F929223ECB51F0099244C /* NYPLBackgroundExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBackgroundExecutor.swift; sourceTree = "<group>"; };
 		733875642423E1B0000FEB67 /* NYPLNetworkExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLNetworkExecutor.swift; sourceTree = "<group>"; };
 		733875662423E540000FEB67 /* NYPLCaching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLCaching.swift; sourceTree = "<group>"; };
+		735F41A2243E381D00046182 /* String+NYPLAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+NYPLAdditionsTests.swift"; sourceTree = "<group>"; };
 		735FED252427494900144C97 /* NYPLNetworkResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLNetworkResponder.swift; sourceTree = "<group>"; };
 		7384C7FF242BB43300D5F960 /* NYPLCachingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLCachingTests.swift; sourceTree = "<group>"; };
 		7384C801242BCC4800D5F960 /* Date+NYPLAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+NYPLAdditions.swift"; sourceTree = "<group>"; };
@@ -1317,6 +1319,7 @@
 				11A14DF51A1BFBED00D6C510 /* UIColor+NYPLColorAdditionsTests.m */,
 				2D2B47631D08F1ED007F7764 /* UpdateCheckTests.swift */,
 				5D3A28D322D3FBB90042B3BD /* UserProfileDocumentTests.swift */,
+				735F41A2243E381D00046182 /* String+NYPLAdditionsTests.swift */,
 			);
 			path = SimplifiedTests;
 			sourceTree = "<group>";
@@ -1642,6 +1645,7 @@
 				7307A5ED23FF1A8500DE53DE /* NYPLOpenSearchDescriptionTests.swift in Sources */,
 				B51C1DFE22860563003B49A5 /* OPDS2CatalogsFeedTests.swift in Sources */,
 				5D73DA4322A080BA00162CB8 /* NYPLMyBooksDownloadCenterTests.swift in Sources */,
+				735F41A3243E381D00046182 /* String+NYPLAdditionsTests.swift in Sources */,
 				5D7CF8BC22C42AE2007CAA34 /* LogTests.swift in Sources */,
 				173F0823241AAA4E00A64658 /* NYPLBookStateTests.swift in Sources */,
 				2D2B477C1D08F821007F7764 /* UpdateCheckTests.swift in Sources */,

--- a/Simplified/Account.swift
+++ b/Simplified/Account.swift
@@ -355,6 +355,27 @@ private let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
   }
 }
 
+extension AccountDetails {
+  override var debugDescription: String {
+    return """
+    supportsSimplyESync=\(supportsSimplyESync)
+    supportsCardCreator=\(supportsCardCreator)
+    supportsReservations=\(supportsReservations)
+    """
+  }
+}
+
+extension Account {
+  override var debugDescription: String {
+    return """
+    uuid=\(uuid)
+    catalogURL=\(String(describing: catalogUrl))
+    authDocURL=\(String(describing: authenticationDocumentUrl))
+    details=\(String(describing: details?.debugDescription))
+    """
+  }
+}
+
 // MARK: URLType
 @objc enum URLType: Int {
   case acknowledgements

--- a/Simplified/AccountsManager.swift
+++ b/Simplified/AccountsManager.swift
@@ -58,6 +58,7 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
     set {
       UserDefaults.standard.set(newValue?.uuid,
                                 forKey: currentAccountIdentifierKey)
+      NYPLErrorLogger.setUserID(NYPLAccount.shared()?.barcode)
       NotificationCenter.default.post(name: NSNotification.Name.NYPLCurrentAccountDidChange, object: nil)
     }
   }

--- a/Simplified/AccountsManager.swift
+++ b/Simplified/AccountsManager.swift
@@ -53,7 +53,12 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
   
   var currentAccount: Account? {
     get {
-      return account(UserDefaults.standard.string(forKey: currentAccountIdentifierKey) ?? "")
+      guard let uuid = currentAccountId else {
+        NYPLErrorLogger.logError(code: .nilCurrentAccountUUID)
+        return nil
+      }
+
+      return account(uuid)
     }
     set {
       UserDefaults.standard.set(newValue?.uuid,
@@ -121,25 +126,35 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
    Take the library list data (either from cache or the internet), load it into
    self.accounts, and load the auth document for the current account if
    necessary.
-   - parameter data: The library list data.
-   - parameter key: ???
+   - parameter data: The library catalog list data obtained from fetching either
+   `prodUrl` or `betaUrl`. This is parsed assuming it's in the OPDS2 format.
+   - parameter key: The key to enter the `accountSets` dictionary with.
    - parameter completion: Always invoked at the end no matter what, providing
    `true` in case of success and `false` otherwise. No guarantees are being made
    about whether this will be called on the main thread or not.
    */
-  private func loadCatalogs(data: Data, key: String, completion: @escaping (Bool) -> ()) {
+  private func loadAccountSetsAndAuthDoc(fromCatalogData data: Data,
+                                         key: String,
+                                         completion: @escaping (Bool) -> ()) {
     do {
       let catalogsFeed = try OPDS2CatalogsFeed.fromData(data)
       let hadAccount = self.currentAccount != nil
+
       self.accountSets[key] = catalogsFeed.catalogs.map { Account(publication: $0) }
 
       // note: `currentAccount` computed property feeds off of `accountSets`, so
       // changing the `accountsSets` dictionary will also change `currentAccount`
       if hadAccount != (self.currentAccount != nil) {
-        self.currentAccount?.loadAuthenticationDocument(completion: { (success) in
+        self.currentAccount?.loadAuthenticationDocument { success in
           if !success {
-            Log.error(#file, "Failed to load authentication document for current account; a bunch of things likely won't work")
+            NYPLErrorLogger.logError(code: .authDocLoadFail,
+                                     message: """
+              Failed to load authentication document for current account: \
+              \(self.currentAccount.debugDescription). A bunch of things \
+              likely won't work.
+              """)
           }
+
           DispatchQueue.main.async {
             var mainFeed = URL(string: self.currentAccount?.catalogUrl ?? "")
             let resolveFn = {
@@ -159,12 +174,15 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
               resolveFn()
             }
           }
-        })
+        }
       } else {
+        // we pass `true` because at this point we know the catalogs loaded
+        // successfully
         completion(true)
       }
     } catch (let error) {
-      Log.error(#file, "Couldn't load catalogs. Error: \(error.localizedDescription)")
+      NYPLErrorLogger.logError(error, code: .errorProcessingAuthDoc,
+                               message: "An error was thrown during loadAccountSetsAndAuthDoc")
       completion(false)
     }
   }
@@ -186,11 +204,14 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
     NYPLNetworkExecutor.shared.GET(targetUrl) { result in
       switch result {
       case .success(let data):
-        self.loadCatalogs(data: data, key: hash) { success in
+        self.loadAccountSetsAndAuthDoc(fromCatalogData: data, key: hash) { success in
           self.callAndClearLoadingCompletionHandlers(key: hash, success)
           NotificationCenter.default.post(name: NSNotification.Name.NYPLCatalogDidLoad, object: nil)
         }
-      case .failure(_):
+      case .failure(let error):
+        NYPLErrorLogger.logError(error,
+                                 code: .catalogLoadError,
+                                 message: "Catalog failed to load from \(targetUrl)")
         self.callAndClearLoadingCompletionHandlers(key: hash, false)
       }
     }

--- a/Simplified/NYPLAccount.h
+++ b/Simplified/NYPLAccount.h
@@ -60,8 +60,6 @@ static NSString *const NYPLAccountLoginDidChangeNotification =
 
 - (void)removeAll;
 
-- (void)removeObject:(NSString *const)key;
-
 - (NSDictionary *)licensor;
 
 @end

--- a/Simplified/NYPLAccount.m
+++ b/Simplified/NYPLAccount.m
@@ -25,7 +25,7 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
   return [self sharedAccount:library];
 }
 
-+ (instancetype)sharedAccount:(NSString *)account
++ (instancetype)sharedAccount:(NSString *)libraryUUID
 {
   static NYPLAccount *sharedAccount = nil;
   
@@ -36,19 +36,19 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
     }
   }
   
-  if (![account isEqualToString:[AccountsManager NYPLAccountUUIDs][0]])
+  if (![libraryUUID isEqualToString:[AccountsManager NYPLAccountUUIDs][0]])
   {
-    barcodeKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountBarcode", account];
-    authorizationIdentifierKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountAuthorization", account];
-    PINKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountPIN", account];
-    adobeTokenKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountAdobeTokenKey", account];
-    patronKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountPatronKey", account];
-    authTokenKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountAuthTokenKey", account];
-    adobeVendorKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountAdobeVendorKey", account];
-    providerKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountProviderKey", account];
-    userIDKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountUserIDKey", account];
-    deviceIDKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountDeviceIDKey", account];
-    licensorKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountLicensorKey", account];
+    barcodeKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountBarcode", libraryUUID];
+    authorizationIdentifierKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountAuthorization", libraryUUID];
+    PINKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountPIN", libraryUUID];
+    adobeTokenKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountAdobeTokenKey", libraryUUID];
+    patronKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountPatronKey", libraryUUID];
+    authTokenKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountAuthTokenKey", libraryUUID];
+    adobeVendorKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountAdobeVendorKey", libraryUUID];
+    providerKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountProviderKey", libraryUUID];
+    userIDKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountUserIDKey", libraryUUID];
+    deviceIDKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountDeviceIDKey", libraryUUID];
+    licensorKey = [NSString stringWithFormat:@"%@_%@",@"NYPLAccountLicensorKey", libraryUUID];
   }
   else
   {
@@ -70,45 +70,29 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
 
 - (BOOL)hasCredentials
 {
-  if (self.hasAuthToken || self.hasBarcodeAndPIN) return YES;
-  if (!self.hasAuthToken && !self.hasBarcodeAndPIN) return NO;
-  
-  @throw NSInternalInconsistencyException;
+  return self.hasAuthToken || self.hasBarcodeAndPIN;
 }
 
 - (BOOL)hasBarcodeAndPIN
 {
-  if(self.barcode && self.PIN) return YES;
-  
-  if(!self.barcode && !self.PIN) return NO;
-  
-  @throw NSInternalInconsistencyException;
+  return self.barcode != nil && self.PIN != nil;
 }
 
 - (BOOL)hasAuthToken
 {
-  if(self.authToken) return YES;
-  
-  if(!self.authToken) return NO;
-  
-  @throw NSInternalInconsistencyException;
+  return self.authToken != nil;
 }
+
 - (BOOL)hasAdobeToken
 {
-  if(self.adobeToken) return YES;
-  
-  if(!self.adobeToken) return NO;
-  
-  @throw NSInternalInconsistencyException;
+  return self.adobeToken != nil;
 }
+
 - (BOOL)hasLicensor
 {
-  if(self.licensor) return YES;
-  
-  if(!self.licensor) return NO;
-  
-  @throw NSInternalInconsistencyException;
+  return self.licensor != nil;
 }
+
 - (NSString *)authorizationIdentifier
 {
   return [[NYPLKeychain sharedKeychain] objectForKey:authorizationIdentifierKey];
@@ -143,36 +127,38 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
 {
   return [[NYPLKeychain sharedKeychain] objectForKey:patronKey];
 }
+
 - (NSString *)patronFullName
 {
   return [NSString stringWithFormat:@"%@ %@ %@", self.patron[@"name"][@"first"], self.patron[@"name"][@"middle"],self.patron[@"name"][@"last"]];
 }
 
-
 - (NSString *)authToken
 {
   return [[NYPLKeychain sharedKeychain] objectForKey:authTokenKey];
 }
+
 - (NSString *)provider
 {
   return [[NYPLKeychain sharedKeychain] objectForKey:providerKey];
 }
+
 - (NSString *)userID
 {
   return [[NYPLKeychain sharedKeychain] objectForKey:userIDKey];
 }
+
 - (NSString *)deviceID
 {
   return [[NYPLKeychain sharedKeychain] objectForKey:deviceIDKey];
 }
-
 
 - (void)setBarcode:(NSString *const)barcode PIN:(NSString *)PIN
 {
   if(!(barcode && PIN)) {
     @throw NSInvalidArgumentException;
   }
-  
+
   [[NYPLKeychain sharedKeychain] setObject:barcode forKey:barcodeKey];
   [[NYPLKeychain sharedKeychain] setObject:PIN forKey:PINKey];
 
@@ -280,18 +266,20 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
    postNotificationName:NYPLAccountDidChangeNotification
    object:self];
 }
+
 - (void)setUserID:(NSString *)userID
 {
   if(!(userID)) {
     @throw NSInvalidArgumentException;
   }
-  
+
   [[NYPLKeychain sharedKeychain] setObject:userID forKey:userIDKey];
   
   [[NSNotificationCenter defaultCenter]
    postNotificationName:NYPLAccountDidChangeNotification
    object:self];
 }
+
 - (void)setDeviceID:(NSString *)deviceID
 {
   if(!(deviceID)) {
@@ -307,9 +295,6 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
 
 - (void)removeAll
 {
-  [[NYPLKeychain sharedKeychain] removeObjectForKey:barcodeKey];
-  [[NYPLKeychain sharedKeychain] removeObjectForKey:authorizationIdentifierKey];
-  [[NYPLKeychain sharedKeychain] removeObjectForKey:PINKey];
   [[NYPLKeychain sharedKeychain] removeObjectForKey:adobeTokenKey];
   [[NYPLKeychain sharedKeychain] removeObjectForKey:patronKey];
   [[NYPLKeychain sharedKeychain] removeObjectForKey:authTokenKey];
@@ -317,20 +302,8 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
   [[NYPLKeychain sharedKeychain] removeObjectForKey:providerKey];
   [[NYPLKeychain sharedKeychain] removeObjectForKey:userIDKey];
   [[NYPLKeychain sharedKeychain] removeObjectForKey:deviceIDKey];
-  
-  [[NSNotificationCenter defaultCenter]
-   postNotificationName:NYPLAccountDidChangeNotification
-   object:self];
-}
 
-
-- (void)removeObject:(NSString *const)key
-{
-  [[NYPLKeychain sharedKeychain] removeObjectForKey:key];
-  
-  [[NSNotificationCenter defaultCenter]
-   postNotificationName:NYPLAccountDidChangeNotification
-   object:self];
+  [self removeBarcodeAndPIN];
 }
 
 - (void)removeBarcodeAndPIN
@@ -338,7 +311,7 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
   [[NYPLKeychain sharedKeychain] removeObjectForKey:barcodeKey];
   [[NYPLKeychain sharedKeychain] removeObjectForKey:authorizationIdentifierKey];
   [[NYPLKeychain sharedKeychain] removeObjectForKey:PINKey];
-  
+
   [[NSNotificationCenter defaultCenter]
    postNotificationName:NYPLAccountDidChangeNotification
    object:self];

--- a/Simplified/NYPLAccount.m
+++ b/Simplified/NYPLAccount.m
@@ -175,6 +175,11 @@ NSString * deviceIDKey = @"NYPLAccountDeviceIDKey";
   
   [[NYPLKeychain sharedKeychain] setObject:barcode forKey:barcodeKey];
   [[NYPLKeychain sharedKeychain] setObject:PIN forKey:PINKey];
+
+  // make sure to set the barcode related to the current account (aka library)
+  // not the one we just signed in to, because we could have signed in into
+  // library A, but still browsing the catalog of library B.
+  [NYPLErrorLogger setUserID:[[NYPLAccount sharedAccount] barcode]];
   
   [[NSNotificationCenter defaultCenter]
    postNotificationName:NYPLAccountDidChangeNotification

--- a/Simplified/NYPLAppDelegate.m
+++ b/Simplified/NYPLAppDelegate.m
@@ -144,6 +144,11 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))backgroundF
   return YES;
 }
 
+-(void)applicationDidBecomeActive:(__unused UIApplication *)app
+{
+  [NYPLErrorLogger setUserID:[[NYPLAccount sharedAccount] barcode]];
+}
+
 - (void)applicationWillResignActive:(__attribute__((unused)) UIApplication *)application
 {
   [[NYPLBookRegistry sharedRegistry] save];

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -311,6 +311,8 @@ static NSString *const RecordsKey = @"records";
         }];
        return;
      }
+
+    [NYPLErrorLogger setUserID:[[NYPLAccount sharedAccount] barcode]];
      
      if(!self.syncShouldCommit) {
        NYPLLOG(@"[syncWithCompletionHandler] Sync shouldn't commit");

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -405,7 +405,7 @@ genericBookmarks:(NSArray<NYPLBookLocation *> *)genericBookmarks
     @throw NSInvalidArgumentException;
   }
   
-  if(state && state == NYPLBookStateUnregistered) {
+  if(state == NYPLBookStateUnregistered) {
     @throw NSInvalidArgumentException;
   }
   

--- a/Simplified/NYPLBookRegistryRecord.m
+++ b/Simplified/NYPLBookRegistryRecord.m
@@ -102,7 +102,18 @@ static NSString *const GenericBookmarksKey = @"genericBookmarks";
                    initWithDictionary:NYPLNullToNil(dictionary[LocationKey])];
   if(self.location && ![self.location isKindOfClass:[NYPLBookLocation class]]) return nil;
   
-  self.state = [NYPLBookStateHelper bookStateFromString:dictionary[StateKey]];
+  NSNumber *state = [NYPLBookStateHelper bookStateFromString:dictionary[StateKey]];
+  if (state) {
+    self.state = state.integerValue;
+  } else {
+    NSString *msg = [NSString stringWithFormat:
+                     @"Received state: %@ during BookRecord init. Input dict=%@",
+                     state, dictionary];
+    [NYPLErrorLogger logError:nil
+                         code:NYPLErrorCodeUnknownBookState
+                      message:msg];
+    @throw NSInvalidArgumentException;
+  }
   
   self.fulfillmentId = NYPLNullToNil(dictionary[FulfillmentIdKey]);
   

--- a/Simplified/NYPLBookState.swift
+++ b/Simplified/NYPLBookState.swift
@@ -73,8 +73,12 @@ class NYPLBookStateHelper : NSObject {
   }
     
   @objc(bookStateFromString:)
-  static func bookState(fromString string: String) -> Int {
-    return NYPLBookState.init(string)?.rawValue ?? -1
+  static func bookState(fromString string: String) -> NSNumber? {
+    guard let state = NYPLBookState(string) else {
+      return nil
+    }
+
+    return NSNumber(integerLiteral: state.rawValue)
   }
     
   @objc static func allBookStates() -> [NYPLBookState.RawValue] {

--- a/Simplified/NYPLDirectoryManager.swift
+++ b/Simplified/NYPLDirectoryManager.swift
@@ -6,7 +6,6 @@ import Foundation
   
   class func current() -> URL? {
     guard let account = AccountsManager.shared.currentAccount else {
-      NYPLErrorLogger.logUnexpectedNilAccount(context: "DirectoryManager::current")
       return nil
     }
     return directory(account.uuid)

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -43,9 +43,11 @@ fileprivate let nullString = "null"
   case deAuthFail = 301
   case barcodeException = 302
   case remoteLoginError = 303
-  case nilAccount = 304
   case userProfileDocFail = 305
   case nilSignUpURL = 306
+
+  /// Deprecated: use nilCurrentAccountUUID instead
+  case nilAccount = 304
 
   // audiobooks
   case audiobookEvent = 400
@@ -58,11 +60,20 @@ fileprivate let nullString = "null"
   case parseProfileTypeMismatch = 601
   case parseProfileValueNotFound = 602
   case parseProfileKeyNotFound = 603
+
+  // account management
+  case authDocLoadFail = 700
+  case errorProcessingAuthDoc = 701
+  case nilCurrentAccountUUID = 702
+  case catalogLoadError = 703
 }
 
 @objcMembers class NYPLErrorLogger : NSObject {
   class func configureCrashAnalytics() {
     FirebaseApp.configure()
+
+    let deviceID = UIDevice.current.identifierForVendor
+    Crashlytics.sharedInstance().setObjectValue(deviceID, forKey: "NYPLDeviceID")
   }
 
   class func setUserID(_ userID: String?) {
@@ -137,14 +148,14 @@ fileprivate let nullString = "null"
 
   // MARK:- Error Logging
 
-  /// Reports a generic error situation.
+  /// Reports an error situation.
   /// - Parameters:
   ///   - error: Any originating error obtained that occurred, if available.
   ///   - code: A code identifying the error situation.
   ///   - message: A string for further context.
   class func logError(_ error: Error? = nil,
-                      code: NYPLErrorCode = .noErr,
-                      message: String) {
+                      code: NYPLErrorCode,
+                      message: String? = nil) {
     logError(error, code: code, message: message)
   }
 
@@ -567,16 +578,16 @@ fileprivate let nullString = "null"
   //----------------------------------------------------------------------------
   // MARK: -
 
-  /// Reports a sign up error.
+  /// Helper to log a generic error to Crashlytics.
   /// - Parameters:
-  ///   - error: Any error obtained during the sign up process, if present.
+  ///   - error: Any originating error obtained that occurred, if available.
   ///   - code: A code identifying the error situation.
   ///   - context: Operating context to help identify where the error occurred.
   ///   - message: A string for further context.
   private class func logError(_ error: Error? = nil,
-                              code: NYPLErrorCode = .noErr,
+                              code: NYPLErrorCode,
                               context: String? = nil,
-                              message: String) {
+                              message: String? = nil) {
     var metadata = [AnyHashable : Any]()
     addAccountInfoToMetadata(&metadata)
 

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -66,7 +66,11 @@ fileprivate let nullString = "null"
   }
 
   class func setUserID(_ userID: String?) {
-    Crashlytics.sharedInstance().setUserIdentifier(userID)
+    if let userIDmd5 = userID?.md5hex() {
+      Crashlytics.sharedInstance().setUserIdentifier(userIDmd5)
+    } else {
+      Crashlytics.sharedInstance().setUserIdentifier(nil)
+    }
   }
 
   /// Broad areas providing some kind of operating context for error reporting.

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -65,6 +65,10 @@ fileprivate let nullString = "null"
     FirebaseApp.configure()
   }
 
+  class func setUserID(_ userID: String?) {
+    Crashlytics.sharedInstance().setUserIdentifier(userID)
+  }
+
   /// Broad areas providing some kind of operating context for error reporting.
   /// These are meant to be related to the code base more than functionality,
   /// (e.g. an error related to audiobooks may happen in different classes)

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -116,12 +116,15 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
     Log.debug(#file, "Task \(taskID) completed, elapsed time: \(elapsed) sec")
 
     if let error = error {
+      currentTaskInfo.completion(.failure(error))
+
+      // logging the error after the completion call so that the error report
+      // will include any eventual logging done in the completion handler.
       NYPLErrorLogger.logNetworkError(
         error,
         requestURL: task.originalRequest?.url,
         response: task.response,
         message: "Task \(taskID) completed with error")
-      currentTaskInfo.completion(.failure(error))
       return
     }
 

--- a/Simplified/String+MD5.swift
+++ b/Simplified/String+MD5.swift
@@ -17,4 +17,8 @@ extension String {
     
     return digestData
   }
+
+  public func md5hex() -> String {
+    return md5().map { String(format: "%02hhx", $0) }.joined()
+  }
 }

--- a/SimplifiedTests/NYPLBookStateTests.swift
+++ b/SimplifiedTests/NYPLBookStateTests.swift
@@ -28,15 +28,15 @@ class NYPLBookStateTests: XCTestCase {
     }
     
     func testBookStateFromString() {
-      XCTAssertEqual(NYPLBookState.Unregistered.rawValue, NYPLBookStateHelper.bookState(fromString: UnregisteredKey))
-      XCTAssertEqual(NYPLBookState.DownloadNeeded.rawValue, NYPLBookStateHelper.bookState(fromString: DownloadNeededKey))
-      XCTAssertEqual(NYPLBookState.Downloading.rawValue, NYPLBookStateHelper.bookState(fromString: DownloadingKey))
-      XCTAssertEqual(NYPLBookState.DownloadFailed.rawValue, NYPLBookStateHelper.bookState(fromString: DownloadFailedKey))
-      XCTAssertEqual(NYPLBookState.DownloadSuccessful.rawValue, NYPLBookStateHelper.bookState(fromString: DownloadSuccessfulKey))
-      XCTAssertEqual(NYPLBookState.Holding.rawValue, NYPLBookStateHelper.bookState(fromString: HoldingKey))
-      XCTAssertEqual(NYPLBookState.Used.rawValue, NYPLBookStateHelper.bookState(fromString: UsedKey))
-      XCTAssertEqual(NYPLBookState.Unsupported.rawValue, NYPLBookStateHelper.bookState(fromString: UnsupportedKey))
-      XCTAssertEqual(-1, NYPLBookStateHelper.bookState(fromString: "InvalidString"))
+      XCTAssertEqual(NYPLBookState.Unregistered.rawValue, NYPLBookStateHelper.bookState(fromString: UnregisteredKey)?.intValue)
+      XCTAssertEqual(NYPLBookState.DownloadNeeded.rawValue, NYPLBookStateHelper.bookState(fromString: DownloadNeededKey)?.intValue)
+      XCTAssertEqual(NYPLBookState.Downloading.rawValue, NYPLBookStateHelper.bookState(fromString: DownloadingKey)?.intValue)
+      XCTAssertEqual(NYPLBookState.DownloadFailed.rawValue, NYPLBookStateHelper.bookState(fromString: DownloadFailedKey)?.intValue)
+      XCTAssertEqual(NYPLBookState.DownloadSuccessful.rawValue, NYPLBookStateHelper.bookState(fromString: DownloadSuccessfulKey)?.intValue)
+      XCTAssertEqual(NYPLBookState.Holding.rawValue, NYPLBookStateHelper.bookState(fromString: HoldingKey)?.intValue)
+      XCTAssertEqual(NYPLBookState.Used.rawValue, NYPLBookStateHelper.bookState(fromString: UsedKey)?.intValue)
+      XCTAssertEqual(NYPLBookState.Unsupported.rawValue, NYPLBookStateHelper.bookState(fromString: UnsupportedKey)?.intValue)
+      XCTAssertNil(NYPLBookStateHelper.bookState(fromString: "InvalidString"))
     }
     
     func testAllBookState() {

--- a/SimplifiedTests/String+NYPLAdditionsTests.swift
+++ b/SimplifiedTests/String+NYPLAdditionsTests.swift
@@ -1,0 +1,16 @@
+//
+//  String+NYPLAdditionsTests.swift
+//  SimplyETests
+//
+//  Created by Ettore Pasquini on 4/8/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import XCTest
+@testable import SimplyE
+
+class String_NYPLAdditionsTests: XCTestCase {
+  func testMD5() {
+    XCTAssertEqual("password".md5hex(), "5f4dcc3b5aa765d61d8327deb882cf99")
+  }
+}


### PR DESCRIPTION
**What's this do?**
This adds user barcode (one-way hashed) tracking to Crashlytics to more easily diagnose hard-to-reproduce errors happening in the wild. Also adds a lot more logging related to account management. Fixes a couple differences accidentally introduced in 3.3.7 related to BookState handling.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2691

**How should this be tested? / Do these changes have associated tests?**
It's unlikely this change actually fixes the issue, plus we never got a clear set of reproducible steps. To test the additional logging and user tracking:
- sign in to a library with your barcode, browse around, sign into different libraries etc.
- ask me to compute the hash for your barcode(s)
- Load the Firebase console, click on Crashlytics, filter by 3.4.0, make sure you're not only looking at crashes, there's a lot of non-fatal events logged: https://console.firebase.google.com/project/simplye-nypl/crashlytics/app/ios:org.nypl.labs.SimplyE/issues?state=open&time=last-thirty-days&type=all
- click on Search by user ID, and enter the hash. You should get some results.
- Each event now should show some info, the most useful stuff is under "Keys". This should not be empty, depending on the event code.

**Dependencies for merging? Releasing to production?**
no dependencies

**Has the application documentation been updated for these changes?**
Added inline.

**Did someone actually run this code to verify it works?**
@ettore 