### PR TITLE
SIMPLY-2843, SIMPLY-2853, SIMPLY-2857: Recover from errors on Catalog and Accounts pages

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -170,6 +170,8 @@
 		732F929323ECB51F0099244C /* NYPLBackgroundExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732F929223ECB51F0099244C /* NYPLBackgroundExecutor.swift */; };
 		733875652423E1B0000FEB67 /* NYPLNetworkExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733875642423E1B0000FEB67 /* NYPLNetworkExecutor.swift */; };
 		733875672423E540000FEB67 /* NYPLCaching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733875662423E540000FEB67 /* NYPLCaching.swift */; };
+		7340DA6224B7E45C00361387 /* URLResponse+NYPL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */; };
+		7340DA6824B7F27900361387 /* NYPLBook+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340DA6724B7F27900361387 /* NYPLBook+Additions.swift */; };
 		735F41A3243E381D00046182 /* String+NYPLAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735F41A2243E381D00046182 /* String+NYPLAdditionsTests.swift */; };
 		735FED262427494900144C97 /* NYPLNetworkResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735FED252427494900144C97 /* NYPLNetworkResponder.swift */; };
 		7384C800242BB43400D5F960 /* NYPLCachingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7384C7FF242BB43300D5F960 /* NYPLCachingTests.swift */; };
@@ -571,6 +573,8 @@
 		732F929223ECB51F0099244C /* NYPLBackgroundExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBackgroundExecutor.swift; sourceTree = "<group>"; };
 		733875642423E1B0000FEB67 /* NYPLNetworkExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLNetworkExecutor.swift; sourceTree = "<group>"; };
 		733875662423E540000FEB67 /* NYPLCaching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLCaching.swift; sourceTree = "<group>"; };
+		7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLResponse+NYPL.swift"; sourceTree = "<group>"; };
+		7340DA6724B7F27900361387 /* NYPLBook+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLBook+Additions.swift"; sourceTree = "<group>"; };
 		735F41A2243E381D00046182 /* String+NYPLAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+NYPLAdditionsTests.swift"; sourceTree = "<group>"; };
 		735FED252427494900144C97 /* NYPLNetworkResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLNetworkResponder.swift; sourceTree = "<group>"; };
 		73609AD8245B53CB00F0E08B /* update-certificates.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "update-certificates.sh"; sourceTree = SOURCE_ROOT; };
@@ -1072,6 +1076,8 @@
 				179699D024131BA500EC309F /* UIColor+LabelColor.swift */,
 				7384C801242BCC4800D5F960 /* Date+NYPLAdditions.swift */,
 				73CDA120243EDAD8009CC6A6 /* URLRequest+NYPL.swift */,
+				7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */,
+				7340DA6724B7F27900361387 /* NYPLBook+Additions.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1757,6 +1763,7 @@
 				2DB436381D4C049200F8E69D /* NYPLReachability.m in Sources */,
 				1195040B1994075B009FB788 /* NYPLReaderViewController.m in Sources */,
 				1183F33B194B775900DC322F /* NYPLCatalogLaneCell.m in Sources */,
+				7340DA6224B7E45C00361387 /* URLResponse+NYPL.swift in Sources */,
 				E6202A021DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.m in Sources */,
 				113137E71A48DAB90082954E /* NYPLReaderReadiumView.m in Sources */,
 				E68CCFC51F9F80CF003DDA6C /* NYPLBarcode.swift in Sources */,
@@ -1842,6 +1849,7 @@
 				114C8CDA19BF55F900719B72 /* NYPLRoundedButton.m in Sources */,
 				AE77EB0CB5B94AEC591E2D91 /* NYPLOPDSLink.m in Sources */,
 				AE77E7E37D89FB3EED630624 /* NYPLOPDSType.m in Sources */,
