### PR TITLE
SIMPLY-2803 Implement bookmark removal functionality

### DIFF
--- a/Simplified/NYPLBookRegistry.h
+++ b/Simplified/NYPLBookRegistry.h
@@ -39,7 +39,10 @@ static NSString *const _Nonnull NYPLBookProcessingDidChangeNotification =
 // directory is not guaranteed to exist at the time this method is called.
 - (nullable NSURL *)registryDirectory;
 
-// Saves the registry. This should be called before the application is terminated.
+/**
+ Saves the registry to disk. This should be called before the application
+ is terminated.
+ */
 - (void)save;
 
 - (void)justLoad;
@@ -141,7 +144,10 @@ genericBookmarks:(nullable NSArray<NYPLBookLocation *> *)genericBookmarks;
 - (void)addReadiumBookmark:(nonnull NYPLReadiumBookmark *)bookmark
              forIdentifier:(nonnull NSString *)identifier;
   
-// Delete bookmark for a book given its identifer
+/**
+ Delete bookmark for a book given its identifer and saves updated registry
+ to disk.
+ */
 - (void)deleteReadiumBookmark:(nonnull NYPLReadiumBookmark *)bookmark
                 forIdentifier:(nonnull NSString *)identifier;
 

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -274,11 +274,23 @@ class NYPLBaseReaderViewController: UIViewController, NYPLBackgroundWorkOwner, L
     updateBookmarkButton(withState: true)
   }
 
-  // TODO: SIMPLY-2803
   private func deleteBookmark(_ bookmark: NYPLReadiumBookmark) {
-    // see NYPLReaderReadiumView::deleteBookmark
-    updateBookmarkButton(withState: false)
+    bookmarksBusinessLogic.deleteBookmark(bookmark)
+    didDeleteBookmark(bookmark)
   }
+
+  private func didDeleteBookmark(_ bookmark: NYPLReadiumBookmark) {
+    // at this point the bookmark has already been removed, so we just need
+    // to verify that the user is not at the same location of another bookmark,
+    // in which case the bookmark icon will be lit up and should stay lit up.
+    if
+      let loc = bookmarksBusinessLogic.currentLocation(in: navigator),
+      bookmarksBusinessLogic.isBookmarkExisting(at: loc) == nil {
+
+      updateBookmarkButton(withState: false)
+    }
+  }
+
 
   //----------------------------------------------------------------------------
   // MARK: - Accessibility
@@ -433,7 +445,7 @@ extension NYPLBaseReaderViewController: NYPLReaderPositionsDelegate {
 
   func positionsVC(_ positionsVC: NYPLReaderPositionsVC,
                    didDeleteBookmark bookmark: NYPLReadiumBookmark) {
-    // TODO: SIMPLY-2803
+    didDeleteBookmark(bookmark)
   }
 
   func positionsVC(_ positionsVC: NYPLReaderPositionsVC,

--- a/Simplified/Reader2/UI/NYPLReaderPositionsVC.swift
+++ b/Simplified/Reader2/UI/NYPLReaderPositionsVC.swift
@@ -232,11 +232,13 @@ class NYPLReaderPositionsVC: UIViewController, UITableViewDataSource, UITableVie
     case .toc:
       break;
     case .bookmarks:
-      if editingStyle == .delete {
-        if let removedBookmark = bookmarksBusinessLogic?.removeBookmark(at: indexPath.row) {
-          delegate?.positionsVC(self, didDeleteBookmark: removedBookmark)
-          tableView.deleteRows(at: [indexPath], with: .fade)
-        }
+      guard editingStyle == .delete else {
+        return
+      }
+      
+      if let removedBookmark = bookmarksBusinessLogic?.deleteBookmark(at: indexPath.row) {
+        delegate?.positionsVC(self, didDeleteBookmark: removedBookmark)
+        tableView.deleteRows(at: [indexPath], with: .fade)
       }
     }
   }


### PR DESCRIPTION
**What's this do?**
Removes a bookmark from the business logic / UI objects. It considers 2 flows: 
1. from drop down list in TOC
2. from right-most icon when it's lit up to signify we are positioned on a bookmarked page.

Does not persist bookmarks on server, for that see SiMPLY-2804. 

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2803

**How should this be tested? / Do these changes have associated tests?**
Might be good to test once the parent story SIMPLY-2608 is complete.
Other than that:
1. add a bookmark, verify it's added
2. re-tap on the same icon to remove bookmark. verify it's removed by opening TOC/bookmarks dropdown.
3. add another bookmark
4. open the dropdown list, and swipe to remove.

**Dependencies for merging? Releasing to production?**
merging to feature branch

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 