### PR TITLE
Invalidate URLSession and fix memory leak

### DIFF
--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -174,6 +174,7 @@ static const NSInteger sSection1Sync = 1;
 
 - (void)dealloc
 {
+  [self.session finishTasksAndInvalidate];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 


### PR DESCRIPTION
**What's this do?**
Fixes a memory leak related to missing invalidating the URLSession in NYPLSettingsAccountDetailViewController.

**Why are we doing this? (w/ JIRA link if applicable)**
This was introduced back in February but was should/could have been fixed in SIMPLY-2765.

**How should this be tested? / Do these changes have associated tests?**
Not really visible to the user, but stopping the memory debugger after going to a library account page in Settings, then going back, should not show living instances of NYPLSettingsAccountDetailViewController.

**Dependencies for merging? Releasing to production?**
Should be included in upcoming 3.4.0.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ettore 