### PR TITLE
SIMPLY-2881 Add parsing of Problem Documents in network layer

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -406,6 +406,8 @@
 		735350B724918432006021BD /* URLRequest+NYPLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735350B624918432006021BD /* URLRequest+NYPLTests.swift */; };
 		735F41A3243E381D00046182 /* String+NYPLAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735F41A2243E381D00046182 /* String+NYPLAdditionsTests.swift */; };
 		735FED262427494900144C97 /* NYPLNetworkResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735FED252427494900144C97 /* NYPLNetworkResponder.swift */; };
+		7360D0D524BFCB9700C8AD16 /* NYPLUserFriendlyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7360D0D424BFCB9700C8AD16 /* NYPLUserFriendlyError.swift */; };
+		7360D0D624BFCB9700C8AD16 /* NYPLUserFriendlyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7360D0D424BFCB9700C8AD16 /* NYPLUserFriendlyError.swift */; };
 		7384C800242BB43400D5F960 /* NYPLCachingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7384C7FF242BB43300D5F960 /* NYPLCachingTests.swift */; };
 		7384C802242BCC4800D5F960 /* Date+NYPLAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7384C801242BCC4800D5F960 /* Date+NYPLAdditions.swift */; };
 		7384C804242BCE5900D5F960 /* Date+NYPLAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7384C803242BCE5900D5F960 /* Date+NYPLAdditionsTests.swift */; };
@@ -826,6 +828,7 @@
 		735F41A2243E381D00046182 /* String+NYPLAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+NYPLAdditionsTests.swift"; sourceTree = "<group>"; };
 		735FED252427494900144C97 /* NYPLNetworkResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLNetworkResponder.swift; sourceTree = "<group>"; };
 		73609AD8245B53CB00F0E08B /* update-certificates.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "update-certificates.sh"; sourceTree = SOURCE_ROOT; };
+		7360D0D424BFCB9700C8AD16 /* NYPLUserFriendlyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserFriendlyError.swift; sourceTree = "<group>"; };
 		7384C7FF242BB43300D5F960 /* NYPLCachingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLCachingTests.swift; sourceTree = "<group>"; };
 		7384C801242BCC4800D5F960 /* Date+NYPLAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+NYPLAdditions.swift"; sourceTree = "<group>"; };
 		7384C803242BCE5900D5F960 /* Date+NYPLAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+NYPLAdditionsTests.swift"; sourceTree = "<group>"; };
@@ -1389,6 +1392,7 @@
 				733875642423E1B0000FEB67 /* NYPLNetworkExecutor.swift */,
 				733875662423E540000FEB67 /* NYPLCaching.swift */,
 				735FED252427494900144C97 /* NYPLNetworkResponder.swift */,
+				7360D0D424BFCB9700C8AD16 /* NYPLUserFriendlyError.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -2236,6 +2240,7 @@
 				7347F0C1245A4DE200558D7F /* NSString+NYPLStringAdditions.m in Sources */,
 				7347F0C2245A4DE200558D7F /* NYPLKeychainManager.swift in Sources */,
 				7347F0C3245A4DE200558D7F /* NYPLErrorLogger.swift in Sources */,
+				7360D0D624BFCB9700C8AD16 /* NYPLUserFriendlyError.swift in Sources */,
 				7347F0C4245A4DE200558D7F /* NYPLOPDSEntryGroupAttributes.m in Sources */,
 				7347F0C5245A4DE200558D7F /* NYPLMyBooksDownloadCenter.m in Sources */,
 				7347F0C6245A4DE200558D7F /* NYPLProblemDocumentCacheManager.swift in Sources */,
@@ -2309,6 +2314,7 @@
 				1139DA6519C7755D00A07810 /* NYPLBookCoverRegistry.m in Sources */,
 				11119742198827850014462F /* NYPLBookDetailDownloadingView.m in Sources */,
 				2DFAC8ED1CD8DDD1003D9EC0 /* NYPLOPDSCategory.m in Sources */,
