### PR TITLE
SIMPLY-2975 Surface rationale of download errors in Crashlytics reports

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -428,6 +428,8 @@
 		73A3EAED2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 73A3EAEC2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m */; };
 		73CDA121243EDAD8009CC6A6 /* URLRequest+NYPL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CDA120243EDAD8009CC6A6 /* URLRequest+NYPL.swift */; };
 		73E84FC624465083009071D8 /* NYPLUserAccountFrontEndValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = 73E84FC524465083009071D8 /* NYPLUserAccountFrontEndValidation.m */; };
+		73FB0AC924EB403D0072E430 /* NYPLBookContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FB0AC824EB403D0072E430 /* NYPLBookContentType.swift */; };
+		73FB0ACA24EB403D0072E430 /* NYPLBookContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FB0AC824EB403D0072E430 /* NYPLBookContentType.swift */; };
 		841B55431B740F2700FAC1AF /* NYPLSettingsEULAViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 841B55421B740F2700FAC1AF /* NYPLSettingsEULAViewController.m */; };
 		84B7A3461B84E8FE00584FB2 /* OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3431B84E8FE00584FB2 /* OFL.txt */; };
 		84B7A3471B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3441B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf */; };
@@ -862,6 +864,7 @@
 		73DA43A82404BA5600985482 /* build-openssl-curl.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "build-openssl-curl.sh"; sourceTree = SOURCE_ROOT; };
 		73E84FC424465083009071D8 /* NYPLUserAccountFrontEndValidation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NYPLUserAccountFrontEndValidation.h; sourceTree = "<group>"; };
 		73E84FC524465083009071D8 /* NYPLUserAccountFrontEndValidation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NYPLUserAccountFrontEndValidation.m; sourceTree = "<group>"; };
+		73FB0AC824EB403D0072E430 /* NYPLBookContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NYPLBookContentType.swift; path = Models/NYPLBookContentType.swift; sourceTree = "<group>"; };
 		841B55411B740F2700FAC1AF /* NYPLSettingsEULAViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYPLSettingsEULAViewController.h; sourceTree = "<group>"; };
 		841B55421B740F2700FAC1AF /* NYPLSettingsEULAViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYPLSettingsEULAViewController.m; sourceTree = "<group>"; };
 		84B7A3431B84E8FE00584FB2 /* OFL.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OFL.txt; sourceTree = "<group>"; };
@@ -1160,6 +1163,7 @@
 				E6DA7E9F1F2A718600CFBEC8 /* NYPLBookAuthor.swift */,
 				E627B559216D4ADD00A7D1D5 /* NYPLBookContentType.h */,
 				E627B553216D4A9700A7D1D5 /* NYPLBookContentType.m */,
+				73FB0AC824EB403D0072E430 /* NYPLBookContentType.swift */,
 				1139DA6319C7755D00A07810 /* NYPLBookCoverRegistry.h */,
 				1139DA6419C7755D00A07810 /* NYPLBookCoverRegistry.m */,
 				1164F104199AC236009BF8BF /* NYPLBookLocation.h */,
@@ -2199,6 +2203,7 @@
 				7347F094245A4DE200558D7F /* NYPLSettingsSplitViewController.m in Sources */,
 				7347F095245A4DE200558D7F /* Date+NYPLAdditions.swift in Sources */,
 				7347F096245A4DE200558D7F /* OPDS2AuthenticationDocument.swift in Sources */,
+				73FB0ACA24EB403D0072E430 /* NYPLBookContentType.swift in Sources */,
 				7347F097245A4DE200558D7F /* NYPLBookRegistryRecord.m in Sources */,
 				7347F098245A4DE200558D7F /* NYPLDeveloperSettingsTableViewController.swift in Sources */,
 				7347F099245A4DE200558D7F /* NYPLBookContentType.m in Sources */,
@@ -2281,6 +2286,7 @@
 				114C8CD719BE2FD300719B72 /* NYPLAttributedString.m in Sources */,
 				17CE5305243C020800315E63 /* NYPLUserAccount.swift in Sources */,
 				5DD5677222B7ECE3001F0C83 /* NYPLSettings.swift in Sources */,