+				7340DA6824B7F27900361387 /* NYPLBook+Additions.swift in Sources */,
 				A949984F2235826500CE4241 /* NYPLPDFViewControllerDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2075,7 +2083,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2122,7 +2130,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Simplified/Account.swift
+++ b/Simplified/Account.swift
@@ -323,7 +323,7 @@ private let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
   /// Load authentication documents from the network or cache.
   /// - Parameter completion: Always invoked at the end of the load process.
   /// No guarantees are being made about whether this is called on the main
-  /// thread or not.
+  /// thread or not. This closure is not retained by `self`.
   func loadAuthenticationDocument(completion: @escaping (Bool) -> ()) {
     guard let urlString = authenticationDocumentUrl, let url = URL(string: urlString) else {
       NYPLErrorLogger.logError(
@@ -344,11 +344,15 @@ private let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
             OPDS2AuthenticationDocument.fromData(serverData)
           completion(true)
         } catch (let error) {
+          let responseBody = String(data: serverData, encoding: .utf8)
           NYPLErrorLogger.logError(
             withCode: .authDocParseFail,
             context: NYPLErrorLogger.Context.accountManagement.rawValue,
             message: "Failed to parse authentication document data obtained from \(url)",
-            metadata: ["underlyingError": error]
+            metadata: [
+              "underlyingError": error,
+              "responseBody": responseBody ?? ""
+            ]
           )
           completion(false)
         }
@@ -378,6 +382,7 @@ extension AccountDetails {
 extension Account {
   override var debugDescription: String {
     return """
+    name=\(name)
     uuid=\(uuid)
     catalogURL=\(String(describing: catalogUrl))
     authDocURL=\(String(describing: authenticationDocumentUrl))

--- a/Simplified/AccountsManager.swift
+++ b/Simplified/AccountsManager.swift
@@ -78,7 +78,7 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
     
     NotificationCenter.default.addObserver(
       self,
-      selector: #selector(updateAccountSetFromSettings),
+      selector: #selector(updateAccountSet),
       name: NSNotification.Name.NYPLUseBetaDidChange,
       object: nil
     )
@@ -150,10 +150,13 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
               withCode: .authDocLoadFail,
               context: NYPLErrorLogger.Context.accountManagement.rawValue,
               message: """
-              Failed to load authentication document for current account: \
-              \(self.currentAccount.debugDescription). A bunch of things \
-              likely won't work.
-              """)
+              Failed to load authentication document for current library: \
+              \(self.currentAccount?.name ?? "N/A"). Will still attempt to \
+              load catalogURL \(self.currentAccount?.catalogUrl ?? "N/A").
+              """,
+              metadata: [
+                "currentLibrary": self.currentAccount?.debugDescription ?? "N/A"
+            ])
           }
 
           DispatchQueue.main.async {
@@ -188,7 +191,11 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
     }
   }
 
-  /// Loads library catalogs from the network, or cache if available.
+  /// Loads library catalogs from the network or cache if available.
+  ///
+  /// After loading the library accounts, the authentication document
+  /// for the current library will be loaded in sequence.
+  ///
   /// - Parameter completion: Always invoked at the end of the load process.
   /// No guarantees are being made about whether this is called on the main
   /// thread or not.
@@ -241,10 +248,10 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
     return self.accountSets[k] ?? []
   }
   
-  func updateAccountSetFromSettings() {
+  func updateAccountSet(completion: @escaping (Bool) -> () = { _ in }) {
     self.accountSet = NYPLSettings.shared.useBetaLibraries ? betaUrlHash : prodUrlHash
     if self.accounts().isEmpty {
-      loadCatalogs(completion: {_ in })
+      loadCatalogs(completion: completion)
     }
   }
 

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -866,7 +866,7 @@ completionHandler:(void (^)(void))handler
            } else {
              NYPLLOG(@"Login Failed: No Licensor Token received or parsed from user profile document");
              [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoLicensorToken
-                                       context:@"SignIn-settingsTab"
+                                       context:@"SignIn-modal"
                                        message:@"The UserProfileDocument obtained from the server contained no licensor token."
                                       metadata:@{
                                         @"hashedBarcode": barcode.md5String

--- a/Simplified/NYPLCatalogSearchViewController.m
+++ b/Simplified/NYPLCatalogSearchViewController.m
@@ -115,7 +115,6 @@
   [self.noResultsLabel integralizeFrame];
 
   [self.reloadView centerInSuperview];
-  [self.reloadView integralizeFrame];
 }
 
 - (void)viewDidLayoutSubviews

--- a/Simplified/NYPLDirectoryManager.swift
+++ b/Simplified/NYPLDirectoryManager.swift
@@ -15,14 +15,11 @@ import Foundation
     let paths = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)
     
     if paths.count < 1 {
-      NYPLErrorLogger.logFileSystemIssue(severity: .error,
-                                         message: "No valid paths",
-                                         context: "DirectoryManager::directory")
+      NYPLErrorLogger.logError(withCode: .missingSystemPaths,
+                               context: "DirectoryManager::directory",
+                               message: "No valid search paths in iOS's ApplicationSupport directory in the UserDomain",
+                               metadata: ["account": account])
       return nil
-    } else if paths.count > 1 {
-      NYPLErrorLogger.logFileSystemIssue(severity: .warning,
-                                         message: "Multiple paths",
-                                         context: "DirectoryManager::directory")
     }
     
     var directoryURL = URL.init(fileURLWithPath: paths[0]).appendingPathComponent(Bundle.main.object(forInfoDictionaryKey: "CFBundleIdentifier") as! String)

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -26,9 +26,6 @@ fileprivate let nullString = "null"
 @objc enum NYPLErrorCode: Int {
   case ignore = 0
 
-  // low-level / system related
-  case fileSystemFail = 1
-
   // generic app related
   case appLaunch = 100
 
@@ -89,6 +86,15 @@ fileprivate let nullString = "null"
   case problemDocMessageDisplayed = 905
   case unableToMakeVCAfterLoading = 906
   case noTaskInfoAvailable = 907
+  case downloadFail = 908
+
+  // wrong content
+  case unknownRightsManagement = 1100
+  case unexpectedFormat = 1101
+
+  // low-level / system related
+  case missingSystemPaths = 1200
+  case fileMoveFail = 1201
 }
 
 @objcMembers class NYPLErrorLogger : NSObject {
@@ -481,25 +487,6 @@ fileprivate let nullString = "null"
     let userInfo = additionalInfo(severity: .info, metadata: metadata)
     let err = NSError(domain: simplyeDomain,
                       code: NYPLErrorCode.appLaunch.rawValue,
-                      userInfo: userInfo)
-
-    Crashlytics.sharedInstance().recordError(err)
-  }
-
-  /**
-   Report a generic path issue when dealing with file system apis.
-   - parameter severity: how critical the user experience is impacted.
-   - parameter message: Message to associate with report.
-   - parameter context: Where this issue arose.
-   */
-  class func logFileSystemIssue(severity: NYPLSeverity,
-                                message: String,
-                                context: String) {
-    let userInfo = additionalInfo(severity: severity,
-                                  message: message,
-                                  context: context)
-    let err = NSError(domain: simplyeDomain,
-                      code: NYPLErrorCode.fileSystemFail.rawValue,
                       userInfo: userInfo)
 
     Crashlytics.sharedInstance().recordError(err)

--- a/Simplified/NYPLReaderViewController.m
+++ b/Simplified/NYPLReaderViewController.m
@@ -456,8 +456,8 @@ didEncounterCorruptionForBook:(__attribute__((unused)) NYPLBook *)book
 
 - (void)viewWillLayoutSubviews
 {
+  [super viewWillLayoutSubviews];
   [self.activityIndicatorView centerInSuperview];
-  [self.activityIndicatorView integralizeFrame];
 }
 
 - (void)willTransitionToTraitCollection:(__unused UITraitCollection *)newCollection

--- a/Simplified/NYPLReloadView.m
+++ b/Simplified/NYPLReloadView.m
@@ -61,7 +61,6 @@ static CGFloat const width = 280;
   {
     [self.titleLabel sizeToFit];
     [self.titleLabel centerInSuperview];
-    [self.titleLabel integralizeFrame];
     CGRect frame = self.titleLabel.frame;
     frame.origin.y = 0;
     self.titleLabel.frame = frame;
@@ -80,7 +79,6 @@ static CGFloat const width = 280;
   {
     [self.reloadButton sizeToFit];
     [self.reloadButton centerInSuperview];
-    [self.reloadButton integralizeFrame];
     CGRect frame = self.reloadButton.frame;
     frame.origin.y = CGRectGetMaxY(self.messageLabel.frame) + padding;
     self.reloadButton.frame = frame;

--- a/Simplified/NYPLRemoteViewController.m
+++ b/Simplified/NYPLRemoteViewController.m
@@ -11,10 +11,10 @@
 
 @property (nonatomic) UIActivityIndicatorView *activityIndicatorView;
 @property (nonatomic) UILabel *activityIndicatorLabel;
+@property (nonatomic) NYPLReloadView *reloadView;
 @property (nonatomic) NSURLConnection *connection;
 @property (nonatomic) NSMutableData *data;
 @property (nonatomic, copy) UIViewController *(^handler)(NYPLRemoteViewController *remoteViewController, NSData *data, NSURLResponse *response);
-@property (nonatomic) NYPLReloadView *reloadView;
 @property (nonatomic, strong) NSURLResponse *response;
 @property (atomic, readwrite) NSURL *URL;
 
@@ -50,6 +50,8 @@
   }
 
   self.reloadView.hidden = NO;
+  self.activityIndicatorLabel.hidden = YES;
+  [self.activityIndicatorView stopAnimating];
 }
 
 - (void)loadWithURL:(NSURL*)url
@@ -75,20 +77,31 @@
 
   // TODO: SIMPLY-2862
   // From the point of view of this VC, there is no point in attempting to
-  // load a remote page if we have no URL.
-  // Upon inspection of the codebase, this happens only at navigation
-  // controllers initialization time, when basically they are initialized
-  // with dummy VCs that have nil URLs which will be replaced once we obtain
-  // the catalog from the authentication document. Expressing this in code
-  // is the point of SIMPLY-2862.
+  // load a remote page if we have no URL. Upon inspection of the codebase,
+  // this happens only in 2 situations:
+  // 1. at navigation controllers / app initialization time, when they are
+  //    initialized with dummy VCs that have nil URLs. These VCs will be
+  //    replaced once we obtain the catalog from the authentication document of
+  //    the current library. Expressing this in code is the point of SIMPLY-2862.
+  // 2. If the request for loading the library accounts and the current
+  //    library's authentication document fail.
+  // These 2 situations are hard to distinguish from here. However, both
+  // can be handled by attempting a reload of the library accounts
+  // and auth doc. This is ok even for case #1 bc there's instrumentation in
+  // AccountManager for ignoring a call if there's one already ongoing.
+  // If those request succeed, there's instrumentation in AccountManager and
+  // NYPLRootTabBarController to trigger the creation of a new
+  // NYPLRemoteViewController furnished this time with a non-nil catalog URL.
+  //
+  // There's a 3rd case to consider also, and that is if the VC was purposedly
+  // set up with a nil URL. While that looks like a programmer error, it will
+  // result in a needless reload of the accounts/auth doc, but it will end up
+  // showing the reload UI anyway.
+  //
+  // Obviously this level of coupling is dreadful, and SIMPLY-2862 should
+  // address this as well.
   if (self.URL == nil) {
-    [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoURL
-                              context:@"RemoteViewController"
-                              message:@"Prevented attempt to load without a URL."
-                             metadata:@{
-                               @"Response": self.response ?: @"N/A",
-                               @"ChildVCs": self.childViewControllers
-                             }];
+    [self reloadAccountsAndAuthenticationDocument];
     return;
   }
 
@@ -112,6 +125,30 @@
   self.data = [NSMutableData data];
   
   [self.connection start];
+}
+
+// TODO: SIMPLY-2862 This method should be removed as part of this ticket
+- (void)reloadAccountsAndAuthenticationDocument
+{
+  NYPLLOG_F(@"Reloading accounts from RemoteVC: %@", self.title);
+  [AccountsManager.shared updateAccountSetWithCompletion:^(BOOL success) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (success) {
+        // since we have the accounts, now we can do a proper reload
+        [self load];
+      } else {
+        [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoURL
+                                  context:@"RemoteViewController"
+                                  message:@"Failed to reload accounts after having found nil URL"
+                                 metadata:@{
+                                   @"currentURL": self.URL ?: @"N/A",
+                                   @"Response": self.response ?: @"N/A",
+                                   @"ChildVCs": self.childViewControllers
+                                 }];
+        [self showReloadViewWithMessage:nil];
+      }
+    });
+  }];
 }
 
 #pragma mark UIViewController
