### PR TITLE
SIMPLY-2846 Access shared accounts dictionary in a thread-safe way

### DIFF
--- a/Simplified/AccountsManager.swift
+++ b/Simplified/AccountsManager.swift
@@ -27,11 +27,17 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
     return shared
   }
   
-  var accountSet: String
+  private var accountSet: String
   private var accountSets = [String: [Account]]()
+  private var accountSetsWorkQueue = DispatchQueue(label: "org.nypl.labs.SimplyE.AccountsManager.workQueue", attributes: .concurrent)
   
   var accountsHaveLoaded: Bool {
-    if let accounts = accountSets[accountSet] {
+    var accounts: [Account]?
+    accountSetsWorkQueue.sync {
+      accounts = accountSets[accountSet]
+    }
+
+    if let accounts = accounts {
       return !accounts.isEmpty
     }
     return false
@@ -127,7 +133,9 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
       let catalogsFeed = try OPDS2CatalogsFeed.fromData(data)
       let hadAccount = self.currentAccount != nil
 
-      self.accountSets[key] = catalogsFeed.catalogs.map { Account(publication: $0) }
+      accountSetsWorkQueue.sync(flags: .barrier) {
+        accountSets[key] = catalogsFeed.catalogs.map { Account(publication: $0) }
+      }
 
       // note: `currentAccount` computed property feeds off of `accountSets`, so
       // changing the `accountsSets` dictionary will also change `currentAccount`
@@ -218,31 +226,50 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
   }
   
   func account(_ uuid:String) -> Account? {
+    // get accountSets dictionary first for thread-safety
+    var accountSetsCopy = [String: [Account]]()
+    var accountSetKey = ""
+    accountSetsWorkQueue.sync {
+      accountSetsCopy = self.accountSets
+      accountSetKey = self.accountSet
+    }
+
     // Check primary account set first
-    if let accounts = self.accountSets[self.accountSet] {
+    if let accounts = accountSetsCopy[accountSetKey] {
       if let account = accounts.filter({ $0.uuid == uuid }).first {
         return account
       }
     }
+
     // Check existing account lists
-    for accountEntry in self.accountSets {
-      if accountEntry.key == self.accountSet {
+    for accountEntry in accountSetsCopy {
+      if accountEntry.key == accountSetKey {
         continue
       }
       if let account = accountEntry.value.filter({ $0.uuid == uuid }).first {
         return account
       }
     }
+
     return nil
   }
   
   func accounts(_ key: String? = nil) -> [Account] {
-    let k = key != nil ? key! : self.accountSet
-    return self.accountSets[k] ?? []
+    var accounts: [Account]? = []
+
+    accountSetsWorkQueue.sync {
+      let k = key ?? self.accountSet
+      accounts = self.accountSets[k]
+    }
+
+    return accounts ?? []
   }
   
   func updateAccountSet(completion: @escaping (Bool) -> () = { _ in }) {
-    self.accountSet = NYPLSettings.shared.useBetaLibraries ? betaUrlHash : prodUrlHash
+    accountSetsWorkQueue.sync(flags: .barrier) {
+      self.accountSet = NYPLSettings.shared.useBetaLibraries ? betaUrlHash : prodUrlHash
+    }
+
     if self.accounts().isEmpty {
       loadCatalogs(completion: completion)
     }

--- a/Simplified/NYPLAgeCheck.swift
+++ b/Simplified/NYPLAgeCheck.swift
@@ -74,10 +74,10 @@ import Foundation
         message: NSLocalizedString("WelcomeScreenAgeVerifyMessage", comment: "An alert message telling the user they must be at least 13 years old and asking how old they are"),
         preferredStyle: .alert
       )
-      alertCont.addAction(UIAlertAction.init(title: "Under 13", style: .default, handler: { _ in
+      alertCont.addAction(UIAlertAction.init(title: NSLocalizedString("Under 13", comment:"A button title indicating an under-age range"), style: .default, handler: { _ in
         completion(false)
       }))
-      alertCont.addAction(UIAlertAction.init(title: "13 or Older", style: .default, handler: { _ in
+      alertCont.addAction(UIAlertAction.init(title: NSLocalizedString("13 or Older", comment: "A button title indicating an age range"), style: .default, handler: { _ in
         completion(true)
       }))
       UIApplication.shared.keyWindow?.rootViewController?.present(alertCont, animated: true, completion: nil)

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -145,7 +145,6 @@ fileprivate let nullString = "null"
     let currentLibrary = AccountsManager.shared.currentAccount
     metadata["currentAccountName"] = currentLibrary?.name ?? nullString
     metadata["currentAccountId"] = AccountsManager.shared.currentAccountId ?? nullString
-    metadata["currentAccountSet"] = AccountsManager.shared.accountSet
     metadata["currentAccountCatalogURL"] = currentLibrary?.catalogUrl ?? nullString
     metadata["currentAccountAuthDocURL"] = currentLibrary?.authenticationDocumentUrl ?? nullString
     metadata["currentAccountLoansURL"] = currentLibrary?.loansUrl ?? nullString

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -244,6 +244,8 @@
 "WelcomeScreenSubtitle2" = "E-books free to download and read without a library card.";
 "WelcomeScreenButtonTitle2" = "Add a Library Later";
 "LibraryListTitle" = "Pick Your Library";
+"Under 13" = "Under 13";
+"13 or Older" = "13 or Older";
 
 // NYPLSettingsAdvancedViewController
 "Advanced" = "Advanced";

--- a/Simplified/it.lproj/Localizable.strings
+++ b/Simplified/it.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-﻿// Accessibility Labels
+// Accessibility Labels
 
 "AccessibilitySwitchLibrary" = "Cambia biblioteca";
 
@@ -62,7 +62,7 @@
 "Settings" = "Impostazioni";
 "Show" = "Mostra";
 "SignOut" = "Disconnessione";
-"SigningOut" = "Firma out";
+"SigningOut" = "Disconnessione in corso";
 "SignUp" = "Registrati";
 "SoftwareLicenses" = "Licenze software";
 "SyncFailed" = "Sincronizzazione non riuscita";
@@ -222,12 +222,14 @@
 "WelcomeScreenAgeVerifyTitle" = "Verifica dell'età";
 "WelcomeScreenAgeVerifyMessage" = "Devi avere almeno 13 anni per scaricare alcuni dei libri nella nostra collection. Quanti anni hai?";
 "WelcomeScreenTitle1" = "Leggi ebook dalla tua biblioteca";
-"WelcomeScreenSubtitle1" = "Consulta il catalog, prendi a prestito e leggi gratuitamente libri dalla tua biblioteca locale.";
+"WelcomeScreenSubtitle1" = "Consulta il catalogo, prendi dei libri in prestito dalla tua biblioteca locale e leggili gratuitamente.";
 "WelcomeScreenButtonTitle1" = "Trova la tua biblioteca";
 "WelcomeScreenTitle2" = "La collezione SimplyE";
 "WelcomeScreenSubtitle2" = "Ebooks gratis da scaricare e leggere senza una tessera di biblioteca.";
 "WelcomeScreenButtonTitle2" = "Aggiungi una biblioteca più tardi";
 "LibraryListTitle" = "Scegli la tua biblioteca";
+"Under 13" = "Meno di 13";
+"13 or Older" = "13 o di più";
 
 // NYPLSettingsAdvancedViewController
 "Advanced" = "Impostazioni avanzate";


### PR DESCRIPTION
**What's this do?**
Puts all accesses to the `AccountManager::accountSets` dictionary behind a concurrent queue using a barrier for write operations to ensure thread-safety for that dictionary.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2846
This crash happened while _reading_ from the dictionary, with a BAD_ACCESS exception reading from 0x0 address. Since that dictionary is on AccountManager, which is a big Singleton class, it can be accessed in R/W mode from many threads, leading to possible memory corruption.

**How should this be tested? / Do these changes have associated tests?**
This crash was hard to reproduce so I don't have clear steps on how to do that. I think QA should focus on doing a testing on the sign-in/sign-out flows, account management, switching different libraries. All the section of the regression suite involving accounts should be executed.
I'll see if I can add some unit tests, but it might be difficult because AccountManager is a singleton also interfacing with the keychain.

**Dependencies for merging? Releasing to production?**
merging to develop

**Has the application documentation been updated for these changes?**
in code

**Did someone actually run this code to verify it works?**
@ettore 