+				73FB0AC924EB403D0072E430 /* NYPLBookContentType.swift in Sources */,
 				E6BC315D1E009F3E0021B65E /* NYPLAgeCheck.swift in Sources */,
 				2D382BD71D08BA99002C423D /* Log.swift in Sources */,
 				11616E11196B0531003D60D9 /* NYPLBookRegistry.m in Sources */,

--- a/Simplified/Models/NYPLBookContentType.swift
+++ b/Simplified/Models/NYPLBookContentType.swift
@@ -1,0 +1,26 @@
+//
+//  NYPLBookContentType.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 8/17/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+class NYPLBookContentTypeConverter: NSObject {
+  @objc class func stringValue(of bookContentType: NYPLBookContentType) -> String {
+    switch bookContentType {
+    case .EPUB:
+      return "Epub"
+    case .audiobook:
+      return "AudioBook"
+    case .PDF:
+      return "PDF"
+    case .unsupported:
+      return "Unsupported"
+    default:
+      return "Unexpected enum value: \(bookContentType.rawValue)"
+    }
+  }
+}

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -180,7 +180,7 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
 
   [self.taskIdentifierToRedirectAttempts removeObjectForKey:@(downloadTask.taskIdentifier)];
   
-  BOOL success = YES; 
+  BOOL success = YES;
   NYPLProblemDocument *problemDocument = nil;
   NYPLMyBooksDownloadRightsManagement rights = [self downloadInfoForBookIdentifier:book.identifier].rightsManagement;
 
@@ -196,30 +196,29 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
        problemDocumentData:problemDocData
        barcode:NYPLUserAccount.sharedAccount.barcode
        url:tmpSavedFileURL
