### PR TITLE
SIMPLY-2695 More logging for OPDS requests + better log searchability

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		738EF2EA2405EC1100F388FB /* FirebaseInstallations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 738EF2E42405EBAD00F388FB /* FirebaseInstallations.framework */; };
 		738EF2EC2405EC5900F388FB /* PromisesObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 738EF2EB2405EC5900F388FB /* PromisesObjC.framework */; };
 		73A3EAED2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 73A3EAEC2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m */; };
+		73CDA121243EDAD8009CC6A6 /* URLRequest+NYPL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CDA120243EDAD8009CC6A6 /* URLRequest+NYPL.swift */; };
 		841B55431B740F2700FAC1AF /* NYPLSettingsEULAViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 841B55421B740F2700FAC1AF /* NYPLSettingsEULAViewController.m */; };
 		84B7A3461B84E8FE00584FB2 /* OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3431B84E8FE00584FB2 /* OFL.txt */; };
 		84B7A3471B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3441B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf */; };
@@ -589,6 +590,7 @@
 		738EF2EB2405EC5900F388FB /* PromisesObjC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromisesObjC.framework; path = Carthage/Build/iOS/PromisesObjC.framework; sourceTree = "<group>"; };
 		73A3EAEB2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NYPLSettingsAccountURLSessionChallengeHandler.h; sourceTree = "<group>"; };
 		73A3EAEC2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NYPLSettingsAccountURLSessionChallengeHandler.m; sourceTree = "<group>"; };
+		73CDA120243EDAD8009CC6A6 /* URLRequest+NYPL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+NYPL.swift"; sourceTree = "<group>"; };
 		73DA43A02404B4A900985482 /* Crashlytics.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Crashlytics.json; sourceTree = SOURCE_ROOT; };
 		73DA43A12404B4A900985482 /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = SOURCE_ROOT; };
 		73DA43A32404B92E00985482 /* Cartfile.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = SOURCE_ROOT; };
@@ -1061,6 +1063,7 @@
 				111559EC19B8FA590003BE94 /* NYPLXML.m */,
 				179699D024131BA500EC309F /* UIColor+LabelColor.swift */,
 				7384C801242BCC4800D5F960 /* Date+NYPLAdditions.swift */,
+				73CDA120243EDAD8009CC6A6 /* URLRequest+NYPL.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1725,6 +1728,7 @@
 				E683953B217663B100371072 /* NYPLFacetViewDefaultDataSource.swift in Sources */,
 				E6207B652118973800864143 /* NYPLAppTheme.swift in Sources */,
 				11A14DF41A1BF94F00D6C510 /* UIColor+NYPLColorAdditions.m in Sources */,
+				73CDA121243EDAD8009CC6A6 /* URLRequest+NYPL.swift in Sources */,
 				A42E0DF41B40F4E00095EBAE /* NYPLCatalogFeedViewController.m in Sources */,
 				11B6020519806CD300800DA9 /* NYPLBookDownloadingCell.m in Sources */,
 				114B7F161A3644CF00B8582B /* NYPLTenPrintCoverView+NYPLImageAdditions.m in Sources */,

