### PR TITLE
Standardizing curl build without idn2

### DIFF
--- a/build_curl.sh
+++ b/build_curl.sh
@@ -78,7 +78,7 @@ build()
     export CFLAGS="-arch ${ARCH} -pipe -Os -gdwarf-2 -isysroot ${SDK} -miphoneos-version-min=${MIN_VERSION}"
     export CPPFLAGS=${MOREFLAGS}
     export LDFLAGS="-arch ${ARCH} -isysroot ${SDK}"
-    ./configure --disable-shared --enable-static --enable-ipv6 --host=${HOST} --prefix="/tmp/curl-${CURL_VERSION}-${ARCH}" --with-darwinssl --enable-threaded-resolver &> "/tmp/curl-${CURL_VERSION}-${ARCH}.log"
+    ./configure --disable-shared --enable-static --enable-ipv6 --host=${HOST} --prefix="/tmp/curl-${CURL_VERSION}-${ARCH}" --with-darwinssl --without-libidn2 --enable-threaded-resolver &> "/tmp/curl-${CURL_VERSION}-${ARCH}.log"
     make -j `sysctl -n hw.logicalcpu_max` &> "/tmp/curl-${CURL_VERSION}-${ARCH}-build.log"
     make install &> "/tmp/curl-${CURL_VERSION}-${ARCH}-install.log"
     popd


### PR DESCRIPTION
**What's this do?**
Normalizes curl builds to exclude idn2

**Why are we doing this? (w/ JIRA link if applicable)**
My dev environment had idn2 installed and the curl config picked it up and tried to link it. This will ensure such variations won't happen with our curl builds.

**How should this be tested? / Do these changes have associated tests?**
Ensure the project builds and works

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@kyles-ep 