-       context:@"myBooks-download-finish"
-       message:@"Error downloading book"];
-    }// we are not logging the problem doc error here but we do further down
+       context:[NSString stringWithFormat:@"Error parsing problem doc downloading %@ book", book.distributor]
+       message:[book loggableShortString]];
+    }
+    [self logBookDownloadFailure:book
+                          reason:@"Got problem document"
+                    downloadTask:downloadTask
+                        metadata:@{@"problemDocument": problemDocument}];
+
     [[NSFileManager defaultManager] removeItemAtURL:tmpSavedFileURL error:NULL];
     success = NO;
   } else {
     // we did NOT get a problem document
     switch(rights) {
       case NYPLMyBooksDownloadRightsManagementUnknown:
-        [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeUnknownRightsManagement
-                                  context:@"myBooksDownload"
-                                  message:[NSString stringWithFormat:@"Unknown rights mgmt after downloading book %@", [book loggableShortString]]
-                                 metadata:@{
-                                   @"taskOriginalRequest": downloadTask.originalRequest.loggableString,
-                                   @"taskCurrentRequest": downloadTask.currentRequest.loggableString,
-                                   @"response": downloadTask.response ?: @"N/A"
-                                 }];
+        [self logBookDownloadFailure:book
+                              reason:@"Unknown rights management exception"
+                        downloadTask:downloadTask
+                            metadata:nil];
         @throw NSInternalInconsistencyException;
             
       case NYPLMyBooksDownloadRightsManagementAdobe:
       {
-        
 #if defined(FEATURE_DRM_CONNECTOR)
-        
         NSData *ACSMData = [NSData dataWithContentsOfURL:tmpSavedFileURL];
         NSString *PDFString = @">application/pdf</dc:format>";
         if([[[NSString alloc] initWithData:ACSMData encoding:NSUTF8StringEncoding] containsString:PDFString]) {
@@ -233,18 +232,11 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
            setState:NYPLBookStateDownloadFailed
            forIdentifier:book.identifier];
 
-          [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeUnexpectedFormat
-                                    context:@"myBooksDownload"
-                                    message:[NSString stringWithFormat:
-                                             @"Received PDF after downloading a Adobe DRM book %@",
-                                             [book loggableShortString]]
-                                   metadata:@{
-                                     @"taskOriginalRequest": downloadTask.originalRequest.loggableString,
-                                     @"taskCurrentRequest": downloadTask.currentRequest.loggableString,
-                                     @"response": downloadTask.response ?: @"N/A"
-                                   }];
+          [self logBookDownloadFailure:book
+                                reason:@"Received PDF for AdobeDRM rights"
+                          downloadTask:downloadTask
+                              metadata:nil];
         } else {
-          
           NYPLLOG_F(@"Download finished. Fulfilling with userID: %@",[[NYPLUserAccount sharedAccount] userID]);
           [[NYPLADEPT sharedInstance]
            fulfillWithACSMData:ACSMData
@@ -252,19 +244,26 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
            userID:[[NYPLUserAccount sharedAccount] userID]
            deviceID:[[NYPLUserAccount sharedAccount] deviceID]];
         }
-        
-#endif        
+#endif
         break;
       }
       case NYPLMyBooksDownloadRightsManagementSimplifiedBearerTokenJSON: {
         NSData *const data = [NSData dataWithContentsOfURL:tmpSavedFileURL];
         if (!data) {
+          [self logBookDownloadFailure:book
+                                reason:@"No Simplified Bearer Token data available on disk"
+                          downloadTask:downloadTask
+                              metadata:nil];
           [self failDownloadForBook:book];
           break;
         }
 
         NSDictionary *const dictionary = NYPLJSONObjectFromData(data);
         if (![dictionary isKindOfClass:[NSDictionary class]]) {
+          [self logBookDownloadFailure:book
+                                reason:@"Unable to deserialize Simplified Bearer Token data"
+                          downloadTask:downloadTask
+                              metadata:nil];
           [self failDownloadForBook:book];
           break;
         }
@@ -273,6 +272,10 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
           [NYPLMyBooksSimplifiedBearerToken simplifiedBearerTokenWithDictionary:dictionary];
 
         if (!simplifiedBearerToken) {
+          [self logBookDownloadFailure:book
+                                reason:@"No Simplified Bearer Token in deserialized data"
+                          downloadTask:downloadTask
+                              metadata:nil];
           [self failDownloadForBook:book];
           break;
         }
@@ -296,8 +299,8 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
         break;
       }
       case NYPLMyBooksDownloadRightsManagementOverdriveManifestJSON: {
-          success = [self moveDownloadedFileAtURL:tmpSavedFileURL book:book];
-          break;
+        success = [self moveDownloadedFileAtURL:tmpSavedFileURL book:book];
+        break;
       }
       case NYPLMyBooksDownloadRightsManagementNone: {
         NSError *removeError = nil, *moveError = nil;
@@ -317,17 +320,16 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
            setState:NYPLBookStateDownloadSuccessful forIdentifier:book.identifier];
           [[NYPLBookRegistry sharedRegistry] save];
         } else if (moveError) {
-          [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeFileMoveFail
-                                    context:@"myBooksDownload"
-                                    message:@"Error moving downloaded book from temporary file location to final URL"
-                                   metadata:@{
-                                     NSUnderlyingErrorKey: moveError,
-                                     @"removeError": removeError.debugDescription ?: @"N/A",
-                                     @"tmpSavedFileURL": tmpSavedFileURL ?: @"N/A",
-                                     @"final file location": finalFileURL ?: @"N/A"
-                                   }];
+          [self logBookDownloadFailure:book
+                                reason:@"Couldn't move book to final disk location"
+                          downloadTask:downloadTask
+                              metadata:@{
+                                @"moveError": moveError,
+                                @"removeError": removeError.debugDescription ?: @"N/A",
+                                @"tmpSavedFileURL": tmpSavedFileURL ?: @"N/A",
+                                @"finalFileURL": finalFileURL ?: @"N/A",
+                              }];
         }
-        
         break;
       }
     }
@@ -347,18 +349,6 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
           [[NYPLBookRegistry sharedRegistry] removeBookForIdentifier:book.identifier];
         }
       }
-
-      NSString *logMsg = [NSString stringWithFormat:@"Downloading book %@ failed", [book loggableShortString]];
-      [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeDownloadFail
-                                context:@"myBooksDownload"
-                                message:logMsg
-                               metadata:@{
-                                 @"problemDoc": problemDocument.debugDictionary ?: @"N/A",
-                                 @"rightsManagement": @(rights),
-                                 @"taskOriginalRequest": downloadTask.originalRequest.loggableString,
-                                 @"taskCurrentRequest": downloadTask.currentRequest.loggableString,
-                                 @"response": downloadTask.response ?: @"N/A"
-                               }];
 
       [NYPLAlertUtils presentFromViewControllerOrNilWithAlertController:alert viewController:nil animated:YES completion:nil];
     });
