### PR TITLE
SIMPLY-2930 Fix crash caused by incorrect notification callback signature

### DIFF
--- a/Simplified/AccountsManager.swift
+++ b/Simplified/AccountsManager.swift
@@ -72,7 +72,7 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
     
     NotificationCenter.default.addObserver(
       self,
-      selector: #selector(updateAccountSet),
+      selector: #selector(updateAccountSetFromNotification(_:)),
       name: NSNotification.Name.NYPLUseBetaDidChange,
       object: nil
     )
@@ -264,7 +264,11 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
 
     return accounts ?? []
   }
-  
+
+  @objc private func updateAccountSetFromNotification(_ notif: NSNotification) {
+    updateAccountSet(completion: { _ in })
+  }
+
   func updateAccountSet(completion: @escaping (Bool) -> () = { _ in }) {
     accountSetsWorkQueue.sync(flags: .barrier) {
       self.accountSet = NYPLSettings.shared.useBetaLibraries ? betaUrlHash : prodUrlHash

--- a/Simplified/NYPLCatalogFeedViewController.m
+++ b/Simplified/NYPLCatalogFeedViewController.m
@@ -162,9 +162,9 @@
         [[NYPLBookRegistry sharedRegistry] save];
       } else {
         [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeRegistrySyncFailure
-                                  context:NSStringFromClass([wSelf class]) ?: @"NYPLCatalogFeedViewController"
+                                  context:@"NYPLCatalogFeedViewController"
                                   message:@"Book registry sync failed"
-                                 metadata:@{@"Catalog feed URL": wSelf.URL ?: @"none"}];
+                                 metadata:@{@"Catalog feed URL": wSelf.URL ?: @"N/A"}];
       }
     }];
   }

--- a/Simplified/NYPLSettingsPrimaryTableViewController.m
+++ b/Simplified/NYPLSettingsPrimaryTableViewController.m
@@ -91,7 +91,10 @@ NSIndexPath *NYPLSettingsPrimaryTableViewControllerIndexPathFromSettingsItem(
 {
   [super viewWillAppear:animated];
   if (self.splitViewController.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
-    [self.tableView deselectRowAtIndexPath:[self.tableView indexPathForSelectedRow] animated:YES];
+    NSIndexPath *selectedIndexPath = [self.tableView indexPathForSelectedRow];
+    if (selectedIndexPath) {
+      [self.tableView deselectRowAtIndexPath:selectedIndexPath animated:YES];
+    }
   }
 }
 


### PR DESCRIPTION
**What's this do?**
Fixes the method signature of a NSNotificationCenter callback, which must include one and only one parameter of type NSNotification. This was broken in a recent refactor. I also fixed some undefined (and eventually unrelated) behaviors I found while debugging.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2930

**How should this be tested? / Do these changes have associated tests?**
See steps in ticket.

**Dependencies for merging? Releasing to production?**
This can go out after 3.5.0 since it only applies to a hidden feature.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ettore 