### PR TITLE
Use authorization_identifier for juvenile APIs

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,6 +1,6 @@
 binary "Crashlytics.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json"
-github "NYPL-Simplified/CardCreator-iOS" ~> 1.1.2
+github "NYPL-Simplified/CardCreator-iOS" ~> 1.2
 github "NYPL-Simplified/NYPLAEToolkit" "master"
 github "NYPL-Simplified/NYPLAudiobookToolkit" "master"
 github "PureLayout/PureLayout" ~> 3.1.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 binary "Crashlytics.json" "3.14.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "6.24.0"
-github "NYPL-Simplified/CardCreator-iOS" "v1.1.2"
+github "NYPL-Simplified/CardCreator-iOS" "v1.2"
 github "NYPL-Simplified/NYPLAEToolkit" "038b7de4fcc777542eedffdb6427087c3f5799a7"
 github "NYPL-Simplified/NYPLAudiobookToolkit" "d43d64389810a519ba3cdf8fbc63bd59e2635d3d"
 github "NYPL-Simplified/PDFRendererProvider-iOS" "b0ee13aa74e0d88193a401c29624dda8120a340d"

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -85,7 +85,19 @@ static const NSInteger sSection1Sync = 1;
 
 @implementation NYPLSettingsAccountDetailViewController
 
+/*
+ For NYPL, this field can accept any of the following:
+ - a username
+ - a 14-digit NYPL-issued barcode
+ - a 16-digit NYC ID issued by the city of New York to its residents. Patrons
+ can set up the NYC ID as a NYPL barcode even if they already have a NYPL card.
+ All of these types of authentication can be used with the PIN to sign in.
+ - Note: A patron can have multiple barcodes, because patrons may lose
+their library card and get a new one with a different barcode.
+Authenticating with any of those barcodes should work.
+ */
 @synthesize usernameTextField;
+
 @synthesize PINTextField;
 
 #pragma mark - Computed variables


### PR DESCRIPTION
**What's this do?**
Uses the authorization_identifier to source the barcode to provide to the juvenile-creation APIs.

**Why are we doing this? (w/ JIRA link if applicable)**
The barcode field in NYPLUserAccount may contain either a barcode or the username, but the Platform APIs for juvenile accounts require to specify what you're passing in (either a barcode or username), but we on the client don't know what the user has signed in with.

For NYPL accounts, and only for NYPL Accounts, the NYPLUserAccount::authorization_identifier instead always contains a barcode: this can be a 14-digit NYPL-issued barcode, or a 16-digit NYC ID (issued by the city of NY). This was confirmed by @leonardr.

**How should this be tested? / Do these changes have associated tests?**
Assuming you verified the juvenile flow in other preceding tickets by signing in to SimplyE via a NYPL barcode, gather the username for that same user, and sign in via the username.
Make sure that user didn't already create 3 juvenile accounts.
Then start the juvenile flow: you should still be eligible to create a juvenile account. I don't think you need to complete the full flow to verify this ticket, since a first eligibility api call is made before even showing the first screen.
It would be good to repeat this by signing in to SimplyE with a NYC ID.

**Dependencies for merging? Releasing to production?**
Merging to feature branch.

**Has the application documentation been updated for these changes?**
Yes. I added comments in this PR based on the discussion with @leonardr and @EdwinGuzman.

**Did someone actually run this code to verify it works?**
@ettore 