### PR TITLE
SIMPLY-2886 Mute warnings related to Adobe DRM lib

### DIFF
--- a/Simplified/Reader2/AdobeDRM/AdobeDRMContainer.mm
+++ b/Simplified/Reader2/AdobeDRM/AdobeDRMContainer.mm
@@ -7,7 +7,12 @@
 //
 
 #import "AdobeDRMContainer.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreorder"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wshift-negative-value"
 #include "dp_all.h"
+#pragma clang diagnostic pop
 
 static id acsdrm_lock = nil;
 


### PR DESCRIPTION
**What's this do?**
The new code for using Adobe DRM on R2 introduced some warnings. This silence them, since they are all in Adobe's libraries.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2886

**How should this be tested? / Do these changes have associated tests?**
No testing needed, since no real changes are added.

**Dependencies for merging? Releasing to production?**
merging to feature branch

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ettore 