@@ -249,7 +286,7 @@
   };
   [NYPLErrorLogger logError:error
                     context:@"RemoteViewController"
-                    message:@"Server-side api call (likely related to Catalog loading) failed"
+                    message:@"Server-side api call (likely related to Catalog loading) did fail with network error"
                    metadata:metadata];
 
   [self resetConnectionInfo];

--- a/Simplified/NYPLRemoteViewController.m
+++ b/Simplified/NYPLRemoteViewController.m
@@ -154,10 +154,7 @@
   [super viewWillLayoutSubviews];
 
   [self.activityIndicatorView centerInSuperview];
-  [self.activityIndicatorView integralizeFrame];
-  
   [self.reloadView centerInSuperview];
-  [self.reloadView integralizeFrame];
 }
 
 - (void)addActivityIndicatorLabel:(NSTimer*)timer

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -773,8 +773,8 @@ static const NSInteger sSection1Sync = 1;
  @note This method is not doing any logging in case `success` is false.
 
  @param success Whether Adobe DRM authorization was successful or not.
- @param error If errorMessage is absent, this will be used to derive a messsage
- to present to the user. This error is always logged no matter what.
+ @param error If errorMessage is absent, this will be used to derive a message
+ to present to the user.
  @param errorMessage Will be presented to the user and will be used as a
  localization key to attempt to localize it.
  */

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -228,8 +228,8 @@ static const NSInteger sSection1Sync = 1;
   UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
   label.text = errorMessage;
   [label sizeToFit];