@@ -465,6 +455,13 @@ didCompleteWithError:(NSError *)error
   */
   
   if(error && error.code != NSURLErrorCancelled) {
+    // TODO: SIMPLY-2985 filter out codes in NYPLErrorLogger
+    [self logBookDownloadFailure:book
+                          reason:@"networking error"
+                    downloadTask:task
+                        metadata:@{
+                          @"urlSessionError": error
+                        }];
     [self failDownloadForBook:book];
     return;
   }
@@ -646,6 +643,34 @@ didCompleteWithError:(NSError *)error
           URLByAppendingPathExtension:@"epub"];
 }
 
+- (void)logBookDownloadFailure:(NYPLBook *)book
+                        reason:(NSString *)reason
+                  downloadTask:(NSURLSessionTask *)downloadTask
+                      metadata:(NSDictionary<NSString*, id> *)metadata
+{
+  NSString *rights = [[self downloadInfoForBookIdentifier:book.identifier]
+                      rightsManagementString];
+  NSString *bookType = [NYPLBookContentTypeConverter stringValueOf:
+                        [book defaultBookContentType]];
+  NSString *context = [NSString stringWithFormat:@"%@ %@ download fail: %@",
+                       book.distributor, bookType, reason];
+
+  NSMutableDictionary<NSString*, id> *dict = [[NSMutableDictionary alloc] initWithDictionary:metadata];
+  dict[@"book"] = book.loggableDictionary;
+  dict[@"rightsManagement"] = rights;
+  dict[@"taskOriginalRequest"] = downloadTask.originalRequest.loggableString;
+  dict[@"taskCurrentRequest"] = downloadTask.currentRequest.loggableString;
+  dict[@"response"] = downloadTask.response ?: @"N/A";
+
+  [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeDownloadFail
+                            context:context
+                            message:nil
+                           metadata:dict];
+}
+
+/// Notifies the book registry AND the user that a book failed to download.
+/// @note This method does NOT log to Crashlytics.
+/// @param book The book that failed to download.
 - (void)failDownloadForBook:(NYPLBook *const)book
 {
   [[NYPLBookRegistry sharedRegistry]
@@ -662,12 +687,6 @@ didCompleteWithError:(NSError *)error
     [NYPLAlertUtils presentFromViewControllerOrNilWithAlertController:alert viewController:nil animated:YES completion:nil];
   });
 
-  [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeDownloadFail
-                            context:@"MyBooksDownloadCenter::failDownloadForBook"
-                            message:[NSString stringWithFormat:@"%@ book download failed", book.distributor]
-                           metadata: @{
-                             @"book": book.loggableDictionary
-                           }];
   [self broadcastUpdate];
 }
 