--- a/Simplified/AccountsManager.swift
+++ b/Simplified/AccountsManager.swift
@@ -54,7 +54,6 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
   var currentAccount: Account? {
     get {
       guard let uuid = currentAccountId else {
-        NYPLErrorLogger.logError(code: .nilCurrentAccountUUID)
         return nil
       }
 
@@ -147,8 +146,10 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
       if hadAccount != (self.currentAccount != nil) {
         self.currentAccount?.loadAuthenticationDocument { success in
           if !success {
-            NYPLErrorLogger.logError(code: .authDocLoadFail,
-                                     message: """
+            NYPLErrorLogger.logError(
+              withCode: .authDocLoadFail,
+              context: NYPLErrorLogger.Context.accountManagement.rawValue,
+              message: """
               Failed to load authentication document for current account: \
               \(self.currentAccount.debugDescription). A bunch of things \
               likely won't work.
@@ -181,7 +182,7 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
         completion(true)
       }
     } catch (let error) {
-      NYPLErrorLogger.logError(error, code: .errorProcessingAuthDoc,
+      NYPLErrorLogger.logError(error, 
                                message: "An error was thrown during loadAccountSetsAndAuthDoc")
       completion(false)
     }
@@ -210,7 +211,6 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
         }
       case .failure(let error):
         NYPLErrorLogger.logError(error,
-                                 code: .catalogLoadError,
                                  message: "Catalog failed to load from \(targetUrl)")
         self.callAndClearLoadingCompletionHandlers(key: hash, false)
       }

--- a/Simplified/NYPLBookRegistryRecord.m
+++ b/Simplified/NYPLBookRegistryRecord.m
@@ -109,9 +109,9 @@ static NSString *const GenericBookmarksKey = @"genericBookmarks";
     NSString *msg = [NSString stringWithFormat:
                      @"Received state: %@ during BookRecord init. Input dict=%@",
                      state, dictionary];
-    [NYPLErrorLogger logError:nil
-                         code:NYPLErrorCodeUnknownBookState
-                      message:msg];
+    [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeUnknownBookState
+                              context:@"NYPLBookRegistryRecord"
+                              message:msg];
     @throw NSInvalidArgumentException;
   }
   

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -108,18 +108,6 @@ fileprivate let nullString = "null"
   // MARK:- Generic helpers
 
   /**
-   Helper method for other logging functions that adds logs to our
-   crash reporting system.
-   */
-  private class func reportLogs() {
-    Log.logQueue.sync {
-      if let logs = (try? String(contentsOfFile: Log.logUrl.path, encoding: .utf8)) {
-        CLSNSLogv("%@",  getVaList([logs]))
-      }
-    }
-  }
-  
-  /**
    Helper method for other logging functions that adds relevant account info
    to our crash reporting system.
    - parameter metadata: report metadata dictionary
@@ -192,7 +180,7 @@ fileprivate let nullString = "null"
     metadata["bookTitle"] = book?.title ?? nullString
     metadata["revokeLink"] = book?.revokeURL?.absoluteString ?? nullString
     addAccountInfoToMetadata(&metadata)
-    reportLogs()
+
     let userInfo = additionalInfo(
       severity: .warning,
       message: "The book identifier was unexpectedly nil when attempting to return.",
@@ -215,7 +203,7 @@ fileprivate let nullString = "null"
     metadata["bookIdentifier"] = book?.identifier ?? nullString
     metadata["bookTitle"] = book?.title ?? nullString
     addAccountInfoToMetadata(&metadata)
-    reportLogs()
+
     let userInfo = additionalInfo(
       severity: .warning,
       message: message,
@@ -247,7 +235,6 @@ fileprivate let nullString = "null"
     metadata["renderer"] = location?.renderer ?? nullString
     metadata["openPageRequest idref"] = locationDictionary?["idref"] ?? nullString
     addAccountInfoToMetadata(&metadata)
-    reportLogs()
     
     let userInfo = additionalInfo(
       severity: .warning,
@@ -267,7 +254,6 @@ fileprivate let nullString = "null"
   class func logDeauthorizationError() {
     var metadata = [AnyHashable : Any]()
     addAccountInfoToMetadata(&metadata)
-    reportLogs()
     
     let userInfo = additionalInfo(
       severity: .info,
@@ -302,7 +288,6 @@ fileprivate let nullString = "null"
       metadata["responseMime"] = httpResponse.mimeType ?? nullString
     }
     addAccountInfoToMetadata(&metadata)
-    reportLogs()
 
     let userInfo = additionalInfo(
       severity: .info,
@@ -326,7 +311,6 @@ fileprivate let nullString = "null"
     metadata["libraryName"] = libraryName ?? nullString
     metadata["errorDescription"] = error?.localizedDescription ?? nullString
     addAccountInfoToMetadata(&metadata)
-    reportLogs()
     
     let userInfo = additionalInfo(
       severity: .info,
@@ -361,7 +345,6 @@ fileprivate let nullString = "null"
     var metadata = [AnyHashable : Any]()
     metadata["accountTypeID"] = accountId ?? nullString
     addAccountInfoToMetadata(&metadata)
-    reportLogs()
     
     let userInfo = additionalInfo(
       severity: .warning,
@@ -381,7 +364,6 @@ fileprivate let nullString = "null"
   class func logNewAppLaunch() {
     var metadata = [AnyHashable : Any]()
     addAccountInfoToMetadata(&metadata)
-    reportLogs()
     
     let userInfo = additionalInfo(severity: .info, metadata: metadata)
     let err = NSError(domain: simplyeDomain,
@@ -419,7 +401,6 @@ fileprivate let nullString = "null"
   class func logBarcodeException(_ exception: NSException?, library: String?) {
     var metadata = [AnyHashable : Any]()
     addAccountInfoToMetadata(&metadata)
-    reportLogs()
     
     let userInfo = additionalInfo(
       severity: .info,
@@ -444,7 +425,6 @@ fileprivate let nullString = "null"
     metadata["url"] = url ?? nullString
     metadata["errorDescription"] = error.localizedDescription
     addAccountInfoToMetadata(&metadata)
-    reportLogs()
 
     let userInfo = additionalInfo(
       severity: .error,
@@ -468,7 +448,6 @@ fileprivate let nullString = "null"
     metadata["url"] = url ?? nullString
     metadata["errorDescription"] = error.localizedDescription
     addAccountInfoToMetadata(&metadata)
-    reportLogs()
     
     let userInfo = additionalInfo(
       severity: .error,
@@ -490,7 +469,6 @@ fileprivate let nullString = "null"
     var metadata = [AnyHashable : Any]()
     metadata["errorDescription"] = error?.localizedDescription ?? nullString
     addAccountInfoToMetadata(&metadata)
-    reportLogs()
 
     let userInfo = additionalInfo(severity: .error, metadata: metadata)
     Crashlytics.sharedInstance().recordError(err,
@@ -569,6 +547,9 @@ fileprivate let nullString = "null"
                            message: message)
   }
 
+  //----------------------------------------------------------------------------
+  // MARK: - Private helpers
+
   @discardableResult
   private class func logNetworkError(_ error: Error? = nil,
                                      requestString: String?,
@@ -599,7 +580,6 @@ fileprivate let nullString = "null"
       Request \(requestString ?? "") failed. \
       Message: \(message ?? "<>"). Error: \(err)
       """)
-    reportLogs()
 
     let userInfo = additionalInfo(severity: .error,
                                   message: message,
@@ -608,9 +588,6 @@ fileprivate let nullString = "null"
                                              withAdditionalUserInfo: userInfo)
     return err
   }
-
-  //----------------------------------------------------------------------------
-  // MARK: -
 
   /// Helper to log a generic error to Crashlytics.
   /// - Parameters:
@@ -640,7 +617,7 @@ fileprivate let nullString = "null"
                                   message: message,
                                   context: context,
                                   metadata: metadata)
-    reportLogs()
+
     Crashlytics.sharedInstance().recordError(err,
                                              withAdditionalUserInfo: userInfo)
   }

--- a/Simplified/NYPLSession.h
+++ b/Simplified/NYPLSession.h
@@ -1,16 +1,27 @@
 @interface NYPLSession : NSObject
 
-+ (id)new NS_UNAVAILABLE;
-- (id)init NS_UNAVAILABLE;
++ (nonnull id)new NS_UNAVAILABLE;
+- (nonnull id)init NS_UNAVAILABLE;
 
-+ (NYPLSession *)sharedSession;
++ (nonnull NYPLSession *)sharedSession;
 
-- (void)uploadWithRequest:(NSURLRequest *)request completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))handler;
+- (void)uploadWithRequest:(nonnull NSURLRequest *)request
+        completionHandler:(void (^ _Nullable)(NSData * _Nullable data,
+                                              NSURLResponse * _Nullable response,
+                                              NSError * _Nullable error))handler;
 
-- (void)withURL:(NSURL *)URL completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))handler;
-
-- (void)withURLs:(NSSet *)URLs handler:(void (^)(NSDictionary *URLsToDataOrNull))handler;
-
-- (NSData *)cachedDataForURL:(NSURL *)URL;
+/**
+ Executes GET request for given URL, unless the URL path ends in "borrow", in
+ which cast a PUT is executed instead.
+ @param URL The endpoint to reach
+ @param handler This handler is always called once a response is received.
+ If @p error is not nil, @p data is always nil.
+ If @p error is nil, @p data may also be nil.
+ @return The request that was issued.
+ */
+- (nonnull NSURLRequest*)withURL:(nonnull NSURL *)URL
+               completionHandler:(void (^ _Nonnull)(NSData * _Nullable data,
+                                                    NSURLResponse * _Nullable response,
+                                                    NSError * _Nullable error))handler;
 
 @end

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -50,7 +50,13 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
   // MARK: - URLSessionDelegate
 
   func urlSession(_ session: URLSession, didBecomeInvalidWithError err: Error?) {
-    NYPLErrorLogger.logNetworkError(err, message: "URLSession became invalid")
+    if let err = err {
+      NYPLErrorLogger.logError(err, message: "URLSession became invalid")
+    } else {
+      NYPLErrorLogger.logError(withCode: .invalidURLSession,
+                               context: NYPLErrorLogger.Context.infrastructure.rawValue,
+                               message: "URLSession became invalid")
+    }
 
     taskInfoLock.lock()
     defer {
@@ -104,7 +110,7 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
 
     guard let currentTaskInfo = taskInfo.removeValue(forKey: taskID) else {
       NYPLErrorLogger.logNetworkError(
-        requestURL: task.originalRequest?.url,
+        request: task.originalRequest,
         response: task.response,
         message: "No task info available for task \(taskID)")
       return
@@ -122,7 +128,7 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
       // will include any eventual logging done in the completion handler.
       NYPLErrorLogger.logNetworkError(
         error,
-        requestURL: task.originalRequest?.url,
+        request: task.originalRequest,
         response: task.response,
         message: "Task \(taskID) completed with error")
       return

--- a/Simplified/Utilities/URLRequest+NYPL.swift
+++ b/Simplified/Utilities/URLRequest+NYPL.swift
@@ -1,0 +1,24 @@
+//
+//  URLRequest+NYPL.swift
+//  SimplyE
+//
+//  Created by Ettore Pasquini on 4/8/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+extension URLRequest {
+
+  /// Since a request can include sensitive data such as access tokens, etc,
+  /// this computed variable includes a "safe" set of data that we can log.
+  var loggableString: String {
+    return "\(httpMethod ?? "") \(url?.absoluteString ?? "")"
+  }
+}
+
+@objc extension NSURLRequest {
+  var loggableString: String {
+    return (self as URLRequest).loggableString
+  }
+}


### PR DESCRIPTION
**What's this do?**
When executing NYPLOPDSFeed requests now we capture more error situations that would have led to harder-to-diagnose parsing errors. For example the server returns 500s with non-nil plain text data but a nil error (somehow URLSession does not create it in this situation): previously we would have continued and tried to process the returned data, failing with a cryptic parse error.

This PR also improves searchability in Crashlytics by using our Context strings as `domain` for NSErrors that it creates, instead of always using "org.nypl.symplye". However CL allows searching only for error domain and code, so a constant domain string is meaningless.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2695

**How should this be tested? / Do these changes have associated tests?**
Sign in into Brooklyn lib and try to browse the various feeds. Reserve, borrow, and download books. You should not see errors, but if you do go to Crashlytics console and search by your Brooklyn user ID. You should see relevant errors being logged (you might have to way a few minutes for CL to populate).

**Dependencies for merging? Releasing to production?**
no dependencies

**Has the application documentation been updated for these changes?**
Added inline.

**Did someone actually run this code to verify it works?**
@ettore 