### PR TITLE
SIMPLY-2953 Wipe MyBooks/Holds/book details cache when pulling to refresh

### DIFF
--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -1058,7 +1058,7 @@ completionHandler:(void (^)(void))handler
       void (^handler)(void) = self.completionHandler;
       self.completionHandler = nil;
       if(handler) handler();
-      [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL success) {
+      [[NYPLBookRegistry sharedRegistry] syncResettingCache:NO completionHandler:^(BOOL success) {
         if (success) {
           [[NYPLBookRegistry sharedRegistry] save];
         }

--- a/Simplified/NYPLAppDelegate.m
+++ b/Simplified/NYPLAppDelegate.m
@@ -87,7 +87,7 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))backgroundF
     NYPLLOG_F(@"[Background Fetch] Starting book registry sync. "
               "ElapsedTime=%f", -startDate.timeIntervalSinceNow);
     // Only the "current library" account syncs during a background fetch.
-    [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL success) {
+    [[NYPLBookRegistry sharedRegistry] syncResettingCache:NO completionHandler:^(BOOL success) {
       if (success) {
         [[NYPLBookRegistry sharedRegistry] save];
       }

--- a/Simplified/NYPLBookDetailTableView.swift
+++ b/Simplified/NYPLBookDetailTableView.swift
@@ -89,7 +89,7 @@ private let standardCellHeight: CGFloat = 44.0
     }
 
     addPendingIndicator()
-    NYPLOPDSFeed.withURL(url) { (feed, errorDict) in
+    NYPLOPDSFeed.withURL(url, shouldResetCache: false) { (feed, errorDict) in
       DispatchQueue.main.async {
         if feed?.type == .acquisitionGrouped {
           let groupedFeed = NYPLCatalogGroupedFeed.init(opdsFeed: feed)

--- a/Simplified/NYPLBookRegistry.h
+++ b/Simplified/NYPLBookRegistry.h
@@ -47,23 +47,29 @@ static NSString *const _Nonnull NYPLBookProcessingDidChangeNotification =
 /**
  Grandfathering original sync method. Passes nil for the background fetch handler.
 
+ @param shouldResetCache Whether we should wipe the whole cache of
+ loans/holds/book details/open search/ungrouped feeds in its entirety or not.
  @param handler Completion Handler is on main thread, but not gauranteed to be called.
  */
-- (void)syncWithCompletionHandler:(void (^ _Nullable)(BOOL success))handler;
+- (void)syncResettingCache:(BOOL)shouldResetCache
+         completionHandler:(void (^ _Nullable)(BOOL success))handler;
 
 /**
  Syncs the latest loans content from the server. Attempting to sync while one is
  already in progress will be ignored. Resetting the registry while a sync is in
  progress will cause the handler not to be called.
 
- @param handler Called on completion on the main thread. Not gauranteed to be
+ @param shouldResetCache Whether we should wipe the whole cache of
+ loans/holds/book details/open search/ungrouped feeds in its entirety or not.
+ @param handler Called on completion on the main thread. Not guaranteed to be
  called.
  @param fetchHandler Called on completion on the main thread while exceuting
  from a Background App State, like from the App Delegate method. Calls to this
  block should be balanced with calls to the method.
  */
-- (void)syncWithCompletionHandler:(void (^ _Nullable)(BOOL success))handler
-            backgroundFetchHandler:(void (^ _Nullable)(UIBackgroundFetchResult))fetchHandler;
+- (void)syncResettingCache:(BOOL)shouldResetCache
+         completionHandler:(void (^ _Nullable)(BOOL success))handler
+    backgroundFetchHandler:(void (^ _Nullable)(UIBackgroundFetchResult))fetchHandler;
 
 /**
  Calls syncWithCompletionHandler: with a handler that presents standard

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -262,13 +262,17 @@ static NSString *const RecordsKey = @"records";
   [self broadcastChange];
 }
 
-- (void)syncWithCompletionHandler:(void (^)(BOOL success))handler
+- (void)syncResettingCache:(BOOL)shouldResetCache
+         completionHandler:(void (^)(BOOL success))handler
 {
-  [self syncWithCompletionHandler:handler backgroundFetchHandler:nil];
+  [self syncResettingCache:shouldResetCache
+         completionHandler:handler
+    backgroundFetchHandler:nil];
 }
 
-- (void)syncWithCompletionHandler:(void (^)(BOOL success))completion
-            backgroundFetchHandler:(void (^)(UIBackgroundFetchResult))fetchHandler
+- (void)syncResettingCache:(BOOL)shouldResetCache
+         completionHandler:(void (^)(BOOL success))completion
+    backgroundFetchHandler:(void (^)(UIBackgroundFetchResult))fetchHandler
 {
   @synchronized(self) {
 
@@ -297,6 +301,7 @@ static NSString *const RecordsKey = @"records";
   
   [NYPLOPDSFeed
    withURL:[[[AccountsManager sharedInstance] currentAccount] loansUrl]
+   shouldResetCache:shouldResetCache
    completionHandler:^(NYPLOPDSFeed *const feed, __unused NSDictionary *error) {
      if(!feed) {
        NYPLLOG(@"Failed to obtain sync data.");
@@ -384,7 +389,7 @@ static NSString *const RecordsKey = @"records";
 
 - (void)syncWithStandardAlertsOnCompletion
 {
-  [self syncWithCompletionHandler:^(BOOL success) {
+  [self syncResettingCache:YES completionHandler:^(BOOL success) {
     if(success) {
       [self save];
     } else {

--- a/Simplified/NYPLCatalogFeedViewController.m
+++ b/Simplified/NYPLCatalogFeedViewController.m
@@ -157,7 +157,7 @@
   UIApplicationState applicationState = [[UIApplication sharedApplication] applicationState];
   if (applicationState == UIApplicationStateActive) {
     __weak __auto_type wSelf = self;
-    [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL success) {
+    [[NYPLBookRegistry sharedRegistry] syncResettingCache:NO completionHandler:^(BOOL success) {
       if (success) {
         [[NYPLBookRegistry sharedRegistry] save];
       } else {

--- a/Simplified/NYPLCatalogGroupedFeedViewController.m
+++ b/Simplified/NYPLCatalogGroupedFeedViewController.m
@@ -456,6 +456,7 @@ viewForHeaderInSection:(NSInteger const)section
 {
   [NYPLOpenSearchDescription
    withURL:self.feed.openSearchURL
+   shouldResetCache:NO
    completionHandler:^(NYPLOpenSearchDescription *const description) {
      [[NSOperationQueue mainQueue] addOperationWithBlock:^{
        self.searchDescription = description;

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -195,7 +195,7 @@
     [UIApplication sharedApplication].delegate.window.tintColor = [NYPLConfiguration mainColor];
     
     [[NYPLBookRegistry sharedRegistry] justLoad];
-    [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL __unused success) {
+    [[NYPLBookRegistry sharedRegistry] syncResettingCache:NO completionHandler:^(BOOL success) {
       if (success) {
         [[NYPLBookRegistry sharedRegistry] save];
       }

--- a/Simplified/NYPLCatalogUngroupedFeed.m
+++ b/Simplified/NYPLCatalogUngroupedFeed.m
@@ -38,6 +38,7 @@ handler:(void (^)(NYPLCatalogUngroupedFeed *category))handler
   
   [NYPLOPDSFeed
    withURL:URL
+   shouldResetCache:NO
    completionHandler:^(NYPLOPDSFeed *const ungroupedFeed, __unused NSDictionary *error) {
      if(!ungroupedFeed) {
        handler(nil);

--- a/Simplified/NYPLCatalogUngroupedFeedViewController.m
+++ b/Simplified/NYPLCatalogUngroupedFeedViewController.m
@@ -315,6 +315,7 @@ didSelectFacetAtIndexPath:(NSIndexPath *const)indexPath
 {
   [NYPLOpenSearchDescription
    withURL:self.feed.openSearchURL
+   shouldResetCache:NO
    completionHandler:^(NYPLOpenSearchDescription *const description) {
      [[NSOperationQueue mainQueue] addOperationWithBlock:^{
        self.searchDescription = description;

--- a/Simplified/NYPLHoldsViewController.m
+++ b/Simplified/NYPLHoldsViewController.m
@@ -85,7 +85,7 @@
   
   self.collectionView.alwaysBounceVertical = YES;
   self.refreshControl = [[UIRefreshControl alloc] init];
-  [self.refreshControl addTarget:self action:@selector(didSelectSync) forControlEvents:UIControlEventValueChanged];
+  [self.refreshControl addTarget:self action:@selector(didPullToRefresh) forControlEvents:UIControlEventValueChanged];
   [self.collectionView addSubview:self.refreshControl];
   
   // We know that super sets it to a flow layout.
@@ -252,7 +252,7 @@ didSelectItemAtIndexPath:(NSIndexPath *const)indexPath
   }
 }
 
-- (void)didSelectSync
+- (void)didPullToRefresh
 {  
   Account *const account = [AccountsManager shared].currentAccount;
   if (account.details.needsAuth) {

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -562,7 +562,7 @@ didCompleteWithError:(NSError *)error
     [[NYPLBookRegistry sharedRegistry] save];
   } else {
     [[NYPLBookRegistry sharedRegistry] setProcessing:YES forIdentifier:book.identifier];
-    [NYPLOPDSFeed withURL:book.revokeURL completionHandler:^(NYPLOPDSFeed *feed, NSDictionary *error) {
+    [NYPLOPDSFeed withURL:book.revokeURL shouldResetCache:NO completionHandler:^(NYPLOPDSFeed *feed, NSDictionary *error) {
 
       [[NYPLBookRegistry sharedRegistry] setProcessing:NO forIdentifier:book.identifier];
       
@@ -676,7 +676,7 @@ didCompleteWithError:(NSError *)error
           borrowCompletion:(void (^)(void))borrowCompletion
 {
   [[NYPLBookRegistry sharedRegistry] setProcessing:YES forIdentifier:book.identifier];
-  [NYPLOPDSFeed withURL:book.defaultAcquisitionIfBorrow.hrefURL completionHandler:^(NYPLOPDSFeed *feed, NSDictionary *error) {
+  [NYPLOPDSFeed withURL:book.defaultAcquisitionIfBorrow.hrefURL shouldResetCache:NO completionHandler:^(NYPLOPDSFeed *feed, NSDictionary *error) {
     [[NYPLBookRegistry sharedRegistry] setProcessing:NO forIdentifier:book.identifier];
 
     if (error || !feed || feed.entries.count < 1) {

--- a/Simplified/NYPLMyBooksViewController.m
+++ b/Simplified/NYPLMyBooksViewController.m
@@ -129,7 +129,7 @@ typedef NS_ENUM(NSInteger, FacetSort) {
 
   self.collectionView.alwaysBounceVertical = YES;
   self.refreshControl = [[UIRefreshControl alloc] init];
-  [self.refreshControl addTarget:self action:@selector(didSelectSync) forControlEvents:UIControlEventValueChanged];
+  [self.refreshControl addTarget:self action:@selector(didPullToRefresh) forControlEvents:UIControlEventValueChanged];
   [self.collectionView addSubview:self.refreshControl];
   
   self.facetBarView = [[NYPLFacetBarView alloc] initWithOrigin:CGPointZero width:0];
@@ -193,11 +193,6 @@ typedef NS_ENUM(NSInteger, FacetSort) {
   }
   self.collectionView.contentInset = contentInset;
   self.collectionView.scrollIndicatorInsets = contentInset;
-}
-
-- (void)pullToRefresh:(UIRefreshControl *)__unused refreshControl
-{
-  [self didSelectSync];
 }
 
 #pragma mark UICollectionViewDelegate
@@ -368,7 +363,7 @@ OK:
 
 #pragma mark -
 
-- (void)didSelectSync
+- (void)didPullToRefresh
 {
   Account *const account = [AccountsManager shared].currentAccount;
   if (account.details.needsAuth) {

--- a/Simplified/NYPLOPDSFeed.h
+++ b/Simplified/NYPLOPDSFeed.h
@@ -21,9 +21,17 @@ typedef NS_ENUM(NSInteger, NYPLOPDSFeedType) {
 + (id)new NS_UNAVAILABLE;
 - (id)init NS_UNAVAILABLE;
 
-+ (void)withURL:(NSURL *)URL completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler;
+/// Executes a GET request for the given URL unless the last path component
+/// is `borrow`, in which case it executes a PUT.
+/// @param URL The URL to contact.
+/// @param shouldResetCache Pass YES to wipe the whole cache.
+/// @param handler The completion handler that will always be called at the
+/// end of the process.
++ (void)  withURL:(NSURL *)URL
+ shouldResetCache:(BOOL)shouldResetCache
+completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler;
 
-// designated initializer
+/// Designated initializer.
 - (instancetype)initWithXML:(NYPLXML *)feedXML;
 
 @end

--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -56,14 +56,19 @@ static NYPLOPDSFeedType TypeImpliedByEntry(NYPLOPDSEntry *const entry)
 
 @implementation NYPLOPDSFeed
 
-+ (void)withURL:(NSURL *)URL completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
++ (void)withURL:(NSURL *)URL
+shouldResetCache:(BOOL)shouldResetCache
+completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
 {
   if(!handler) {
     @throw NSInvalidArgumentException;
   }
 
   __block NSURLRequest *request = nil;
-  request = [[NYPLSession sharedSession] withURL:URL completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+  request = [[NYPLSession sharedSession]
+             withURL:URL
+             shouldResetCache:shouldResetCache
+             completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
 
     if (error != nil) {
       // NYPLSession already logged this.

--- a/Simplified/NYPLOpenSearchDescription.h
+++ b/Simplified/NYPLOpenSearchDescription.h
@@ -19,6 +19,7 @@
 - (id)init NS_UNAVAILABLE;
 
 + (void)withURL:(NSURL *)URL
+shouldResetCache:(BOOL)shouldResetCache
 completionHandler:(void (^)(NYPLOpenSearchDescription *description))handler;
 
 - (instancetype)initWithXML:(NYPLXML *)OSDXML;

--- a/Simplified/NYPLOpenSearchDescription.m
+++ b/Simplified/NYPLOpenSearchDescription.m
@@ -17,6 +17,7 @@
 @implementation NYPLOpenSearchDescription
 
 + (void)withURL:(NSURL *const)URL
+shouldResetCache:(BOOL)shouldResetCache
 completionHandler:(void (^)(NYPLOpenSearchDescription *))handler
 {
   if(!handler) {
@@ -25,6 +26,7 @@ completionHandler:(void (^)(NYPLOpenSearchDescription *))handler
   
   [[NYPLSession sharedSession]
    withURL:URL
+   shouldResetCache:shouldResetCache
    completionHandler:^(NSData *const data, __unused NSURLResponse *response, __unused NSError *error) {
      if(!data) {
        NYPLLOG(@"Failed to retrieve data.");

--- a/Simplified/NYPLSession.h
+++ b/Simplified/NYPLSession.h
@@ -14,12 +14,14 @@
  Executes GET request for given URL, unless the URL path ends in "borrow", in
  which cast a PUT is executed instead.
  @param URL The endpoint to reach
+ @param shouldResetCache Pass YES to wipe the whole cache for this session.
  @param handler This handler is always called once a response is received.
  If @p error is not nil, @p data is always nil.
  If @p error is nil, @p data may also be nil.
  @return The request that was issued.
  */
 - (nonnull NSURLRequest*)withURL:(nonnull NSURL *)URL
+                shouldResetCache:(BOOL)shouldResetCache
                completionHandler:(void (^ _Nonnull)(NSData * _Nullable data,
                                                     NSURLResponse * _Nullable response,
                                                     NSError * _Nullable error))handler;

--- a/Simplified/NYPLSession.m
+++ b/Simplified/NYPLSession.m
@@ -82,6 +82,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *const)challenge
 }
 
 - (NSURLRequest*)withURL:(NSURL *const)URL
+        shouldResetCache:(BOOL)shouldResetCache
        completionHandler:(void (^)(NSData *data,
                                    NSURLResponse *response,
                                    NSError *error))handler
@@ -89,9 +90,17 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *const)challenge
   if(!handler) {
     @throw NSInvalidArgumentException;
   }
-  
+
   NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:URL cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:60.0];
-  
+
+  if (shouldResetCache) {
+    // NB: this sledgehammer approach is not ideal, and the only reason we
+    // don't use `removeCachedResponseForRequest:` (which is really what we
+    // should be using) is because that method has been buggy since iOS 8,
+    // and it still is in iOS 13.
+    [self.session.configuration.URLCache removeAllCachedResponses];
+  }
+
   NSString *lpe = [URL lastPathComponent];
   if ([lpe isEqualToString:@"borrow"])
     [req setHTTPMethod:@"PUT"];

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -803,7 +803,7 @@ Authenticating with any of those barcodes should work.
       [self.selectedUserAccount setBarcode:self.usernameTextField.text PIN:self.PINTextField.text];
 
       if ([self.selectedAccountId isEqualToString:[AccountsManager shared].currentAccount.uuid]) {
-        [[NYPLBookRegistry sharedRegistry] syncWithCompletionHandler:^(BOOL success) {
+        [[NYPLBookRegistry sharedRegistry] syncResettingCache:NO completionHandler:^(BOOL success) {
           if (success) {
             [[NYPLBookRegistry sharedRegistry] save];
           }

--- a/Simplified/NYPLSignInBusinessLogic.swift
+++ b/Simplified/NYPLSignInBusinessLogic.swift
@@ -12,7 +12,8 @@ import NYPLCardCreator
 @objc protocol NYPLBookRegistrySyncing: NSObjectProtocol {
   var syncing: Bool {get}
   func reset(_ libraryAccountUUID: String)
-  func sync(completionHandler: ((_ success: Bool) -> Void)?)
+  func syncResettingCache(_ resetCache: Bool,
+                          completionHandler: ((_ success: Bool) -> Void)?)
   func save()
 }
 


### PR DESCRIPTION
**What's this do?**
Wipes the cache contained inside NYPLSession when user pulls-to-refresh by parametrizing the api calls with a "refersh" parameter.

One gotcha: because NSURLCache::removeCachedResponseForRequest: has a bug, it's impossible to reliably remove only the response related to a given request. Since the same class (NYPLSession) handles requests for MyBooks, Holds, book details page, search, ungrouped feeds, invalidating the cache for one of those pages will also wipe the cache all others.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2953

**How should this be tested? / Do these changes have associated tests?**
1. install 3.5.1
2. route device network traffic via Charles.
3. sign in into any library, put some books in My Books.
4. verify that you see a request for circulation.librarysimplified.org/NYNYPL/loans in Charles on the left panel:
![charles-loan-requests](https://user-images.githubusercontent.com/289104/90072702-c113b000-dcac-11ea-87e3-0285657281df.png)
5. verify that pulling to refresh in My Books returns instantaneously. You should not see a new request in Charles
6. install the build with this fix.
7. open up My Books and pull to refresh: now you should see a new request every time you pull to refresh, and the spinner should spin for much longer.

**Dependencies for merging? Releasing to production?**
This is one of the emergencies we need to fix in the next release.

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
@ettore 