@@ -803,13 +822,13 @@ didCompleteWithError:(NSError *)error
       [[OverdriveAPIExecutor shared] fulfillBookWithUrlString:URL.absoluteString
                                                      username:[[NYPLUserAccount sharedAccount] barcode]
                                                           PIN:[[NYPLUserAccount sharedAccount] PIN]
-                                                   completion:^(NSDictionary<NSString *,id> * _Nullable responseHeader, NSError * _Nullable error) {
+                                                   completion:^(NSDictionary<NSString *,id> * _Nullable responseHeaders, NSError * _Nullable error) {
         if (error) {
           [NYPLErrorLogger logError:error
-                            context:@"myBooksDownload"
-                            message:@"An error occurred fulfilling Overdrive book"
+                            context:@"Overdrive audiobook fulfillment error"
+                            message:nil
                            metadata:@{
-                             @"responseHEaders": responseHeader ?: @"N/A",
+                             @"responseHeaders": responseHeaders ?: @"N/A",
                              @"acquisitionURL": URL ?: @"N/A",
                              @"book": book.loggableDictionary,
                              @"bookRegistryState": [NYPLBookStateHelper stringValueFromBookState:state]
@@ -818,34 +837,47 @@ didCompleteWithError:(NSError *)error
           return;
         }
 
-        if (!responseHeader[@"x-overdrive-scope"] || !responseHeader[@"location"]) {
-          [NYPLErrorLogger logOverdriveInvalidResponseWithMessage:@"Overdrive book fulfillment response does not contain valid data" response:responseHeader];
+        if (!responseHeaders[@"x-overdrive-scope"] || !responseHeaders[@"location"]) {
+          [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeOverdriveFulfillResponseParseFail
+                                    context:@"Overdrive audiobook fulfillment: wrong headers"
+                                    message:@"Response does not contain the expected headers"
+                                   metadata:@{
+                                     @"responseHeaders": responseHeaders ?: @"N/A",
+                                     @"acquisitionURL": URL ?: @"N/A",
+                                     @"book": book.loggableDictionary,
+                                     @"bookRegistryState": [NYPLBookStateHelper stringValueFromBookState:state]
+                                   }];
           [self failDownloadForBook:book];
           return;
         }
           
         if ([[OverdriveAPIExecutor shared] patronToken] && ![[[OverdriveAPIExecutor shared] patronToken] isExpired]) {
           // Use existing Patron Token
-          NSURLRequest *request = [[OverdriveAPIExecutor shared] getManifestRequestWithUrlString:responseHeader[@"location"]];
+          NSURLRequest *request = [[OverdriveAPIExecutor shared] getManifestRequestWithUrlString:responseHeaders[@"location"]];
           [self addDownloadTaskWithRequest:request book:book];
         } else {
-          [[OverdriveAPIExecutor shared] refreshPatronTokenWithKey:NYPLSecrets.overdriveClientKey secret:NYPLSecrets.overdriveClientSecret username:[[NYPLUserAccount sharedAccount] barcode] PIN:[[NYPLUserAccount sharedAccount] PIN] scope:responseHeader[@"x-overdrive-scope"] completion:^(NSError * _Nullable error) {
+          [[OverdriveAPIExecutor shared]
+           refreshPatronTokenWithKey:NYPLSecrets.overdriveClientKey
+           secret:NYPLSecrets.overdriveClientSecret
+           username:[[NYPLUserAccount sharedAccount] barcode]
+           PIN:[[NYPLUserAccount sharedAccount] PIN]
+           scope:responseHeaders[@"x-overdrive-scope"]
+           completion:^(NSError * _Nullable error) {
             if (error) {
               [NYPLErrorLogger logError:error
-                                context:@"myBooksDownload"
-                                message:@"An error occurred refreshing Overdrive patron token"
+                                context:@"Overdrive audiobook fulfillment: patron token error"
+                                message:@"Error refreshing Overdrive patron token"
                                metadata:@{
-                                 @"responseHEaders": responseHeader ?: @"N/A",
+                                 @"responseHeaders": responseHeaders ?: @"N/A",
                                  @"acquisitionURL": URL ?: @"N/A",
                                  @"book": book.loggableDictionary,
                                  @"bookRegistryState": [NYPLBookStateHelper stringValueFromBookState:state]
                                }];
-
               [self failDownloadForBook:book];
               return;
             }
               
-            NSURLRequest *request = [[OverdriveAPIExecutor shared] getManifestRequestWithUrlString:responseHeader[@"location"]];
+            NSURLRequest *request = [[OverdriveAPIExecutor shared] getManifestRequestWithUrlString:responseHeaders[@"location"]];
             [self addDownloadTaskWithRequest:request book:book];
           }];
         }
@@ -861,13 +893,20 @@ didCompleteWithError:(NSError *)error
         // NSURLSessionDownloadTask created from a request with a nil URL pathetically results in a
         // segmentation fault.
         NYPLLOG(@"Aborting request with invalid URL.");
+        [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeDownloadFail
+                                  context:@"Book download failure: nil download URL"
+                                  message:@"Unable to download book because the download URL is nil"
+                                 metadata:@{
+                                   @"acquisitionURL": URL ?: @"N/A",
+                                   @"book": book.loggableDictionary,
+                                   @"bookRegistryState": [NYPLBookStateHelper stringValueFromBookState:state]
+                                 }];
         [self failDownloadForBook:book];
         return;
       }
       
       [self addDownloadTaskWithRequest:request book:book];
     }
-
   } else {
     [NYPLAccountSignInViewController
      requestCredentialsUsingExistingBarcode:NO
@@ -1027,19 +1066,30 @@ didCompleteWithError:(NSError *)error
    object:self];
 }
 
-- (BOOL)moveDownloadedFileAtURL:(NSURL *)location
+- (BOOL)moveDownloadedFileAtURL:(NSURL *)sourceLocation
                            book:(NYPLBook *)book
 {
-  BOOL success = [[NSFileManager defaultManager] replaceItemAtURL:[self fileURLForBookIndentifier:book.identifier]
-                                                    withItemAtURL:location
+  NSError *replaceError = nil;
+  NSURL *destURL = [self fileURLForBookIndentifier:book.identifier];
+  BOOL success = [[NSFileManager defaultManager] replaceItemAtURL:destURL
+                                                    withItemAtURL:sourceLocation
                                                    backupItemName:nil
                                                           options:NSFileManagerItemReplacementUsingNewMetadataOnly
                                                  resultingItemURL:nil
-                                                            error:nil];
+                                                            error:&replaceError];
   
   if(success) {
     [[NYPLBookRegistry sharedRegistry] setState:NYPLBookStateDownloadSuccessful forIdentifier:book.identifier];
     [[NYPLBookRegistry sharedRegistry] save];
+  } else {
+    [self logBookDownloadFailure:book
+                          reason:@"Couldn't move book to final disk location"
+                    downloadTask:nil
+                        metadata:@{
+                          @"replaceError": replaceError ?: @"N/A",
+                          @"destinationFileURL": destURL ?: @"N/A",
+                          @"sourceFileURL": sourceLocation ?: @"N/A",
+                        }];
   }
 
   return success;
@@ -1057,32 +1107,78 @@ didCompleteWithError:(NSError *)error
   [self broadcastUpdate];
 }
 
-- (void)adept:(__attribute__((unused)) NYPLADEPT *)adept didFinishDownload:(BOOL)success toURL:(NSURL *)URL fulfillmentID:(NSString *)fulfillmentID isReturnable:(BOOL)isReturnable rightsData:(NSData *)rightsData tag:(NSString *)tag error:(__attribute__((unused)) NSError *)error
+- (void)    adept:(__attribute__((unused)) NYPLADEPT *)adept
+didFinishDownload:(BOOL)didFinishDownload
+            toURL:(NSURL *)adeptToURL
+    fulfillmentID:(NSString *)fulfillmentID
+     isReturnable:(BOOL)isReturnable
+       rightsData:(NSData *)rightsData
+              tag:(NSString *)tag
+            error:(NSError *)adeptError
 {
   NYPLBook *const book = [[NYPLBookRegistry sharedRegistry] bookForIdentifier:tag];
+  NSString *rights = [[NSString alloc] initWithData:rightsData encoding:kCFStringEncodingUTF8];
+  BOOL didSucceedCopying = NO;
 
-  if(success) {
+  if(didFinishDownload) {
     [[NSFileManager defaultManager]
      removeItemAtURL:[self fileURLForBookIndentifier:book.identifier]
      error:NULL];
 
     if (![self fileURLForBookIndentifier:book.identifier]) {
+      [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeAdobeDRMFulfillmentFail
+                                context:@"Adobe DRM error: final file URL unavailable"
+                                message:@"fileURLForBookIndentifier returned nil, so no destination to copy file to."
+                               metadata:@{
+                                 @"adeptError": adeptError ?: @"N/A",
+                                 @"fileURLToRemove": adeptToURL ?: @"N/A",
+                                 @"book": book.loggableDictionary,
+                                 @"AdobeFulfilmmentID": fulfillmentID,
+                                 @"AdobeRights": rights,
+                                 @"AdobeTag": tag
+                               }];
       [self failDownloadForBook:book];
-      [NYPLErrorLogger
-       logMissingFileURLAfterDownloadingBook:book
-       message:@"fileURLForBookIndentifier returned nil, so no destination to copy file to."];
       return;
     }
     
     // This needs to be a copy else the Adept connector will explode when it tries to delete the
     // temporary file.
-    success = [[NSFileManager defaultManager]
-               copyItemAtURL:URL
-               toURL:[self fileURLForBookIndentifier:book.identifier]
-               error:NULL];
+    NSError *copyError = nil;
+    NSURL *destURL = [self fileURLForBookIndentifier:book.identifier];
+    didSucceedCopying = [[NSFileManager defaultManager]
+                         copyItemAtURL:adeptToURL
+                         toURL:destURL
+                         error:&copyError];
+    if(!didSucceedCopying) {
+      [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeAdobeDRMFulfillmentFail
+                                context:@"Adobe DRM error: failure copying file"
+                                message:@"NSFileManager::copyItemAtURL:toURL:error: failed"
+                               metadata:@{
+                                 @"adeptError": adeptError ?: @"N/A",
+                                 @"copyError": copyError ?: @"N/A",
+                                 @"fromURL": adeptToURL ?: @"N/A",
+                                 @"destURL": destURL ?: @"N/A",
+                                 @"book": book.loggableDictionary,
+                                 @"AdobeFulfilmmentID": fulfillmentID,
+                                 @"AdobeRights": rights,
+                                 @"AdobeTag": tag
+                               }];
+    }
+  } else {
+    [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeAdobeDRMFulfillmentFail
+                              context:@"Adobe DRM error: did not finish download"
+                              message:@"ADEPT callback was called with didFinishDownload == false"
+                             metadata:@{
+                               @"adeptError": adeptError ?: @"N/A",
+                               @"adeptToURL": adeptToURL ?: @"N/A",
+                               @"book": book.loggableDictionary,
+                               @"AdobeFulfilmmentID": fulfillmentID,
+                               @"AdobeRights": rights,
+                               @"AdobeTag": tag
+                             }];
   }
 
-  if(!success) {
+  if(didFinishDownload == NO || didSucceedCopying == NO) {
     [self failDownloadForBook:book];
     return;
   }

--- a/Simplified/NYPLMyBooksDownloadInfo.h
+++ b/Simplified/NYPLMyBooksDownloadInfo.h
@@ -25,4 +25,6 @@ typedef NS_ENUM(NSInteger, NYPLMyBooksDownloadRightsManagement) {
 
 - (instancetype)withRightsManagement:(NYPLMyBooksDownloadRightsManagement)rightsManagement;
 
+- (NSString *)rightsManagementString;
+
 @end

--- a/Simplified/NYPLMyBooksDownloadInfo.m
+++ b/Simplified/NYPLMyBooksDownloadInfo.m
@@ -43,4 +43,23 @@
           rightsManagement:rightsManagement];
 }
 
+- (NSString *)rightsManagementString
+{
+  switch (self.rightsManagement) {
+    case NYPLMyBooksDownloadRightsManagementUnknown:
+      return @"Unknown";
+    case NYPLMyBooksDownloadRightsManagementNone:
+      return @"None";
+    case NYPLMyBooksDownloadRightsManagementAdobe:
+      return @"Adobe";
+    case NYPLMyBooksDownloadRightsManagementSimplifiedBearerTokenJSON:
+      return @"SimplifiedBearerTokenJSON";
+    case NYPLMyBooksDownloadRightsManagementOverdriveManifestJSON:
+      return @"OverdriveManifestJSON";
+    default:
+      return [NSString stringWithFormat:@"Unexpected value: %ld",
+              (long)self.rightsManagement];
+  }
+}
+
 @end

--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -78,8 +78,8 @@ completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
 
     if (data == nil) {
       [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeOpdsFeedNoData
-                                context:@"NYPLOPDSFeed"
-                                message:@"Received no data from server"
+                                context:@"NYPLOPDSFeed: no data from server"
+                                message:nil
                                metadata:@{
                                  @"Request": [request loggableString],
                                  @"Response": response,
@@ -98,27 +98,25 @@ completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
         NSString *msg = [NSString stringWithFormat:@"Got %ld HTTP status with no error object.", (long)httpResp.statusCode];
 
         NSString *dataString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-        if (dataString == nil) {
-          dataString = [NSString stringWithFormat:@"datalength=%lu",
-                        (unsigned long)data.length];
+
+        NSDictionary *problemDocDict = nil;
+        if (response.isProblemDocument) {
+          problemDocDict = [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)0 error:nil];
         }
 
         [NYPLErrorLogger logNetworkError:error
                                     code:NYPLErrorCodeApiCall
-                                 context:NSStringFromClass([self class])
+                                 context:@"NYPLOPDSFeed: HTTP status error"
                                  request:request
                                 response:response
                                  message:msg
                                 metadata:@{
-                                  @"receivedData": dataString ?: @""
+                                  @"receivedData": dataString ?: @"N/A",
+                                  @"receivedDataLength (bytes)": @(data.length),
+                                  @"problemDoc": problemDocDict ?: @"N/A"
                                 }];
 
-        NSDictionary *errorDict = nil;
-        if (response.isProblemDocument) {
-          errorDict = [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)0 error:nil];
-        }
-
-        NYPLAsyncDispatch(^{handler(nil, errorDict);});
+        NYPLAsyncDispatch(^{handler(nil, problemDocDict);});
         return;
       }
     }
@@ -127,9 +125,12 @@ completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
     if(!feedXML) {
       NYPLLOG(@"Failed to parse data as XML.");
       [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeFeedParseFail
-                                context:@"NYPLOPDSFeed"
-                                message:[NSString stringWithFormat:@"%@ - Response: %@", [request loggableString], response]
-                               metadata:nil];
+                                context:@"NYPLOPDSFeed: Failed to parse data as XML"
+                                message:@"Error in NYPLOPDSFeed::withURL:"
+                               metadata:@{
+                                 @"request": request.loggableString,
+                                 @"response": response ?: @"N/A",
+                               }];
       // this error may be nil
       NSDictionary *error = [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)0 error:nil];
       NYPLAsyncDispatch(^{handler(nil, error);});
@@ -140,9 +141,12 @@ completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
     if(!feed) {
       NYPLLOG(@"Could not interpret XML as OPDS.");
       [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeOpdsFeedParseFail
-                                context:@"NYPLOPDSFeed"
-                                message:[NSString stringWithFormat:@"%@ - Response: %@", [request loggableString], response]
-                               metadata:nil];
+                                context:@"NYPLOPDSFeed: Failed to parse XML as OPDS"
+                                message:@"Error in NYPLOPDSFeed::withURL:"
+                               metadata:@{
+                                 @"request": request.loggableString,
+                                 @"response": response ?: @"N/A",
+                               }];
       NYPLAsyncDispatch(^{handler(nil, nil);});
       return;
     }

--- a/Simplified/Utilities/NYPLBook+Additions.swift
+++ b/Simplified/Utilities/NYPLBook+Additions.swift
@@ -25,7 +25,9 @@ extension NYPLBook {
       "bookTitle": title ?? "",
       "bookID": identifier ?? "",
       "bookDistributor": distributor ?? "",
-      "acquisitions": acquisitions
+      "acquisitions": acquisitions,
+      "alternateURL": alternateURL ?? "N/A",
+      "contentType": NYPLBookContentTypeConverter.stringValue(of: defaultBookContentType())
     ]
   }
 }


### PR DESCRIPTION
**What's this do?**
Expose a more detailed reason of error in the summary of the Crashlytics report (which coincides with the `NSError.domain`) and use `NSError.errorCode` as a way to group related errors together. 

E.g. all the business-logic-related book download errors now have the same error code, but the `context` aka NSError.domain will expose the distributor, the book medium  and reason of the error. This will create a larger number of non-fatal "issues" in Crashlytics but each one will contain less instances. This also addresses the fact that it's not possible to link to one event instance inside the same "issue"/group.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2975

**How should this be tested? / Do these changes have associated tests?**
For the most part this should be just logging additions. There's a minor refactor in the Adobe fulfillment code after book download, so smoke-testing that would be sufficient for this ticket. If you encounter any server error, please let me know the date, time, iOS version so I can take a look in Crashlytics to verify things are reported correctly there.

**Dependencies for merging? Releasing to production?**
none

**Has the application documentation been updated for these changes?**
Added comments in the code

**Did someone actually run this code to verify it works?**
@ettore 