+				7360D0D524BFCB9700C8AD16 /* NYPLUserFriendlyError.swift in Sources */,
 				11068C55196DD37900E8A94B /* NYPLNull.m in Sources */,
 				1111973C19880E8D0014462F /* NYPLLinearView.m in Sources */,
 				11396FB9193D289100E16EE8 /* NSDate+NYPLDateAdditions.m in Sources */,

--- a/Simplified.xcodeproj/xcshareddata/xcschemes/Simplified.xcscheme
+++ b/Simplified.xcodeproj/xcshareddata/xcschemes/Simplified.xcscheme
@@ -98,6 +98,11 @@
             value = "99999"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DYLD_PRINT_STATISTICS"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
          <AdditionalOption

--- a/Simplified/AccountsManager.swift
+++ b/Simplified/AccountsManager.swift
@@ -205,8 +205,13 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
           NotificationCenter.default.post(name: NSNotification.Name.NYPLCatalogDidLoad, object: nil)
         }
       case .failure(let error):
-        NYPLErrorLogger.logError(error,
-                                 message: "Catalog failed to load from \(targetUrl)")
+        NYPLErrorLogger.logError(
+          withCode: .libraryListLoadFail,
+          context: NYPLErrorLogger.Context.accountManagement.rawValue,
+          message: "Libraries list failed to load from \(targetUrl)",
+          metadata: [
+            NSUnderlyingErrorKey: error,
+        ])
         self.callAndClearLoadingCompletionHandlers(key: hash, false)
       }
     }

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -932,57 +932,55 @@ completionHandler:(void (^)(void))handler
          [self.PINTextField becomeFirstResponder];
        }
 
-       if ([response.MIMEType isEqualToString:@"application/vnd.opds.authentication.v1.0+json"]) {
-         [NYPLErrorLogger logRemoteLoginError:error
-                                      barcode:barcode
-                                      request:request
-                                     response:response
-                                      library:self.currentAccount
-                                      message:@"Sign-in failed via SignIn-modal, no problem doc"];
-       } else if ([response.MIMEType isEqualToString:@"application/problem+json"] || [response.MIMEType isEqualToString:@"application/api-problem+json"]) {
-         NSError *problemDocumentParseError = nil;
-         NYPLProblemDocument *problemDocument = [NYPLProblemDocument fromData:data error:&problemDocumentParseError];
-         if (problemDocumentParseError) {
-           [NYPLErrorLogger logProblemDocumentParseError:problemDocumentParseError
-                                                 barcode:barcode
-                                                     url:request.URL
-                                                 context:@"AccountSignInVC-validateCreds"
-                                                 message:@"Sign-in failed via SignIn-modal, problem doc parsing failed"];
-         } else if (problemDocument) {
-           [NYPLErrorLogger logLoginError:error
-                                  barcode:barcode
-                                  library:self.currentAccount
-                                  request:request
-                          problemDocument:problemDocument
-                                 metadata:@{
-                                   @"message": @"Sign-in failed via SignIn-modal, got a problem doc"
-                                 }];
-           NSString *msg = NSLocalizedString(@"A server error occurred. Please try again later, and if the problem persists, contact your library's Help Desk.", @"Error message for when a server error occurs.");
-           msg = [NSString stringWithFormat:@"%@\n\n(Error details: %@)", msg,
-                  (problemDocument.detail ?: problemDocument.title)];
-           UIAlertController *alert = [NYPLAlertUtils alertWithTitle:@"SettingsAccountViewControllerLoginFailed"
-                                                             message:msg];
-           [NYPLAlertUtils setProblemDocumentWithController:alert document:problemDocument append:YES];
-           [[NYPLRootTabBarController sharedController] safelyPresentViewController: alert animated:YES completion:nil];
-           return; // Short-circuit!! Early return
-         } else {
-           [NYPLErrorLogger logRemoteLoginError:error
-                                        barcode:barcode
-                                        request:request
-                                       response:response
-                                        library:self.currentAccount
-                                        message:@"Sign-in failed via SignIn-modal"];
-         }
-       }
-     
-       // Fallthrough case: show alert
-       [[NYPLRootTabBarController sharedController] safelyPresentViewController:
-        [NYPLAlertUtils alertWithTitle:@"SettingsAccountViewControllerLoginFailed" error:error]
-                                                                     animated:YES
-                                                                   completion:nil];
+      NYPLProblemDocument *problemDocument = nil;
+      UIAlertController *alert = nil;
+      NSError *problemDocParseError = nil;
+      if (response.isProblemDocument) {
+        problemDocument = [NYPLProblemDocument fromData:data
+                                                  error:&problemDocParseError];
+        if (problemDocParseError == nil && problemDocument != nil) {
+          NSString *msg = NSLocalizedString(@"A server error occurred. Please try again later, and if the problem persists, contact your library's Help Desk.", @"Error message for when a server error occurs.");
+          NSString *errorDetails = (problemDocument.detail ?: problemDocument.title);
+          if (errorDetails) {
+            msg = [NSString stringWithFormat:@"%@\n\n(Error details: %@)", msg,
+                 errorDetails];
+          }
+          alert = [NYPLAlertUtils alertWithTitle:@"SettingsAccountViewControllerLoginFailed"
+                                         message:msg];
+          [NYPLAlertUtils setProblemDocumentWithController:alert
+                                                  document:problemDocument
+                                                    append:YES];
+        }
+      }
 
