### PR TITLE
SIMPLY-2843 Log every sign in/out error + provide better user messages

### DIFF
--- a/Simplified/Account.swift
+++ b/Simplified/Account.swift
@@ -326,7 +326,12 @@ private let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
   /// thread or not.
   func loadAuthenticationDocument(completion: @escaping (Bool) -> ()) {
     guard let urlString = authenticationDocumentUrl, let url = URL(string: urlString) else {
-      Log.error(#file, "Invalid or missing authentication document URL")
+      NYPLErrorLogger.logError(
+        withCode: .noURL,
+        context: NYPLErrorLogger.Context.accountManagement.rawValue,
+        message: "Failed to load authentication document because its URL is invalid",
+        metadata: ["self.uuid": uuid]
+      )
       completion(false)
       return
     }
@@ -339,16 +344,21 @@ private let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
             OPDS2AuthenticationDocument.fromData(serverData)
           completion(true)
         } catch (let error) {
-          Log.error(#file, """
-            Failed to parse authentication document data for URL \(url). Error:
-            \(error.localizedDescription)
-            """)
+          NYPLErrorLogger.logError(
+            withCode: .authDocParseFail,
+            context: NYPLErrorLogger.Context.accountManagement.rawValue,
+            message: "Failed to parse authentication document data obtained from \(url)",
+            metadata: ["underlyingError": error]
+          )
           completion(false)
         }
       case .failure(let error):
-        Log.error(#file, """
-          Failed to load authentication document at URL \(url). Error: \(error)
-          """)
+        NYPLErrorLogger.logError(
+          withCode: .authDocLoadFail,
+          context: NYPLErrorLogger.Context.accountManagement.rawValue,
+          message: "Request to load authentication document at \(url) failed.",
+          metadata: ["underlyingError": error]
+        )
         completion(false)
       }
     }

--- a/Simplified/NYPLAlertUtils.swift
+++ b/Simplified/NYPLAlertUtils.swift
@@ -42,7 +42,7 @@ import UIKit
     if customMessage != nil { // Custom message override
       message = customMessage as! String
     } else if message.isEmpty { // Handle unassigned message
-      message = "UnknownError"
+      message = "An error occurred. Please try again later or report an issue from the Settings tab."
     }
     
     return alert(title: title, message: message)

--- a/Simplified/NYPLBookCellDelegate.m
+++ b/Simplified/NYPLBookCellDelegate.m
@@ -228,16 +228,17 @@
 - (void)registerCallbackForLogHandler
 {
   [DefaultAudiobookManager setLogHandler:^(enum LogLevel level, NSString * _Nonnull message, NSError * _Nullable error) {
+    NSString *msg = [NSString stringWithFormat:@"Level: %ld. Message: %@",
+                     (long)level, message];
+
     if (error) {
       [NYPLErrorLogger logAudiobookIssue:error
                                 severity:NYPLSeverityError
-                                 message:message];
+                                 message:msg];
     } else {
-      if (level != LogLevelDebug) {
+      if (level > LogLevelDebug) {
         NSError *error = [NSError errorWithDomain:@"org.nypl.labs.audiobookToolkit" code:0 userInfo:nil];
-        NSString *msg = [NSString stringWithFormat:@"Level: %ld. Message: %@",
-                         (long)level, message];
-        
+
         NYPLSeverity severity = level == LogLevelInfo ? NYPLSeverityInfo : level == LogLevelWarn ? NYPLSeverityWarning : NYPLSeverityError;
         [NYPLErrorLogger logAudiobookIssue:error
                                   severity:severity

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -181,8 +181,10 @@ didFinishDownloadingToURL:(NSURL *const)location
     problemDocument = [NYPLProblemDocument fromData:[NSData dataWithContentsOfURL:location] error:&problemDocumentParseError];
     if (problemDocumentParseError) {
       [NYPLErrorLogger logProblemDocumentParseError:problemDocumentParseError
+                                            barcode:NYPLUserAccount.sharedAccount.barcode
                                                 url:location
-                                            context:@"myBooks-download-finish"];
+                                            context:@"myBooks-download-finish"
+                                            message:@"Error downloading book"];
     }
     [[NSFileManager defaultManager] removeItemAtURL:location error:NULL];
     success = NO;

--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -90,11 +90,23 @@ static NYPLOPDSFeedType TypeImpliedByEntry(NYPLOPDSEntry *const entry)
         // this captures a situation where (e.g.) borrow requests to the
         // Brooklyn lib come back with a 500 status code, no error, and non-nil
         // data containing "An internal error occurred" plain text.
-        NSString *msg = [NSString stringWithFormat:@"Got %ld HTTP status with no error object. Received data: `%@`", (long)httpResp.statusCode, [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]];
-        [NYPLErrorLogger logNetworkError:nil
+        NSString *msg = [NSString stringWithFormat:@"Got %ld HTTP status with no error object.", (long)httpResp.statusCode];
+
+        NSString *dataString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        if (dataString == nil) {
+          dataString = [NSString stringWithFormat:@"datalength=%lu",
+                        (unsigned long)data.length];
+        }
+
+        [NYPLErrorLogger logNetworkError:error
+                                    code:NYPLErrorCodeApiCall
+                                 context:NSStringFromClass([self class])
                                  request:request
                                 response:response
-                                 message:msg];
+                                 message:msg
+                                metadata:@{
+                                  @"receivedData": dataString ?: @""
+                                }];
 
         NSDictionary *errorDict = nil;
         if ([response.MIMEType isEqualToString:@"application/problem+json"]

--- a/Simplified/NYPLRemoteViewController.m
+++ b/Simplified/NYPLRemoteViewController.m
@@ -279,8 +279,10 @@
 
     if (problemDocumentParseError) {
       [NYPLErrorLogger logProblemDocumentParseError:problemDocumentParseError
+                                            barcode:nil
                                                 url:[self.response URL]
-                                            context:@"RemoteViewController"];
+                                            context:@"RemoteViewController"
+                                            message:@"Server-side api call (likely related to Catalog loading) failed and couldn't parse the problem doc either"];
       alert = [NYPLAlertUtils
                alertWithTitle:NSLocalizedString(@"Error", @"Title for a generic error")
                message:NSLocalizedString(@"Unknown error parsing problem document",

--- a/Simplified/NYPLSession.m
+++ b/Simplified/NYPLSession.m
@@ -105,10 +105,19 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *const)challenge
                         NSError *const error) {
     if (error) {
       NSString *dataString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+      if (dataString == nil) {
+        dataString = [NSString stringWithFormat:@"datalength=%lu",
+                      (unsigned long)data.length];
+      }
       [NYPLErrorLogger logNetworkError:error
+                                  code:NYPLErrorCodeApiCall
+                               context:NSStringFromClass([self class])
                                request:req
                               response:response
-                               message:dataString];
+                               message:@"NYPLSession error"
+                              metadata:@{
+                                @"receivedData": dataString ?: @""
+                              }];
       handler(nil, response, error);
       return;
     }

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -110,6 +110,8 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
 
     guard let currentTaskInfo = taskInfo.removeValue(forKey: taskID) else {
       NYPLErrorLogger.logNetworkError(
+        error,
+        code: .noTaskInfoAvailable,
         request: task.originalRequest,
         response: task.response,
         message: "No task info available for task \(taskID)")

--- a/Simplified/String+MD5.swift
+++ b/Simplified/String+MD5.swift
@@ -22,3 +22,9 @@ extension String {
     return md5().map { String(format: "%02hhx", $0) }.joined()
   }
 }
+
+@objc extension NSString {
+  public func md5String() -> NSString {
+    return (self as String).md5hex() as NSString
+  }
+}


### PR DESCRIPTION
**What's this do?**
I did a review of both Sign In VCs and logged every single error that can originate from both.
Also made sure to log the (hashed) barcode since it won't be otherwise available in Crashlytics if sign-in fails.
All errors logged to Crashlytics are now wrapped in a new NSError we generate and log, instead of logging the original error. This should make it more obvious which parts of the app are affected instead of (for example) seeing a generic "Request timeout" error in Crashlytics.
Also, this PR adds an alert before performing sign-out to warn the user that book downloads/returns authorizations or book registry syncing is in progress.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2843
https://jira.nypl.org/browse/SIMPLY-2857

**How should this be tested? / Do these changes have associated tests?**
Every time you encounter a sign-in error you should now be able to see it in Crashlytics. It should also be simple to understand if the error is a server-side or client-side one. Filtering by version will make it pretty easy to see your error events.
To test the new alert try to slow down the internet speed with the Network Link Conditioner. Then try download of a large book or trigger a book registry sync and quickly enough log out. This should trigger the new alert (see ticket).

**Dependencies for merging? Releasing to production?**
Merging to hot fix branch. I will also  merge to release branch to develop to minimize conflicts.

**Has the application documentation been updated for these changes?**
I added docs in the codebase.

**Did someone actually run this code to verify it works?**
@ettore 