-  label.center = CGPointMake(self.view.frame.size.width / 2, self.view.frame.size.height / 2);
   [self.view addSubview:label];
+  [label centerInSuperviewWithOffset:self.tableView.contentOffset];
 }
 
 - (void)setupViews {

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -136,6 +136,17 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
       return
     }
 
+    // TODO: SIMPLY-2881
+    // Note: we purposedly ignore looking at the HTTP status code to
+    // determine if we had an actual success or failure because currently
+    // upper/application level classes sometimes parse the Problem Document
+    // that may be returned in the `progressData`.
+    //
+    // So while we currently must consider that (and anything that didn't
+    // generate an actual `error`) a "successful" result here, ideally (per
+    // SIMPLY-2881) NYPLNetworkResponder should check for presence of a problem
+    // document instead of having other classes do that work elsewhere.
+
     currentTaskInfo.completion(.success(currentTaskInfo.progressData))
   }
 

--- a/Simplified/SimplyE-Bridging-Header.h
+++ b/Simplified/SimplyE-Bridging-Header.h
@@ -30,6 +30,8 @@
 #import "NYPLHoldsNavigationController.h"
 #import "NYPLMyBooksDownloadCenter.h"
 #import "NYPLBookLocation.h"
+#import "NYPLReloadView.h"
+#import "UIView+NYPLViewAdditions.h"
 #if FEATURE_DRM_CONNECTOR
 #import "ADEPT/NYPLADEPTErrors.h"
 #import "ADEPT/NYPLADEPT.h"

