### PR TITLE
SIMPLY-2984 Use lowercase keys when reading Overdrive headers

### DIFF
--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -817,8 +817,8 @@ didCompleteWithError:(NSError *)error
           [self failDownloadForBook:book];
           return;
         }
-          
-        if (!responseHeader[@"X-Overdrive-Scope"] || !responseHeader[@"Location"]) {
+
+        if (!responseHeader[@"x-overdrive-scope"] || !responseHeader[@"location"]) {
           [NYPLErrorLogger logOverdriveInvalidResponseWithMessage:@"Overdrive book fulfillment response does not contain valid data" response:responseHeader];
           [self failDownloadForBook:book];
           return;
@@ -826,10 +826,10 @@ didCompleteWithError:(NSError *)error
           
         if ([[OverdriveAPIExecutor shared] patronToken] && ![[[OverdriveAPIExecutor shared] patronToken] isExpired]) {
           // Use existing Patron Token
-          NSURLRequest *request = [[OverdriveAPIExecutor shared] getManifestRequestWithUrlString:responseHeader[@"Location"]];
+          NSURLRequest *request = [[OverdriveAPIExecutor shared] getManifestRequestWithUrlString:responseHeader[@"location"]];
           [self addDownloadTaskWithRequest:request book:book];
         } else {
-          [[OverdriveAPIExecutor shared] refreshPatronTokenWithKey:NYPLSecrets.overdriveClientKey secret:NYPLSecrets.overdriveClientSecret username:[[NYPLUserAccount sharedAccount] barcode] PIN:[[NYPLUserAccount sharedAccount] PIN] scope:responseHeader[@"X-Overdrive-Scope"] completion:^(NSError * _Nullable error) {
+          [[OverdriveAPIExecutor shared] refreshPatronTokenWithKey:NYPLSecrets.overdriveClientKey secret:NYPLSecrets.overdriveClientSecret username:[[NYPLUserAccount sharedAccount] barcode] PIN:[[NYPLUserAccount sharedAccount] PIN] scope:responseHeader[@"x-overdrive-scope"] completion:^(NSError * _Nullable error) {
             if (error) {
               [NYPLErrorLogger logError:error
                                 context:@"myBooksDownload"
@@ -845,7 +845,7 @@ didCompleteWithError:(NSError *)error
               return;
             }
               
-            NSURLRequest *request = [[OverdriveAPIExecutor shared] getManifestRequestWithUrlString:responseHeader[@"Location"]];
+            NSURLRequest *request = [[OverdriveAPIExecutor shared] getManifestRequestWithUrlString:responseHeader[@"location"]];
             [self addDownloadTaskWithRequest:request book:book];
           }];
         }


### PR DESCRIPTION
**What's this do?**
This is an PR to integrate changes in the Overdrive processor framework that now makes sure to return header keys that are always lowercased. This will ensure better reliability across different library servers that may return headers that are capitalized in different ways. E.g. some servers may return header keys such as `X-Overdrive-Scope` and others `x-overdrive-scope`.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2984

**How should this be tested? / Do these changes have associated tests?**
make sure to download Overdrive audiobooks from NYPL and then RoundRock library and Houston. They should all work consistently.

**Dependencies for merging? Releasing to production?**
In accordance with Product, we'll merge this to develop.

btw this PR is dependent on https://github.com/NYPL-Simplified/audiobook-ios-overdrive/pull/4

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 