### PR TITLE
Fix potential crash and deadlock in network error handling

### DIFF
--- a/Simplified/NYPLCatalogFeedViewController.m
+++ b/Simplified/NYPLCatalogFeedViewController.m
@@ -162,7 +162,7 @@
         [[NYPLBookRegistry sharedRegistry] save];
       } else {
         [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeRegistrySyncFailure
-                                  context:NSStringFromClass([wSelf class])
+                                  context:NSStringFromClass([wSelf class]) ?: @"NYPLCatalogFeedViewController"
                                   message:@"Book registry sync failed"
                                  metadata:@{@"Catalog feed URL": wSelf.URL ?: @"none"}];
       }

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -109,6 +109,7 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
     taskInfoLock.lock()
 
     guard let currentTaskInfo = taskInfo.removeValue(forKey: taskID) else {
+      taskInfoLock.unlock()
       NYPLErrorLogger.logNetworkError(
         error,
         code: .noTaskInfoAvailable,


### PR DESCRIPTION
**What's this do?**
Fixes one error logging where we could pass a nil string to a Swift non-optional, and secondly a lock that was not unlocked in case a `guard` was hit.

**Why are we doing this? (w/ JIRA link if applicable)**
Avoid potential error situations/crash.

**How should this be tested? / Do these changes have associated tests?**
No real testing is actually needed. These are low level bugs.

**Dependencies for merging? Releasing to production?**
merging to hot fix branch.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ettore 