### PR TITLE
SIMPLY-2933 Ensure presence of barButton anchor when presenting sheet

### DIFF
--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -112,7 +112,7 @@
   NYPLCatalogFeedViewController *viewController = (NYPLCatalogFeedViewController *)self.visibleViewController;
 
   UIAlertControllerStyle style;
-  if (viewController) {
+  if (viewController && viewController.navigationItem.leftBarButtonItem) {
     style = UIAlertControllerStyleActionSheet;
   } else {
     style = UIAlertControllerStyleAlert;

--- a/Simplified/NYPLHoldsNavigationController.m
+++ b/Simplified/NYPLHoldsNavigationController.m
@@ -68,7 +68,7 @@
   NYPLHoldsViewController *viewController = (NYPLHoldsViewController *)self.visibleViewController;
 
   UIAlertControllerStyle style;
-  if (viewController) {
+  if (viewController && viewController.navigationItem.leftBarButtonItem) {
     style = UIAlertControllerStyleActionSheet;
   } else {
     style = UIAlertControllerStyleAlert;

--- a/Simplified/NYPLMyBooksNavigationController.m
+++ b/Simplified/NYPLMyBooksNavigationController.m
@@ -70,7 +70,7 @@
   NYPLMyBooksViewController *viewController = (NYPLMyBooksViewController *)self.visibleViewController;
 
   UIAlertControllerStyle style;
-  if (viewController) {
+  if (viewController && viewController.navigationItem.leftBarButtonItem) {
     style = UIAlertControllerStyleActionSheet;
   } else {
     style = UIAlertControllerStyleAlert;


### PR DESCRIPTION
**What's this do?**
Ensures we do have a barButtonItem to use as anchor when presenting an alert view controller in sheet presentation style.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2933

**How should this be tested? / Do these changes have associated tests?**
This crash seems to be happening only on iPads on iOS 9 and sometimes 10. I looked at the code at where we use alert sheets and they are in these locations:
- accounts settings page, click on Add Library button
- switching library in Catalog, MyBooks, Holds tabs
- select a sort option in catalogs/my books/holds tabs

**Dependencies for merging? Releasing to production?**
none, this will go in 3.5.1 or whatever is next

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ettore however I do not have a iOS 9 device