-       return;
-     }];
+      // error logging
+      if (problemDocParseError) {
+        [NYPLErrorLogger logProblemDocumentParseError:problemDocParseError
+                                  problemDocumentData:data
+                                              barcode:barcode
+                                                  url:request.URL
+                                              context:@"AccountSignInVC-validateCreds"
+                                              message:@"Sign-in failed via SignIn-modal, problem doc parsing failed"];
+      } else {
+        [NYPLErrorLogger logLoginError:error
+                               barcode:barcode
+                               library:self.currentAccount
+                               request:request
+                              response:response
+                       problemDocument:problemDocument
+                              metadata:@{
+                                @"message": @"Sign-in failed via SignIn-modal"
+                              }];
+      }
+
+      // notify user of error
+      if (alert == nil) {
+        alert = [NYPLAlertUtils alertWithTitle:@"SettingsAccountViewControllerLoginFailed" error:error];
+      }
+      [[NYPLRootTabBarController sharedController] safelyPresentViewController:alert
+                                                                      animated:YES
+                                                                    completion:nil];
+    }];
   
   [task resume];
 }

--- a/Simplified/NYPLAlertUtils.swift
+++ b/Simplified/NYPLAlertUtils.swift
@@ -93,7 +93,7 @@ import UIKit
     @return
    */
   class func setProblemDocument(controller: UIAlertController?, document: NYPLProblemDocument?, append: Bool) {
-    guard let controller = controller else {
+    guard let alert = controller else {
       return
     }
     guard let document = document else {
@@ -101,19 +101,19 @@ import UIKit
     }
 
     if append == false {
-      controller.title = document.title
-      controller.message = document.detail
+      alert.title = document.title
+      alert.message = document.detail
       return
     }
 
     var titleWasAdded = false
-    if controller.title?.isEmpty ?? true {
-      controller.title = document.title
+    if alert.title?.isEmpty ?? true {
+      alert.title = document.title
       titleWasAdded = true
     }
 
     let existingMsg: String = {
-      if let existingMsg = controller.message, !existingMsg.isEmpty {
+      if let existingMsg = alert.message, !existingMsg.isEmpty {
         return existingMsg + "\n"
       }
       return ""
@@ -122,9 +122,9 @@ import UIKit
     let docDetail: String = document.detail ?? ""
 
     if !titleWasAdded, let docTitle = document.title, !docTitle.isEmpty {
-      controller.message = "\(existingMsg)\(docTitle)\n\(docDetail)"
+      alert.message = "\(existingMsg)\(docTitle)\n\(docDetail)"
     } else {
-      controller.message = "\(existingMsg)\(docDetail)"
+      alert.message = "\(existingMsg)\(docDetail)"
     }
   }
   

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -179,12 +179,14 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
 
   if ([downloadTask.response isProblemDocument]) {
     NSError *problemDocumentParseError = nil;
+    NSData *problemDocData = [NSData dataWithContentsOfURL:tmpSavedFileURL];
     problemDocument = [NYPLProblemDocument
-                       fromData:[NSData dataWithContentsOfURL:tmpSavedFileURL]
+                       fromData:problemDocData
                        error:&problemDocumentParseError];
     if (problemDocumentParseError) {
       [NYPLErrorLogger
        logProblemDocumentParseError:problemDocumentParseError
+       problemDocumentData:problemDocData
        barcode:NYPLUserAccount.sharedAccount.barcode
        url:tmpSavedFileURL
        context:@"myBooks-download-finish"

--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -109,8 +109,7 @@ static NYPLOPDSFeedType TypeImpliedByEntry(NYPLOPDSEntry *const entry)
                                 }];
 
         NSDictionary *errorDict = nil;
-        if ([response.MIMEType isEqualToString:@"application/problem+json"]
-            || [response.MIMEType isEqualToString:@"application/api-problem+json"]) {
+        if (response.isProblemDocument) {
           errorDict = [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)0 error:nil];
         }
 

--- a/Simplified/NYPLProblemDocument.swift
+++ b/Simplified/NYPLProblemDocument.swift
@@ -10,13 +10,21 @@ import Foundation
     "http://librarysimplified.org/terms/problem/loan-already-exists";
   static let noStatus: Int = -1
 
+  /// Per RFC7807, this identifies the type of problem.
   let type: String?
+
+  /// Per RFC7807, this is a short, human-readable summary of the problem.
   let title: String?
 
-  /// The HTTP status code.
+  /// Per RFC7807, this will match the HTTP status code.
   let status: Int?
 
+  /// Per RFC7807, this is a human-readable explanation of the specific problem
+  /// that occurred. It can also provide information to correct the problem.
   let detail: String?
+
+  /// Per RFC7807, a URI reference that identifies the specific occurrence of
+  /// the problem.
   let instance: String?
   
   fileprivate init(_ dict: [String : Any]) {

--- a/Simplified/NYPLRemoteViewController.m
+++ b/Simplified/NYPLRemoteViewController.m
@@ -259,9 +259,9 @@
                               message:@"Failed to create VC after loading from server"
                              metadata:@{
                                @"HTTPstatusCode": @(httpResponse.statusCode),
-                               @"mimeType": httpResponse.MIMEType,
+                               @"response.mimeType": httpResponse.MIMEType ?: @"N/A",
                                @"URL": self.URL ?: @"N/A",
-                               @"response.URL": httpResponse.URL ?: @"N/A"
+                               @"response": httpResponse ?: @"N/A"
                              }];
     self.reloadView.hidden = NO;
   }
@@ -303,16 +303,14 @@
 
 - (void)handleErrorResponse:(NSHTTPURLResponse *)httpResponse
 {
-  BOOL mimeTypeMatches = [self.response.MIMEType isEqualToString:@"application/problem+json"] ||
-  [self.response.MIMEType isEqualToString:@"application/api-problem+json"];
-
-  if (mimeTypeMatches) {
+  if (httpResponse.isProblemDocument) {
     NSError *problemDocumentParseError = nil;
     NYPLProblemDocument *pDoc = [NYPLProblemDocument fromData:self.data error:&problemDocumentParseError];
     UIAlertController *alert;
 
     if (problemDocumentParseError) {
       [NYPLErrorLogger logProblemDocumentParseError:problemDocumentParseError
+                                problemDocumentData:self.data
                                             barcode:nil
                                                 url:[self.response URL]
                                             context:@"RemoteViewController"

--- a/Simplified/Network/NYPLNetworkExecutor.swift
+++ b/Simplified/Network/NYPLNetworkExecutor.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
+/// Use this enum to express either-or semantics in a result.
 enum NYPLResult<SuccessInfo> {
   case success(SuccessInfo)
-  case failure(Error)
+  case failure(NYPLUserFriendlyError)
 }
-
 
 /// A class that is capable of executing network requests in a thread-safe way.
 /// This class implements caching according to server response caching headers,
@@ -68,7 +68,7 @@ class NYPLNetworkExecutor {
   ///   - completion: Always called when the resource is either fetched from
   /// the network or from the cache.
   func executeRequest(_ req: URLRequest,
-           completion: @escaping (_ result: NYPLResult<Data>) -> Void) {
+                      completion: @escaping (_: NYPLResult<Data>) -> Void) {
     let task = urlSession.dataTask(with: req)
     responder.addCompletion(completion, taskID: task.taskIdentifier)
     task.resume()

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-//------------------------------------------------------------------------------
 fileprivate struct NYPLNetworkTaskInfo {
   var progressData: Data
   var startDate: Date
   var completion: ((NYPLResult<Data>) -> Void)
 
+  //----------------------------------------------------------------------------
   init(completion: (@escaping (NYPLResult<Data>) -> Void)) {
     self.progressData = Data()
     self.startDate = Date()
@@ -21,21 +21,27 @@ fileprivate struct NYPLNetworkTaskInfo {
   }
 }
 
-//------------------------------------------------------------------------------
+// MARK: -
+
+/// This class responds to URLSession events related to the tasks being
+/// issued on the URLSession, keeping a tally of the related completion
+/// handlers in a thread-safe way.
 class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate {
   typealias TaskID = Int
 
   private var taskInfo: [TaskID: NYPLNetworkTaskInfo]
 
-  /// Protects access to `taskInfo`.
+  /// Protects access to `taskInfo` to ensure thread-safety.
   private let taskInfoLock: NSRecursiveLock
 
+  //----------------------------------------------------------------------------
   override init() {
     self.taskInfo = [Int: NYPLNetworkTaskInfo]()
     self.taskInfoLock = NSRecursiveLock()
     super.init()
   }
 
+  //----------------------------------------------------------------------------
   func addCompletion(_ completion: @escaping (NYPLResult<Data>) -> Void,
                      taskID: TaskID) {
     taskInfoLock.lock()
@@ -46,9 +52,9 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
     taskInfo[taskID] = NYPLNetworkTaskInfo(completion: completion)
   }
 
-  //----------------------------------------------------------------------------
   // MARK: - URLSessionDelegate
 
+  //----------------------------------------------------------------------------
   func urlSession(_ session: URLSession, didBecomeInvalidWithError err: Error?) {
     if let err = err {
       NYPLErrorLogger.logError(err, message: "URLSession became invalid")
@@ -66,9 +72,9 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
     taskInfo.removeAll()
   }
 
-  //----------------------------------------------------------------------------
   // MARK: - URLSessionDataDelegate
 
+  //----------------------------------------------------------------------------
   func urlSession(_ session: URLSession,
                   dataTask: URLSessionDataTask,
                   didReceive data: Data) {
@@ -82,6 +88,7 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
     taskInfo[dataTask.taskIdentifier] = currentTaskInfo
   }
 
+  //----------------------------------------------------------------------------
   func urlSession(_ session: URLSession,
                   dataTask: URLSessionDataTask,
                   willCacheResponse proposedResponse: CachedURLResponse,
@@ -101,13 +108,16 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
     }
   }
 
+  //----------------------------------------------------------------------------
   func urlSession(_ session: URLSession,
                   task: URLSessionTask,
                   didCompleteWithError error: Error?) {
     let taskID = task.taskIdentifier
+    var logMetadata: [String: Any] = [
+      "currentRequest": task.currentRequest?.loggableString ?? "N/A",
+    ]
 
     taskInfoLock.lock()
-
     guard let currentTaskInfo = taskInfo.removeValue(forKey: taskID) else {
       taskInfoLock.unlock()
       NYPLErrorLogger.logNetworkError(
@@ -115,17 +125,46 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
         code: .noTaskInfoAvailable,
         request: task.originalRequest,
         response: task.response,
-        message: "No task info available for task \(taskID)")
+        message: "No task info available for task \(taskID). Completion closure could not be called.",
+        metadata: logMetadata)
+      return
+    }
+    taskInfoLock.unlock()
+
+    let responseData = currentTaskInfo.progressData
+    let elapsed = Date().timeIntervalSince(currentTaskInfo.startDate)
+    logMetadata["elapsedTime"] = elapsed
+    Log.info(#file, "Task \(taskID) completed, elapsed time: \(elapsed) sec")
+
+    // attempt parsing of Problem Document
+    if task.response?.isProblemDocument() ?? false {
+      let parseError: Error?
+      do {
+        let problemDoc = try NYPLProblemDocument.fromData(responseData)
+        let err = task.makeErrorFromProblemDocument(problemDoc)
+        parseError = nil
+        logMetadata["problemDocument"] = problemDoc
+        currentTaskInfo.completion(.failure(err))
+      } catch (let error) {
+        parseError = error
+        let responseString = String(data: responseData, encoding: .utf8) ?? "N/A"
+        logMetadata["problemDocumentBody"] = responseString
+        currentTaskInfo.completion(.failure(error as NYPLUserFriendlyError))
+      }
+      if let error = error {
+        logMetadata["urlSessionError"] = error
+      }
+      NYPLErrorLogger.logNetworkError(parseError,
+                                      request: task.originalRequest,
+                                      response: task.response,
+                                      message: "Network request for task \(taskID)  failed. A Problem Document was returned.",
+                                      metadata: logMetadata)
       return
     }
 
-    taskInfoLock.unlock()
-
-    let elapsed = Date().timeIntervalSince(currentTaskInfo.startDate)
-    Log.debug(#file, "Task \(taskID) completed, elapsed time: \(elapsed) sec")
-
+    // no problem document, but if we have an error it's still a failure
     if let error = error {
-      currentTaskInfo.completion(.failure(error))
+      currentTaskInfo.completion(.failure(error as NYPLUserFriendlyError))
 
       // logging the error after the completion call so that the error report
       // will include any eventual logging done in the completion handler.
@@ -133,22 +172,52 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
         error,
         request: task.originalRequest,
         response: task.response,
-        message: "Task \(taskID) completed with error")
+        message: "Network task \(taskID) completed with error",
+        metadata: logMetadata)
       return
     }
 
-    // TODO: SIMPLY-2881
-    // Note: we purposedly ignore looking at the HTTP status code to
-    // determine if we had an actual success or failure because currently
-    // upper/application level classes sometimes parse the Problem Document
-    // that may be returned in the `progressData`.
-    //
-    // So while we currently must consider that (and anything that didn't
-    // generate an actual `error`) a "successful" result here, ideally (per
-    // SIMPLY-2881) NYPLNetworkResponder should check for presence of a problem
-    // document instead of having other classes do that work elsewhere.
+    // no problem document nor error, but response could still be a failure
+    if let httpResponse = task.response as? HTTPURLResponse {
+      guard !httpResponse.isFailure() else {
+        logMetadata["response"] = httpResponse
+        logMetadata[NSLocalizedDescriptionKey] = NSLocalizedString("UnknownRequestError", comment: "A generic error message for when a network request fails")
+        let err = NSError(domain: NYPLErrorLogger.Context.infrastructure.rawValue,
+                          code: NYPLErrorCode.responseFail.rawValue,
+                          userInfo: logMetadata)
+        currentTaskInfo.completion(.failure(err))
+        NYPLErrorLogger.logNetworkError(code: NYPLErrorCode.responseFail,
+                                        request: task.originalRequest,
+                                        message: "Network request for task \(taskID) failed.",
+                                        metadata: logMetadata)
+        return
+      }
+    }
 
-    currentTaskInfo.completion(.success(currentTaskInfo.progressData))
+    currentTaskInfo.completion(.success(responseData))
   }
+}
 
+extension URLSessionTask {
+  //----------------------------------------------------------------------------
+  func makeErrorFromProblemDocument(_ problemDoc: NYPLProblemDocument) -> NSError {
+    var userInfo = [String: Any]()
+    if let currentRequest = currentRequest {
+      userInfo["taskCurrentRequest"] = currentRequest
+    }
+    if let originalRequest = originalRequest {
+      userInfo["taskOriginalRequest"] = originalRequest
+    }
+    if let response = response {
+      userInfo["response"] = response
+    }
+
+    let err = NSError.makeFromProblemDocument(
+      problemDoc,
+      domain: NYPLErrorLogger.Context.infrastructure.rawValue,
+      code: NYPLErrorCode.apiCall.rawValue,
+      userInfo: userInfo)
+
+    return err
+  }
 }

--- a/Simplified/Network/NYPLUserFriendlyError.swift
+++ b/Simplified/Network/NYPLUserFriendlyError.swift
@@ -1,0 +1,66 @@
+//
+//  NYPLUserFriendlyError.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 7/15/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+/// A protocol describing an error that MAY offer user friendly
+/// messaging to the user.
+protocol NYPLUserFriendlyError: Error {
+  /// A short summary of the error, if available.
+  var userFriendlyTitle: String? { get }
+
+  /// A user-friendly short message describing the error in more detail,
+  /// if possible.
+  var userFriendlyMessage: String? { get }
+}
+
+// Dummy implementation merely to ease error reporting work upstream, where
+// it's very common to have to handle errors obtained in various ways. This
+// is also ok because user friendly strings are in general never guaranteed
+// to be there, even when we obtain a problem document.
+extension NYPLUserFriendlyError {
+  var userFriendlyTitle: String? { return nil }
+  var userFriendlyMessage: String? { return nil  }
+}
+
+extension NSError: NYPLUserFriendlyError {
+  private static let userFriendlyTitleKey = "userFriendlyTitle"
+  private static let userFriendlyMessageKey = "userFriendlyMessage"
+
+  var userFriendlyTitle: String? {
+    return userInfo[NSError.userFriendlyTitleKey] as? String
+  }
+
+  var userFriendlyMessage: String? {
+    return (userInfo[NSError.userFriendlyMessageKey] ?? userInfo[NSLocalizedDescriptionKey]) as? String
+  }
+
+  /// Builds an NSError using the given problem document for its user-friendly
+  /// messaging.
+  /// - Parameters:
+  ///   - problemDoc: The problem document per RFC7807.
+  ///   - domain: The domain to give to the error being created.
+  ///   - code: The code to give to the error being created.
+  ///   - userInfo: The user friendly messaging will be appended to this
+  ///   dictionary.
+  /// - Returns: A new NSError with the ProblemDocument `title` and `detail`.
+  static func makeFromProblemDocument(_ problemDoc: NYPLProblemDocument,
+                                      domain: String,
+                                      code: Int,
+                                      userInfo: [String: Any]?) -> NSError {
+    var userInfo = userInfo ?? [String: Any]()
+    if let title = problemDoc.title {
+      userInfo[NSError.userFriendlyTitleKey] = title
+    }
+    if let detail = problemDoc.detail {
+      userInfo[NSError.userFriendlyMessageKey] = detail
+    }
+    
+    return NSError(domain: domain, code: code, userInfo: userInfo)
+  }
+}

--- a/Simplified/Utilities/URLResponse+NYPL.swift
+++ b/Simplified/Utilities/URLResponse+NYPL.swift
@@ -23,3 +23,9 @@ extension URLResponse {
       mimeType == "application/api-problem+json"
   }
 }
+
+extension HTTPURLResponse {
+  @objc func isFailure() -> Bool {
+    return statusCode < 200 || statusCode > 299
+  }
+}


### PR DESCRIPTION
**What's this do?**
Centralizes the parsing of Problem Documents in our new network layer. The Problem Document info is returned up in additional `userInfo` keys (per NYPLUserFriendlyError protocol) added to the NSError passed in the completion closure. 

It also simplifies the flow of the error handling code in the Sign In VCs.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2881

**How should this be tested? / Do these changes have associated tests?**
Currently the network layer is only used to load the libraries list and the authentication document, but in both cases the calling code does not need to present a detailed error to the user. So this is mainly an infrastructure change. We should still verify that libraries loading and sign in is not broken and that in case of error an error message is presented. For that we can use Charles as explained here: https://github.com/NYPL-Simplified/Simplified/wiki/Using-Charles-Proxy-to-verify-mobile-apps-networking-behavior

**Dependencies for merging? Releasing to production?**
N/A

**Has the application documentation been updated for these changes?**
I added docs and comments in the code.

**Did someone actually run this code to verify it works?**
@ettore 