--- a/Simplified/UIView+NYPLViewAdditions.h
+++ b/Simplified/UIView+NYPLViewAdditions.h
@@ -5,6 +5,8 @@
 
 - (void)centerInSuperview;
 
+- (void)centerInSuperviewWithOffset:(CGPoint)offset;
+
 - (void)integralizeFrame;
 
 @end

--- a/Simplified/UIView+NYPLViewAdditions.m
+++ b/Simplified/UIView+NYPLViewAdditions.m
@@ -16,6 +16,14 @@
 {
   self.center = CGPointMake(CGRectGetWidth(self.superview.bounds) * 0.5,
                             CGRectGetHeight(self.superview.bounds) * 0.5);
+  [self integralizeFrame];
+}
+
+- (void)centerInSuperviewWithOffset:(CGPoint)offset
+{
+  self.center = CGPointMake(CGRectGetWidth(self.superview.bounds) * 0.5 + offset.x,
+                            CGRectGetHeight(self.superview.bounds) * 0.5 + offset.y);
+  [self integralizeFrame];
 }
 
 - (void)integralizeFrame

--- a/Simplified/Utilities/NYPLBook+Additions.swift
+++ b/Simplified/Utilities/NYPLBook+Additions.swift
@@ -1,0 +1,31 @@
+//
+//  NYPLBook+Additions.swift
+//  SimplyE
+//
+//  Created by Ettore Pasquini on 7/9/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+extension NYPLBook {
+  /// An informative short string describing the book, for logging purposes.
+  @objc func loggableShortString() -> String {
+    return "<\(title ?? "")` ID=\(identifier ?? "") Distributor=\(distributor ?? "")>"
+  }
+
+  /// An informative dictionary detailing all aspects of the book that could
+  /// be interesting for logging purposes.
+  @objc func loggableDictionary() -> [String: Any] {
+    let acquisitions = self.acquisitions.compactMap {
+      $0.dictionaryRepresentation()
+    }
+
+    return [
+      "bookTitle": title ?? "",
+      "bookID": identifier ?? "",
+      "bookDistributor": distributor ?? "",
+      "acquisitions": acquisitions
+    ]
+  }
+}

