### PR TITLE
Add nullability to NYPLRoundedButton + swiftier alert method

### DIFF
--- a/Simplified/NYPLAlertUtils.swift
+++ b/Simplified/NYPLAlertUtils.swift
@@ -129,24 +129,30 @@ import UIKit
   }
   
   /**
-    Presents an alert view from another given view
-    @param alertController the alert to display
-    @param viewController the view from which the alert is displayed
-    @param animated true/false for animation
-    @param completion callback passed on to UIViewcontroller::present
-    @return
+   Presents an alert view from another given view
+
+   - Parameters:
+     - alertController: The alert to display.
+     - viewController: The view from which the alert is displayed.
+     - animated: Whether to animate the presentation of the alert or not.
+     - completion: Callback passed on to UIViewcontroller::present().
    */
-  class func presentFromViewControllerOrNil(alertController: UIAlertController?, viewController: UIViewController?, animated: Bool, completion: (() -> Void)?) {
+  class func presentFromViewControllerOrNil(alertController: UIAlertController?,
+                                            viewController: UIViewController?,
+                                            animated: Bool,
+                                            completion: (() -> Void)?) {
     guard let alertController = alertController else {
       return
     }
-    if (viewController == nil) {
+
+    guard let vc = viewController else {
       NYPLRootTabBarController.shared()?.safelyPresentViewController(alertController, animated: animated, completion: completion)
-    } else {
-      viewController!.present(alertController, animated: animated, completion: completion)
-      if alertController.message != nil {
-        Log.info(#file, alertController.message!)
-      }
+      return
+    }
+
+    vc.present(alertController, animated: animated, completion: completion)
+    if let msg = alertController.message {
+      Log.info(#file, msg)
     }
   }
 }

--- a/Simplified/NYPLRoundedButton.h
+++ b/Simplified/NYPLRoundedButton.h
@@ -5,16 +5,16 @@ typedef NS_ENUM(NSInteger, NYPLRoundedButtonType) {
 
 @interface NYPLRoundedButton : UIButton
 
-+ (id)buttonWithType:(UIButtonType)buttonType NS_UNAVAILABLE;
-+ (id)new NS_UNAVAILABLE;
-- (id)init NS_UNAVAILABLE;
-- (id)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
-- (id)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
++ (nonnull id)buttonWithType:(UIButtonType)buttonType NS_UNAVAILABLE;
++ (nonnull id)new NS_UNAVAILABLE;
+- (nonnull id)init NS_UNAVAILABLE;
+- (nullable id)initWithCoder:(nonnull NSCoder *)aDecoder NS_UNAVAILABLE;
+- (nonnull id)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
 
 @property (nonatomic) NYPLRoundedButtonType type;
-@property (nonatomic) NSDate *endDate;
+@property (nonatomic, nullable) NSDate *endDate;
 @property (nonatomic) BOOL fromDetailView;
 
-+ (instancetype)button;
++ (nonnull instancetype)button;
 
 @end


### PR DESCRIPTION
**What's this do?**
Adds nullability annotations to NYPLRoundedButton and improves code readability in one of our alert methods.

**Why are we doing this? (w/ JIRA link if applicable)**
Objc Nullability is important when interoperating with Swift. I looked at all code paths where NYPLRoundedButton is used between objc-swift.

**How should this be tested? / Do these changes have associated tests?**
There's no specific QA steps here, beside some exploratory testing in relation to bookmarking.

**Dependencies for merging? Releasing to production?**
Not releasing to prod right now.

**Has the application documentation been updated for these changes?**
Yes.

**Did someone actually run this code to verify it works?**
@ettore 