--- a/Simplified/Utilities/URLResponse+NYPL.swift
+++ b/Simplified/Utilities/URLResponse+NYPL.swift
@@ -1,0 +1,25 @@
+//
+//  URLResponse+NYPL.swift
+//  SimplyE
+//
+//  Created by Ettore Pasquini on 7/9/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+extension URLResponse {
+
+  /// Determines if the response is a Problem Document response per
+  /// https://tools.ietf.org/html/rfc7807.
+  /// - Returns: `true` is the response contains a problem Document,
+  /// `false` otherwise.
+  @objc func isProblemDocument() -> Bool {
+    guard let mimeType = mimeType else {
+      return false
+    }
+
+    return mimeType == "application/problem+json" ||
+      mimeType == "application/api-problem+json"
+  }
+}


### PR DESCRIPTION
**What's this do?**
SIMPLY-2843: In case the catalog fails to load because of a nil URL, the catalog screen will now try to reload both the library accounts list and the current library authentication document. 
SIMPLY-2843, SIMPLY-2853: In case the library accounts list fails, the Settings screen would appear empty and the user would be stuck in the water. This PR adds a Reload button to allow the user to recover from that.
SIMPLY-2857: Adds extensive logging for book download errors.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2843
https://jira.nypl.org/browse/SIMPLY-2853
https://jira.nypl.org/browse/SIMPLY-2857

**How should this be tested? / Do these changes have associated tests?**
The easiest way would be to use a proxy and rewrite the responses. I've used Charles, where one can do the following:
1. enable SSL proxying on device per https://www.charlesproxy.com/documentation/using-charles/ssl-certificates
2. once you are able to see decrypted requests, from the Tools menu choose "Rewrite..."
3. Click "Add" on the left of the dialog, then add these 2 locations:
https://libraryregistry.librarysimplified.org/libraries
https://circulation.librarysimplified.org/*/authentication_document
4. on the bottom right of the dialog, click on Add and enable:
- Response Status --> Replace with "500 Internal Server Error"
- Body for Response --> Replace with any string

![response-status-rewrite](https://user-images.githubusercontent.com/289104/87107924-e036a200-c215-11ea-924e-8ceed9ffc980.png)
![body-rewrite](https://user-images.githubusercontent.com/289104/87107934-e462bf80-c215-11ea-8930-7289fbccb6ae.png)
![rewrite-summary](https://user-images.githubusercontent.com/289104/87107939-e62c8300-c215-11ea-887f-56afe77acc82.png)

Once you have that, make sure to clear the cache of the app from the Settings screen. Otherwise the network won't even be hit for the 2 libraries and authentication document requests, since we cache those. 

![charles-main](https://user-images.githubusercontent.com/289104/87212288-9bbd0c00-c2d2-11ea-9165-3745b85aa4a8.png)

Then launch the app and you should see a "Try Again" button in both the catalog screen and on the Settings > Accounts page. If you then disable response rewrites in Charles and hit "Try Again", the pages should reload correctly.

**Dependencies for merging? Releasing to production?**
merging to hot fix branch, since this is fairly urgent.

**Has the application documentation been updated for these changes?**
Yes. I added a ton of comments in the code.

**Did someone actually run this code to verify it works?**
@ettore 