### PR TITLE
SIMPLY-2992 Reorg error logger functions

### DIFF
--- a/Simplified/Account.swift
+++ b/Simplified/Account.swift
@@ -328,7 +328,7 @@ private let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
     guard let urlString = authenticationDocumentUrl, let url = URL(string: urlString) else {
       NYPLErrorLogger.logError(
         withCode: .noURL,
-        context: "Authentication Document Load Error",
+        summary: "Authentication Document Load Error",
         message: "Failed to load authentication document because its URL is invalid",
         metadata: ["self.uuid": uuid]
       )
@@ -347,7 +347,7 @@ private let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
           let responseBody = String(data: serverData, encoding: .utf8)
           NYPLErrorLogger.logError(
             withCode: .authDocParseFail,
-            context: "Authentication Document Load Error",
+            summary: "Authentication Document Load Error",
             message: "Failed to parse authentication document data obtained from \(url)",
             metadata: [
               "underlyingError": error,
@@ -359,7 +359,7 @@ private let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
       case .failure(let error):
         NYPLErrorLogger.logError(
           withCode: .authDocLoadFail,
-          context: "Authentication Document Load Error",
+          summary: "Authentication Document Load Error",
           message: "Request to load authentication document at \(url) failed.",
           metadata: ["underlyingError": error]
         )

--- a/Simplified/Account.swift
+++ b/Simplified/Account.swift
@@ -328,7 +328,7 @@ private let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
     guard let urlString = authenticationDocumentUrl, let url = URL(string: urlString) else {
       NYPLErrorLogger.logError(
         withCode: .noURL,
-        context: NYPLErrorLogger.Context.accountManagement.rawValue,
+        context: "Authentication Document Load Error",
         message: "Failed to load authentication document because its URL is invalid",
         metadata: ["self.uuid": uuid]
       )
@@ -347,7 +347,7 @@ private let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
           let responseBody = String(data: serverData, encoding: .utf8)
           NYPLErrorLogger.logError(
             withCode: .authDocParseFail,
-            context: NYPLErrorLogger.Context.accountManagement.rawValue,
+            context: "Authentication Document Load Error",
             message: "Failed to parse authentication document data obtained from \(url)",
             metadata: [
               "underlyingError": error,
@@ -359,7 +359,7 @@ private let accountSyncEnabledKey        = "NYPLAccountSyncEnabledKey"
       case .failure(let error):
         NYPLErrorLogger.logError(
           withCode: .authDocLoadFail,
-          context: NYPLErrorLogger.Context.accountManagement.rawValue,
+          context: "Authentication Document Load Error",
           message: "Request to load authentication document at \(url) failed.",
           metadata: ["underlyingError": error]
         )

--- a/Simplified/AccountsManager.swift
+++ b/Simplified/AccountsManager.swift
@@ -141,20 +141,6 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
       // changing the `accountsSets` dictionary will also change `currentAccount`
       if hadAccount != (self.currentAccount != nil) {
         self.currentAccount?.loadAuthenticationDocument { success in
-          if !success {
-            NYPLErrorLogger.logError(
-              withCode: .authDocLoadFail,
-              context: NYPLErrorLogger.Context.accountManagement.rawValue,
-              message: """
-              Failed to load authentication document for current library: \
-              \(self.currentAccount?.name ?? "N/A"). Will still attempt to \
-              load catalogURL \(self.currentAccount?.catalogUrl ?? "N/A").
-              """,
-              metadata: [
-                "currentLibrary": self.currentAccount?.debugDescription ?? "N/A"
-            ])
-          }
-
           DispatchQueue.main.async {
             var mainFeed = URL(string: self.currentAccount?.catalogUrl ?? "")
             let resolveFn = {
@@ -215,7 +201,7 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
       case .failure(let error):
         NYPLErrorLogger.logError(
           withCode: .libraryListLoadFail,
-          context: NYPLErrorLogger.Context.accountManagement.rawValue,
+          context: "Unable to load libraries list",
           message: "Libraries list failed to load from \(targetUrl)",
           metadata: [
             NSUnderlyingErrorKey: error,

--- a/Simplified/AccountsManager.swift
+++ b/Simplified/AccountsManager.swift
@@ -201,7 +201,7 @@ private let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSaf
       case .failure(let error):
         NYPLErrorLogger.logError(
           withCode: .libraryListLoadFail,
-          context: "Unable to load libraries list",
+          summary: "Unable to load libraries list",
           message: "Libraries list failed to load from \(targetUrl)",
           metadata: [
             NSUnderlyingErrorKey: error,

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -320,9 +320,10 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       {
         if (self.currentAccount.details.signUpUrl == nil) {
           // this situation should be impossible, but let's log it if it happens
-          [NYPLErrorLogger logSignUpError:nil
-                                     code:NYPLErrorCodeNilSignUpURL
-                                  message:@"signUpUrl from current account is nil"];
+          [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNilSignUpURL
+                                    context:@"SignUp Error in modal: nil signUp URL"
+                                    message:nil
+                                   metadata:nil];
           return;
         }
 
@@ -840,7 +841,7 @@ completionHandler:(void (^)(void))handler
          UserProfileDocument *pDoc = [UserProfileDocument fromData:data error:&pDocError];
          if (!pDoc) {
            [NYPLErrorLogger logUserProfileDocumentAuthError:pDocError
-                                                    context:@"SignIn-modal"
+                                                    context:@"SignIn-modal: unable to parse user profile doc"
                                                     barcode:barcode];
            [self authorizationAttemptDidFinish:NO error:[NSError errorWithDomain:@"NYPLAuth" code:20 userInfo:@{ NSLocalizedDescriptionKey: @"Error parsing user profile document." }]];
            return;
@@ -850,7 +851,7 @@ completionHandler:(void (^)(void))handler
            } else {
              NYPLLOG(@"Authorization ID (Barcode String) was nil.");
              [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoAuthorizationIdentifier
-                                       context:@"SignIn-modal"
+                                       context:@"SignIn-modal: no auth-id in user profile doc"
                                        message:@"The UserProfileDocument obtained from the server contained no authorization identifier."
                                       metadata:@{
                                         @"hashedBarcode": barcode.md5String
@@ -959,7 +960,7 @@ completionHandler:(void (^)(void))handler
                                   problemDocumentData:data
                                               barcode:barcode
                                                   url:request.URL
-                                              context:@"AccountSignInVC-validateCreds"
+                                              context:@"AccountSignInVC-validateCreds: Problem Doc parse error"
                                               message:@"Sign-in failed via SignIn-modal, problem doc parsing failed"];
       } else {
         [NYPLErrorLogger logLoginError:error

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -321,7 +321,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
         if (self.currentAccount.details.signUpUrl == nil) {
           // this situation should be impossible, but let's log it if it happens
           [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNilSignUpURL
-                                    context:@"SignUp Error in modal: nil signUp URL"
+                                    summary:@"SignUp Error in modal: nil signUp URL"
                                     message:nil
                                    metadata:nil];
           return;
@@ -841,7 +841,7 @@ completionHandler:(void (^)(void))handler
          UserProfileDocument *pDoc = [UserProfileDocument fromData:data error:&pDocError];
          if (!pDoc) {
            [NYPLErrorLogger logUserProfileDocumentAuthError:pDocError
-                                                    context:@"SignIn-modal: unable to parse user profile doc"
+                                                    summary:@"SignIn-modal: unable to parse user profile doc"
                                                     barcode:barcode];
            [self authorizationAttemptDidFinish:NO error:[NSError errorWithDomain:@"NYPLAuth" code:20 userInfo:@{ NSLocalizedDescriptionKey: @"Error parsing user profile document." }]];
            return;
@@ -851,7 +851,7 @@ completionHandler:(void (^)(void))handler
            } else {
              NYPLLOG(@"Authorization ID (Barcode String) was nil.");
              [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoAuthorizationIdentifier
-                                       context:@"SignIn-modal: no auth-id in user profile doc"
+                                       summary:@"SignIn-modal: no auth-id in user profile doc"
                                        message:@"The UserProfileDocument obtained from the server contained no authorization identifier."
                                       metadata:@{
                                         @"hashedBarcode": barcode.md5String
@@ -862,7 +862,7 @@ completionHandler:(void (^)(void))handler
            } else {
              NYPLLOG(@"Login Failed: No Licensor Token received or parsed from user profile document");
              [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoLicensorToken
-                                       context:@"SignIn-modal"
+                                       summary:@"SignIn-modal"
                                        message:@"The UserProfileDocument obtained from the server contained no licensor token."
                                       metadata:@{
                                         @"hashedBarcode": barcode.md5String
@@ -960,7 +960,7 @@ completionHandler:(void (^)(void))handler
                                   problemDocumentData:data
                                               barcode:barcode
                                                   url:request.URL
-                                              context:@"AccountSignInVC-validateCreds: Problem Doc parse error"
+                                              summary:@"AccountSignInVC-validateCreds: Problem Doc parse error"
                                               message:@"Sign-in failed via SignIn-modal, problem doc parsing failed"];
       } else {
         [NYPLErrorLogger logLoginError:error

--- a/Simplified/NYPLAlertUtils.swift
+++ b/Simplified/NYPLAlertUtils.swift
@@ -47,9 +47,15 @@ import UIKit
         message = errorDescription
       } else {
         message = "An error occurred. Please try again later or report an issue from the Settings tab."
+        var metadata = [String: Any]()
+        metadata["alertTitle"] = title ?? "N/A"
+        if let error = error {
+          metadata["error"] = error
+        }
         NYPLErrorLogger.logError(withCode: .genericErrorMsgDisplayed,
-                                 context: NYPLErrorLogger.Context.errorHandling.rawValue,
-                                 message: "Error \(error?.description ?? "") contained no usable error message for the user, so we defaulted to a generic one.")
+                                 context: "Displayed error alert with generic message",
+                                 message: "Error \(error?.description ?? "") contained no usable error message for the user, so we defaulted to a generic one.",
+                                 metadata: metadata)
       }
     }
 

--- a/Simplified/NYPLAlertUtils.swift
+++ b/Simplified/NYPLAlertUtils.swift
@@ -53,7 +53,7 @@ import UIKit
           metadata["error"] = error
         }
         NYPLErrorLogger.logError(withCode: .genericErrorMsgDisplayed,
-                                 context: "Displayed error alert with generic message",
+                                 summary: "Displayed error alert with generic message",
                                  message: "Error \(error?.description ?? "") contained no usable error message for the user, so we defaulted to a generic one.",
                                  metadata: metadata)
       }

--- a/Simplified/NYPLBookCellDelegate.m
+++ b/Simplified/NYPLBookCellDelegate.m
@@ -316,7 +316,7 @@
 
   NSString *logMsg = [NSString stringWithFormat:@"bookID: %@; fileURL: %@", book.identifier, url];
   [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeAudiobookCorrupted
-                            context:@"Audiobooks: corrupted audiobook"
+                            summary:@"Audiobooks: corrupted audiobook"
                             message:logMsg
                            metadata:nil];
 }

--- a/Simplified/NYPLBookCellDelegate.m
+++ b/Simplified/NYPLBookCellDelegate.m
@@ -316,7 +316,7 @@
 
   NSString *logMsg = [NSString stringWithFormat:@"bookID: %@; fileURL: %@", book.identifier, url];
   [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeAudiobookCorrupted
-                            context:@"audiobooks"
+                            context:@"Audiobooks: corrupted audiobook"
                             message:logMsg
                            metadata:nil];
 }

--- a/Simplified/NYPLBookCellDelegate.m
+++ b/Simplified/NYPLBookCellDelegate.m
@@ -255,7 +255,7 @@
                                  message:msg];
     } else {
       if (level > LogLevelDebug) {
-        NSError *error = [NSError errorWithDomain:@"org.nypl.labs.audiobookToolkit" code:0 userInfo:nil];
+        NSError *error = [NSError errorWithDomain:@"org.nypl.labs.audiobookToolkit" code:NYPLErrorCodeAudiobookExternalError userInfo:nil];
 
         NYPLSeverity severity = level == LogLevelInfo ? NYPLSeverityInfo : level == LogLevelWarn ? NYPLSeverityWarning : NYPLSeverityError;
         [NYPLErrorLogger logAudiobookIssue:error

--- a/Simplified/NYPLBookDetailViewController.m
+++ b/Simplified/NYPLBookDetailViewController.m
@@ -181,7 +181,7 @@
     NSString *msg = [NSString stringWithFormat:@"Lane %@ has no subsection URL to display more books",
                      lane.title];
     [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoURL
-                              context:NSStringFromClass([self class])
+                              summary:NSStringFromClass([self class])
                               message:msg
                              metadata:@{
                                @"methodName": @"didSelectMoreBooksForLane:"

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -693,6 +693,11 @@ genericBookmarks:(NSArray<NYPLBookLocation *> *)genericBookmarks
 
 - (void)setProcessing:(BOOL)processing forIdentifier:(NSString *)identifier
 {
+  // guard to avoid crash
+  if (identifier == nil) {
+    return;
+  }
+
   @synchronized(self) {
     if(processing) {
       [self.processingIdentifiers addObject:identifier];

--- a/Simplified/NYPLBookRegistryRecord.m
+++ b/Simplified/NYPLBookRegistryRecord.m
@@ -110,7 +110,7 @@ static NSString *const GenericBookmarksKey = @"genericBookmarks";
                      @"Received state: %@ during BookRecord init. Input dict=%@",
                      state, dictionary];
     [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeUnknownBookState
-                              context:@"NYPLBookRegistryRecord"
+                              summary:@"NYPLBookRegistryRecord"
                               message:msg
                              metadata:nil];
     @throw NSInvalidArgumentException;

--- a/Simplified/NYPLCatalogFeedViewController.m
+++ b/Simplified/NYPLCatalogFeedViewController.m
@@ -39,7 +39,8 @@
   if (![response.MIMEType isEqualToString:@"application/atom+xml"]) {
     NYPLLOG(@"Did not receive XML atom feed, cannot initialize");
     [NYPLErrorLogger
-     logCatalogInitErrorWithCode:NYPLErrorCodeInvalidResponseMimeType];
+     logCatalogInitErrorWithCode:NYPLErrorCodeInvalidResponseMimeType
+     response:response metadata:nil];
     return nil;
   }
 
@@ -47,7 +48,8 @@
   if(!XML) {
     NYPLLOG(@"Cannot initialize due to invalid XML.");
     [NYPLErrorLogger
-     logCatalogInitErrorWithCode:NYPLErrorCodeInvalidXML];
+     logCatalogInitErrorWithCode:NYPLErrorCodeInvalidXML
+     response:response metadata:nil];
     return nil;
   }
 
@@ -55,7 +57,8 @@
   if(!feed) {
     NYPLLOG(@"Cannot initialize due to XML not representing an OPDS feed.");
     [NYPLErrorLogger
-     logCatalogInitErrorWithCode:NYPLErrorCodeOpdsFeedParseFail];
+     logCatalogInitErrorWithCode:NYPLErrorCodeOpdsFeedParseFail
+     response:response metadata:nil];
     return nil;
   }
 
@@ -72,7 +75,10 @@
               remoteViewController:remoteVC];
     case NYPLOPDSFeedTypeInvalid:
       NYPLLOG(@"Cannot initialize due to invalid feed.");
-      [NYPLErrorLogger logCatalogInitErrorWithCode:NYPLErrorCodeInvalidFeedType];
+      [NYPLErrorLogger
+       logCatalogInitErrorWithCode:NYPLErrorCodeInvalidFeedType
+       response:response
+       metadata:@{ @"feedType": @(feed.type)}];
       return nil;
     case NYPLOPDSFeedTypeNavigation: {
       return [NYPLCatalogFeedViewController navigationFeedWithData:XML

--- a/Simplified/NYPLCatalogFeedViewController.m
+++ b/Simplified/NYPLCatalogFeedViewController.m
@@ -96,7 +96,7 @@
   if (!gatedXML) {
     NYPLLOG(@"Cannot initialize due to lack of support for navigation feeds.");
     [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoAgeGateElement
-                              context:NSStringFromClass([self class])
+                              summary:NSStringFromClass([self class])
                               message:@"Data received from Server lacks `gate` element for age-check."
                              metadata:nil];
     return nil;
@@ -114,7 +114,7 @@
         [remoteVC loadWithURL:url];
       } else {
         [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoURL
-                                  context:NSStringFromClass([self class])
+                                  summary:NSStringFromClass([self class])
                                   message:@"Server response for age verification lacks a URL to load."
                                  metadata:@{
                                    @"ageAboveLimit": @(ageAboveLimit),
@@ -168,7 +168,7 @@
         [[NYPLBookRegistry sharedRegistry] save];
       } else {
         [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeRegistrySyncFailure
-                                  context:@"NYPLCatalogFeedViewController"
+                                  summary:@"NYPLCatalogFeedViewController"
                                   message:@"Book registry sync failed"
                                  metadata:@{@"Catalog feed URL": wSelf.URL ?: @"N/A"}];
       }

--- a/Simplified/NYPLCatalogGroupedFeedViewController.m
+++ b/Simplified/NYPLCatalogGroupedFeedViewController.m
@@ -378,7 +378,7 @@ viewForHeaderInSection:(NSInteger const)section
     [self.remoteViewController loadWithURL:newURL];
   } else {
     [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoURL
-                              context:NSStringFromClass([self class])
+                              summary:NSStringFromClass([self class])
                               message:@"Catalog facet missing href URL"
                              metadata:nil];
     [self.remoteViewController showReloadViewWithMessage:NSLocalizedString(@"This URL cannot be found. Please close the app entirely and reload it. If the problem persists, please contact your library's Help Desk.", @"Generic error message indicating that the URL the user was trying to load is missing.")];
@@ -429,7 +429,7 @@ viewForHeaderInSection:(NSInteger const)section
     NSString *msg = [NSString stringWithFormat:@"Lane %@ has no subsection URL to display category",
                      lane.title];
     [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoURL
-                              context:NSStringFromClass([self class])
+                              summary:NSStringFromClass([self class])
                               message:msg
                              metadata:@{
                                @"methodName": @"didSelectCategory:"

--- a/Simplified/NYPLCatalogUngroupedFeedViewController.m
+++ b/Simplified/NYPLCatalogUngroupedFeedViewController.m
@@ -217,7 +217,7 @@ didSelectFacetAtIndexPath:(NSIndexPath *const)indexPath
   } else {
     NSString *msg = [NSString stringWithFormat:@"Facet %@ is missing the `href` URL to load", facet.title];
     [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoURL
-                              context:NSStringFromClass([self class])
+                              summary:NSStringFromClass([self class])
                               message:msg
                              metadata:@{@"methodName": @"facetView:didSelectFacetAtIndexPath:"}];
     [self.remoteViewController showReloadViewWithMessage:NSLocalizedString(@"This URL cannot be found. Please close the app entirely and reload it. If the problem persists, please contact your library's Help Desk.", @"Generic error message indicating that the URL the user was trying to load is missing.")];
@@ -235,7 +235,7 @@ didSelectFacetAtIndexPath:(NSIndexPath *const)indexPath
   } else {
     NSString *msg = [NSString stringWithFormat:@"Facet %@ is missing the `href` URL to load", entryPointFacet.title];
     [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoURL
-                              context:NSStringFromClass([self class])
+                              summary:NSStringFromClass([self class])
                               message:msg
                              metadata:@{@"methodName": @"entryPointViewDidSelectWithEntryPointFacet:"}];
     [self.remoteViewController showReloadViewWithMessage:NSLocalizedString(@"This URL cannot be found. Please close the app entirely and reload it. If the problem persists, please contact your library's Help Desk.", @"Generic error message indicating that the URL the user was trying to load is missing.")];

--- a/Simplified/NYPLDirectoryManager.swift
+++ b/Simplified/NYPLDirectoryManager.swift
@@ -16,7 +16,7 @@ import Foundation
     
     if paths.count < 1 {
       NYPLErrorLogger.logError(withCode: .missingSystemPaths,
-                               context: "DirectoryManager::directory",
+                               summary: "DirectoryManager::directory",
                                message: "No valid search paths in iOS's ApplicationSupport directory in the UserDomain",
                                metadata: ["account": account])
       return nil

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -117,26 +117,9 @@ fileprivate let nullString = "null"
     }
   }
 
-  /// Broad areas providing some kind of operating context for error reporting.
-  ///
-  /// - note: This is deprecated because it's of little use in Crashlytics.
-  /// Instead of context it's more useful to provide a string that identifies
-  /// and describes the error in a more developer-friendly way.
-  /// - todo: SIMPLY-2985 will address this deprecation.
-  enum Context: String {
-    case accountManagement
-    case audiobooks
-    case catalog
-    case infrastructure
-    case myBooks
-    case opds
-    case signIn
-    case signOut
-    case signUp
-    case errorHandling
-  }
-
   // MARK:- Private helpers
+
+  // TODO: SIMPLY-2992 move these private helpers to bottom of file
 
   /**
    Helper method for other logging functions that adds relevant library
@@ -268,7 +251,7 @@ fileprivate let nullString = "null"
     addAccountInfoToMetadata(&metadata)
 
     let userInfo = additionalInfo(severity: .error, metadata: metadata)
-    let err = NSError(domain: Context.signIn.rawValue,
+    let err = NSError(domain: "SignIn error: problem document available",
                       code: errorCode,
                       userInfo: userInfo)
 
@@ -299,7 +282,7 @@ fileprivate let nullString = "null"
       severity: .info,
       message: "Local Login Failed With Error",
       metadata: metadata)
-    let err = NSError(domain: Context.signIn.rawValue,
+    let err = NSError(domain: "SignIn error: Adobe activation",
                       code: NYPLErrorCode.adeptAuthFail.rawValue,
                       userInfo: userInfo)
 
@@ -320,7 +303,7 @@ fileprivate let nullString = "null"
       message: "No Valid Licensor available to deauthorize device. Signing out NYPLAccount credentials anyway with no message to the user.",
       context: "NYPLSettingsAccountDetailViewController",
       metadata: metadata)
-    let err = NSError(domain: Context.signOut.rawValue,
+    let err = NSError(domain: "SignOut deauthorization error: no licensor",
                       code: NYPLErrorCode.invalidLicensor.rawValue,
                       userInfo: userInfo)
 
@@ -360,7 +343,7 @@ fileprivate let nullString = "null"
     addAccountInfoToMetadata(&metadata)
     let userInfo = additionalInfo(severity: .info, metadata: metadata)
 
-    let err = NSError(domain: "\(Context.signIn.rawValue): BarcodeScanner",
+    let err = NSError(domain: "SignIn error: BarcodeScanner exception",
                       code: NYPLErrorCode.barcodeException.rawValue,
                       userInfo: userInfo)
 
@@ -429,6 +412,7 @@ fileprivate let nullString = "null"
   ///   in Crashlytics UI.
   ///   - barcode: The clear-text barcode used to authenticate. This will be
   ///   hashed.
+  /// TODO: SIMPLY-2992 move this together with sign-in functions
   class func logUserProfileDocumentAuthError(_ error: NSError?,
                                              context: String,
                                              barcode: String?) {
@@ -466,10 +450,8 @@ fileprivate let nullString = "null"
   }
 
   class func logAudiobookInfoEvent(message: String) {
-    let userInfo = additionalInfo(severity: .info,
-                                  message: message,
-                                  context: Context.audiobooks.rawValue)
-    let err = NSError(domain: Context.audiobooks.rawValue,
+    let userInfo = additionalInfo(severity: .info, message: message)
+    let err = NSError(domain: "Audiobooks",
                       code: NYPLErrorCode.audiobookUserEvent.rawValue,
                       userInfo: userInfo)
     Crashlytics.sharedInstance().recordError(err)
@@ -518,7 +500,7 @@ fileprivate let nullString = "null"
                                   message: message,
                                   metadata: metadata)
     let error = NSError(
-      domain: context ?? Context.infrastructure.rawValue,
+      domain: context ?? "Network error",
       code: (code != .ignore ? code : NYPLErrorCode.apiCall).rawValue,
       userInfo: userInfo)
 

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -21,8 +21,11 @@ fileprivate let nullString = "null"
   }
 }
 
-/// Detailed error codes that span across Contexts. E.g. you could have a
-/// `invalidURLSession` for any `Context` that's using URLSession.
+/// Detailed error codes that span across different error reports.
+/// E.g. you could have a `invalidURLSession` for a number of different api
+/// calls, happening in catalog loading, sign-in, etc. So the `summary` of
+/// the error will be different, but the code will be the same. Sometimes it
+/// is useful in fact to search all possible instances of a given code.
 @objc enum NYPLErrorCode: Int {
   case ignore = 0
 
@@ -140,20 +143,15 @@ fileprivate let nullString = "null"
   /// - Parameters:
   ///   - severity: How severe the event is.
   ///   - message: An optional message.
-  ///   - context: Page/VC name or anything that can help identify the in-code location where the error occurred.
   ///   - metadata: Any additional metadata.
   private class func additionalInfo(severity: NYPLSeverity,
                                     message: String? = nil,
-                                    context: String? = nil,
                                     metadata: [String: Any]? = nil) -> [String: Any] {
     var dict = metadata ?? [:]
 
     dict["severity"] = severity.stringValue()
     if let message = message {
       dict["message"] = message
-    }
-    if let context = context {
-      dict["context"] = context
     }
 
     return dict
@@ -164,18 +162,16 @@ fileprivate let nullString = "null"
   /// Reports an error.
   /// - Parameters:
   ///   - error: Any originating error that occurred.
-  ///   - context: Choose from `Context` enum or provide a string that can
-  ///   be used to group similar errors. This will be the top line (searchable)
-  ///   in Crashlytics UI.
+  ///   - summary: This will be the top line (searchable) in Crashlytics UI.
   ///   - message: A string for further context.
   ///   - metadata: Any additional metadata to be logged.
   class func logError(_ error: Error,
-                      context: String? = nil,
+                      summary: String? = nil,
                       message: String? = nil,
                       metadata: [String: Any]? = nil) {
     logError(error,
              code: .ignore,
-             context: context,
+             summary: summary,
              message: message,
              metadata: metadata)
   }
@@ -185,18 +181,16 @@ fileprivate let nullString = "null"
   /// - Parameters:
   ///   - code: A code identifying the error situation. Searchable in
   ///   Crashlytics UI.
-  ///   - context: Choose from `Context` enum or provide a string that can
-  ///   be used to group similar errors. This will be the top line (searchable)
-  ///   in Crashlytics UI.
+  ///   - summary: This will be the top line (searchable) in Crashlytics UI.
   ///   - message: A string for further context.
   ///   - metadata: Any additional metadata to be logged.
   class func logError(withCode code: NYPLErrorCode,
-                      context: String,
+                      summary: String,
                       message: String? = nil,
                       metadata: [String: Any]? = nil) {
     logError(nil,
              code: code,
-             context: context,
+             summary: summary,
              message: message,
              metadata: metadata)
   }
@@ -301,7 +295,6 @@ fileprivate let nullString = "null"
     let userInfo = additionalInfo(
       severity: .warning,
       message: "No Valid Licensor available to deauthorize device. Signing out NYPLAccount credentials anyway with no message to the user.",
-      context: "NYPLSettingsAccountDetailViewController",
       metadata: metadata)
     let err = NSError(domain: "SignOut deauthorization error: no licensor",
                       code: NYPLErrorCode.invalidLicensor.rawValue,
@@ -358,7 +351,7 @@ fileprivate let nullString = "null"
       metadata["response"] = response
     }
     logError(withCode: code,
-             context: "Catalog VC Initialization",
+             summary: "Catalog VC Initialization",
              metadata: metadata)
   }
 
@@ -367,7 +360,7 @@ fileprivate let nullString = "null"
    - parameter originalError: the parsing error.
    - parameter barcode: The clear-text user barcode. This will be hashed.
    - parameter url: the url the problem document is being fetched from.
-   - parameter context: client-provided operating context.
+   - parameter summary: client-provided operating context.
    - parameter message: A dev-friendly message to concisely explain what's
    happening.
    */
@@ -375,7 +368,7 @@ fileprivate let nullString = "null"
                                           problemDocumentData: Data?,
                                           barcode: String?,
                                           url: URL?,
-                                          context: String,
+                                          summary: String,
                                           message: String?) {
     var metadata = [String: Any]()
     addAccountInfoToMetadata(&metadata)
@@ -396,7 +389,7 @@ fileprivate let nullString = "null"
       message: message,
       metadata: metadata)
 
-    let err = NSError(domain: context,
+    let err = NSError(domain: summary,
                       code: NYPLErrorCode.parseProblemDocFail.rawValue,
                       userInfo: userInfo)
 
@@ -407,14 +400,12 @@ fileprivate let nullString = "null"
   /// from the server during sign in / up / out process.
   /// - Parameters:
   ///   - error: The parse error.
-  ///   - context: Choose from `Context` enum or provide a string that can
-  ///   be used to group similar errors. This will be the top line (searchable)
-  ///   in Crashlytics UI.
+  ///   - summary: This will be the top line (searchable) in Crashlytics UI.
   ///   - barcode: The clear-text barcode used to authenticate. This will be
   ///   hashed.
   /// TODO: SIMPLY-2992 move this together with sign-in functions
   class func logUserProfileDocumentAuthError(_ error: NSError?,
-                                             context: String,
+                                             summary: String,
                                              barcode: String?) {
     var userInfo = [String : Any]()
     addAccountInfoToMetadata(&userInfo)
@@ -426,7 +417,7 @@ fileprivate let nullString = "null"
       userInfo[NSUnderlyingErrorKey] = originalError
     }
 
-    let err = NSError(domain: context,
+    let err = NSError(domain: summary,
                       code: NYPLErrorCode.userProfileDocFail.rawValue,
                       userInfo: userInfo)
 
@@ -468,7 +459,7 @@ fileprivate let nullString = "null"
   ///   wrapped under `NSUnderlyingErrorKey` in Crashlytics.
   ///   - code: Client-provided code to identify errors more easily.
   ///   Searchable in Crashlytics.
-  ///   - context: Client-provided context to identify errors more easily.
+  ///   - summary: Client-provided context to identify errors more easily.
   ///   Searchable in Crashlytics.
   ///   - request: Only the output of `loggableString` will be attached to the
   ///   report, to ensure privacy.
@@ -478,7 +469,7 @@ fileprivate let nullString = "null"
   @discardableResult
   class func logNetworkError(_ originalError: Error? = nil,
                              code: NYPLErrorCode = .ignore,
-                             context: String? = nil,
+                             summary: String? = nil,
                              request: URLRequest?,
                              response: URLResponse? = nil,
                              message: String? = nil,
@@ -500,7 +491,7 @@ fileprivate let nullString = "null"
                                   message: message,
                                   metadata: metadata)
     let error = NSError(
-      domain: context ?? "Network error",
+      domain: summary ?? "Network error",
       code: (code != .ignore ? code : NYPLErrorCode.apiCall).rawValue,
       userInfo: userInfo)
 
@@ -521,12 +512,12 @@ fileprivate let nullString = "null"
   ///   - originalError: Any originating error that occurred, if available.
   ///   - code: A code identifying the error situation. This is ignored if
   ///   `error` is not nil.
-  ///   - context: Operating context to help identify where the error occurred.
+  ///   - summary: Operating context to help identify where the error occurred.
   ///   - message: A string for further context.
   ///   - metadata: Any additional metadata to be logged.
   private class func logError(_ originalError: Error?,
                               code: NYPLErrorCode = .ignore,
-                              context: String? = nil,
+                              summary: String? = nil,
                               message: String? = nil,
                               metadata: [String: Any]? = nil) {
     if let message = message {
@@ -554,7 +545,7 @@ fileprivate let nullString = "null"
       finalCode = NYPLErrorCode.ignore.rawValue
     }
 
-    let err = NSError(domain: context ?? NYPLSimplyEDomain,
+    let err = NSError(domain: summary ?? NYPLSimplyEDomain,
                       code: finalCode,
                       userInfo: userInfo)
 

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -531,9 +531,6 @@ didCompleteWithError:(NSError *)error
   NSString *bookTitle = book.title;
   NYPLBookState state = [[NYPLBookRegistry sharedRegistry] stateForIdentifier:identifier];
   BOOL downloaded = state == NYPLBookStateDownloadSuccessful || state == NYPLBookStateUsed;
-  if (!book.identifier) {
-    [NYPLErrorLogger logUnexpectedNilIdentifier:identifier book:book];
-  }
 
   // Process Adobe Return
 #if defined(FEATURE_DRM_CONNECTOR)

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -196,7 +196,7 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
        problemDocumentData:problemDocData
        barcode:NYPLUserAccount.sharedAccount.barcode
        url:tmpSavedFileURL
-       context:[NSString stringWithFormat:@"Error parsing problem doc downloading %@ book", book.distributor]
+       summary:[NSString stringWithFormat:@"Error parsing problem doc downloading %@ book", book.distributor]
        message:[book loggableShortString]];
     }
     [self logBookDownloadFailure:book
@@ -660,7 +660,7 @@ didCompleteWithError:(NSError *)error
   dict[@"response"] = downloadTask.response ?: @"N/A";
 
   [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeDownloadFail
-                            context:context
+                            summary:context
                             message:nil
                            metadata:dict];
 }
@@ -822,7 +822,7 @@ didCompleteWithError:(NSError *)error
                                                    completion:^(NSDictionary<NSString *,id> * _Nullable responseHeaders, NSError * _Nullable error) {
         if (error) {
           [NYPLErrorLogger logError:error
-                            context:@"Overdrive audiobook fulfillment error"
+                            summary:@"Overdrive audiobook fulfillment error"
                             message:nil
                            metadata:@{
                              @"responseHeaders": responseHeaders ?: @"N/A",
@@ -836,7 +836,7 @@ didCompleteWithError:(NSError *)error
 
         if (!responseHeaders[@"x-overdrive-scope"] || !responseHeaders[@"location"]) {
           [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeOverdriveFulfillResponseParseFail
-                                    context:@"Overdrive audiobook fulfillment: wrong headers"
+                                    summary:@"Overdrive audiobook fulfillment: wrong headers"
                                     message:@"Response does not contain the expected headers"
                                    metadata:@{
                                      @"responseHeaders": responseHeaders ?: @"N/A",
@@ -862,7 +862,7 @@ didCompleteWithError:(NSError *)error
            completion:^(NSError * _Nullable error) {
             if (error) {
               [NYPLErrorLogger logError:error
-                                context:@"Overdrive audiobook fulfillment: patron token error"
+                                summary:@"Overdrive audiobook fulfillment: patron token error"
                                 message:@"Error refreshing Overdrive patron token"
                                metadata:@{
                                  @"responseHeaders": responseHeaders ?: @"N/A",
@@ -891,7 +891,7 @@ didCompleteWithError:(NSError *)error
         // segmentation fault.
         NYPLLOG(@"Aborting request with invalid URL.");
         [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeDownloadFail
-                                  context:@"Book download failure: nil download URL"
+                                  summary:@"Book download failure: nil download URL"
                                   message:@"Unable to download book because the download URL is nil"
                                  metadata:@{
                                    @"acquisitionURL": URL ?: @"N/A",
@@ -1124,7 +1124,7 @@ didFinishDownload:(BOOL)didFinishDownload
 
     if (![self fileURLForBookIndentifier:book.identifier]) {
       [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeAdobeDRMFulfillmentFail
-                                context:@"Adobe DRM error: final file URL unavailable"
+                                summary:@"Adobe DRM error: final file URL unavailable"
                                 message:@"fileURLForBookIndentifier returned nil, so no destination to copy file to."
                                metadata:@{
                                  @"adeptError": adeptError ?: @"N/A",
@@ -1148,7 +1148,7 @@ didFinishDownload:(BOOL)didFinishDownload
                          error:&copyError];
     if(!didSucceedCopying) {
       [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeAdobeDRMFulfillmentFail
-                                context:@"Adobe DRM error: failure copying file"
+                                summary:@"Adobe DRM error: failure copying file"
                                 message:@"NSFileManager::copyItemAtURL:toURL:error: failed"
                                metadata:@{
                                  @"adeptError": adeptError ?: @"N/A",
@@ -1163,7 +1163,7 @@ didFinishDownload:(BOOL)didFinishDownload
     }
   } else {
     [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeAdobeDRMFulfillmentFail
-                              context:@"Adobe DRM error: did not finish download"
+                              summary:@"Adobe DRM error: did not finish download"
                               message:@"ADEPT callback was called with didFinishDownload == false"
                              metadata:@{
                                @"adeptError": adeptError ?: @"N/A",

--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -78,7 +78,7 @@ completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
 
     if (data == nil) {
       [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeOpdsFeedNoData
-                                context:@"NYPLOPDSFeed: no data from server"
+                                summary:@"NYPLOPDSFeed: no data from server"
                                 message:nil
                                metadata:@{
                                  @"Request": [request loggableString],
@@ -106,7 +106,7 @@ completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
 
         [NYPLErrorLogger logNetworkError:error
                                     code:NYPLErrorCodeApiCall
-                                 context:@"NYPLOPDSFeed: HTTP status error"
+                                 summary:@"NYPLOPDSFeed: HTTP status error"
                                  request:request
                                 response:response
                                  message:msg
@@ -125,7 +125,7 @@ completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
     if(!feedXML) {
       NYPLLOG(@"Failed to parse data as XML.");
       [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeFeedParseFail
-                                context:@"NYPLOPDSFeed: Failed to parse data as XML"
+                                summary:@"NYPLOPDSFeed: Failed to parse data as XML"
                                 message:@"Error in NYPLOPDSFeed::withURL:"
                                metadata:@{
                                  @"request": request.loggableString,
@@ -141,7 +141,7 @@ completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
     if(!feed) {
       NYPLLOG(@"Could not interpret XML as OPDS.");
       [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeOpdsFeedParseFail
-                                context:@"NYPLOPDSFeed: Failed to parse XML as OPDS"
+                                summary:@"NYPLOPDSFeed: Failed to parse XML as OPDS"
                                 message:@"Error in NYPLOPDSFeed::withURL:"
                                metadata:@{
                                  @"request": request.loggableString,

--- a/Simplified/NYPLReaderReadiumView.m
+++ b/Simplified/NYPLReaderReadiumView.m
@@ -563,7 +563,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
     if (!contentCFI) {
       contentCFI = @"";
       [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNilCFI
-                                context:@"R1 eReader warning: no CFI from NYPLLocation"
+                                summary:@"R1 eReader warning: no CFI from NYPLLocation"
                                 message:nil
                                metadata:@{
                                  @"Book": self.book.loggableDictionary ?: @"N/A",
@@ -774,7 +774,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
        if(!result || [result isKindOfClass:[NSNull class]]) {
          NYPLLOG(@"Readium failed to generate a CFI. This is a bug in Readium 1.");
          [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNilCFI
-                                   context:@"eReader bug: R1 failed to generate CFI"
+                                   summary:@"eReader bug: R1 failed to generate CFI"
                                    message:nil
                                   metadata:@{
                                     @"Book": self.book.loggableDictionary ?: @"N/A",

--- a/Simplified/NYPLReaderReadiumView.m
+++ b/Simplified/NYPLReaderReadiumView.m
@@ -562,11 +562,15 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
     NSString *contentCFI = locationDictionary[@"contentCFI"];
     if (!contentCFI) {
       contentCFI = @"";
-      [NYPLErrorLogger logNilContentCFIWithLocation:location
-                                 locationDictionary:locationDictionary
-                                             bookId:self.book.identifier
-                                              title:self.book.title
-                                            message:@"No CFI from NYPLLocation"];
+      [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNilCFI
+                                context:@"R1 eReader warning: no CFI from NYPLLocation"
+                                message:nil
+                               metadata:@{
+                                 @"Book": self.book.loggableDictionary ?: @"N/A",
+                                 @"Registry locationString": location.locationString ?: @"N/A",
+                                 @"renderer": location.renderer ?: @"N/A",
+                                 @"openPageRequest idref": locationDictionary[@"idref"] ?: @"N/A",
+                               }];
     }
     dictionary[@"openPageRequest"] = @{@"idref": locationDictionary[@"idref"], @"elementCfi": contentCFI};
     NYPLLOG_F(@"Readium Initialize: Open Page Req idref: %@ elementCfi: %@", locationDictionary[@"idref"], contentCFI);
@@ -768,12 +772,13 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
      withCompletionHandler:^(id  _Nullable result, __unused NSError *_Nullable error) {
 
        if(!result || [result isKindOfClass:[NSNull class]]) {
-         NYPLLOG(@"Readium failed to generate a CFI. This is a bug in Readium.");
-         [NYPLErrorLogger logNilContentCFIWithLocation:nil
-                                    locationDictionary:nil
-                                                bookId:nil
-                                                 title:nil
-                                               message:@"Readium failed to generate a CFI"];
+         NYPLLOG(@"Readium failed to generate a CFI. This is a bug in Readium 1.");
+         [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNilCFI
+                                   context:@"eReader bug: R1 failed to generate CFI"
+                                   message:nil
+                                  metadata:@{
+                                    @"Book": self.book.loggableDictionary ?: @"N/A",
+                                  }];
          return;
        }
        NSString *const locationJSON = result;

--- a/Simplified/NYPLReaderTOCViewController.m
+++ b/Simplified/NYPLReaderTOCViewController.m
@@ -279,14 +279,8 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       NYPLReadiumBookmark *bookmark = self.bookmarks[indexPath.row];
       [self.bookmarks removeObjectAtIndex:indexPath.row];
       [self.delegate TOCViewController:self didDeleteBookmark:bookmark];
-    } else { // This is to catch SIMPLY-740. Remove if we haven't seen such a problem.
-      NSMutableDictionary *metadataParams = [NSMutableDictionary dictionary];
-      [metadataParams setObject:[NSNumber numberWithLong:indexPath.row] forKey:@"rowIndex"];
-      [metadataParams setObject:[NSNumber numberWithLong:self.bookmarks.count] forKey:@"bookmarkCount"];
-      [NYPLErrorLogger logDeleteBookmarkErrorWithMessage:@"Attempting to delete bookmark out of bounds."
-                                                 context:@"NYPLReaderTOCViewController"
-                                                metadata:metadataParams];
     }
+    
     [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:(UITableViewRowAnimationFade)];
   }
 }

--- a/Simplified/NYPLRemoteViewController.m
+++ b/Simplified/NYPLRemoteViewController.m
@@ -138,7 +138,7 @@
         [self load];
       } else {
         [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoURL
-                                  context:@"RemoteViewController"
+                                  summary:@"RemoteViewController"
                                   message:@"Failed to reload accounts after having found nil URL"
                                  metadata:@{
                                    @"currentURL": self.URL ?: @"N/A",
@@ -255,7 +255,7 @@
     [vc didMoveToParentViewController:self];
   } else {
     [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeUnableToMakeVCAfterLoading
-                              context:@"RemoteViewController"
+                              summary:@"RemoteViewController"
                               message:@"Failed to create VC after loading from server"
                              metadata:@{
                                @"HTTPstatusCode": @(httpResponse.statusCode),
@@ -285,7 +285,7 @@
     @"connection.originalRequest": connection.originalRequest.loggableString ?: @"none",
   };
   [NYPLErrorLogger logError:error
-                    context:@"RemoteViewController"
+                    summary:@"RemoteViewController"
                     message:@"Server-side api call (likely related to Catalog loading) did fail with network error"
                    metadata:metadata];
 
@@ -313,7 +313,7 @@
                                 problemDocumentData:self.data
                                             barcode:nil
                                                 url:[self.response URL]
-                                            context:@"Catalog api fail: Problem Doc parse error"
+                                            summary:@"Catalog api fail: Problem Doc parse error"
                                             message:@"Server-side api call (likely related to Catalog loading) failed and couldn't parse the problem doc either"];
       alert = [NYPLAlertUtils
                alertWithTitle:NSLocalizedString(@"Error", @"Title for a generic error")
@@ -321,7 +321,7 @@
                                          @"Message for a problem document error")];
     } else {
       [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeProblemDocMessageDisplayed
-                                context:@"Catalog api fail: Problem Doc returned"
+                                summary:@"Catalog api fail: Problem Doc returned"
                                 message:@"Server-side api call (likely related to Catalog loading) failed"
                                metadata:pDoc.debugDictionary];
       alert = [NYPLAlertUtils alertWithTitle:pDoc.title message:pDoc.detail];
@@ -331,7 +331,7 @@
     // not a 200 but also no problem doc: this could be an error or not
     // depending on the mimeType and the data
     [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeUnexpectedHTTPCodeWarning
-                              context:@"Catalog api fail"
+                              summary:@"Catalog api fail"
                               message:@"Server-side api call (likely related to Catalog loading) returned a non-200 HTTP status"
                              metadata:@{
                                @"HTTPstatusCode": @(httpResponse.statusCode),

--- a/Simplified/NYPLRemoteViewController.m
+++ b/Simplified/NYPLRemoteViewController.m
@@ -313,7 +313,7 @@
                                 problemDocumentData:self.data
                                             barcode:nil
                                                 url:[self.response URL]
-                                            context:@"RemoteViewController"
+                                            context:@"Catalog api fail: Problem Doc parse error"
                                             message:@"Server-side api call (likely related to Catalog loading) failed and couldn't parse the problem doc either"];
       alert = [NYPLAlertUtils
                alertWithTitle:NSLocalizedString(@"Error", @"Title for a generic error")
@@ -321,7 +321,7 @@
                                          @"Message for a problem document error")];
     } else {
       [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeProblemDocMessageDisplayed
-                                context:@"RemoteViewController"
+                                context:@"Catalog api fail: Problem Doc returned"
                                 message:@"Server-side api call (likely related to Catalog loading) failed"
                                metadata:pDoc.debugDictionary];
       alert = [NYPLAlertUtils alertWithTitle:pDoc.title message:pDoc.detail];
@@ -331,7 +331,7 @@
     // not a 200 but also no problem doc: this could be an error or not
     // depending on the mimeType and the data
     [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeUnexpectedHTTPCodeWarning
-                              context:@"RemoteViewController"
+                              context:@"Catalog api fail"
                               message:@"Server-side api call (likely related to Catalog loading) returned a non-200 HTTP status"
                              metadata:@{
                                @"HTTPstatusCode": @(httpResponse.statusCode),

--- a/Simplified/NYPLSession.m
+++ b/Simplified/NYPLSession.m
@@ -120,7 +120,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *const)challenge
       }
       [NYPLErrorLogger logNetworkError:error
                                   code:NYPLErrorCodeApiCall
-                               context:NSStringFromClass([self class])
+                               summary:NSStringFromClass([self class])
                                request:req
                               response:response
                                message:@"NYPLSession error"

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -465,7 +465,7 @@ Authenticating with any of those barcodes should work.
        UserProfileDocument *pDoc = [UserProfileDocument fromData:data error:&pDocError];
        if (!pDoc) {
          [NYPLErrorLogger logUserProfileDocumentAuthError:pDocError
-                                                  context:@"signOut: unable to parse user profile doc"
+                                                  summary:@"signOut: unable to parse user profile doc"
                                                   barcode:currentBarcode];
          [self showLogoutAlertWithError:pDocError responseCode:statusCode];
          [self removeActivityTitle];
@@ -488,7 +488,7 @@ Authenticating with any of those barcodes should work.
                         currentBarcode.md5String];
        [NYPLErrorLogger logNetworkError:error
                                    code:NYPLErrorCodeApiCall
-                                context:@"signOut"
+                                summary:@"signOut"
                                 request:request
                                response:response
                                 message:msg
@@ -563,7 +563,7 @@ Authenticating with any of those barcodes should work.
        // Even though we failed, let the user continue to log out.
        // The most likely reason is a user changing their PIN.
        [NYPLErrorLogger logError:error
-                         context:@"User lost an activation on signout: ADEPT error"
+                         summary:@"User lost an activation on signout: ADEPT error"
                          message:nil
                         metadata:@{
                           @"DeviceID": deviceID ?: @"N/A",
@@ -632,7 +632,7 @@ Authenticating with any of those barcodes should work.
                                   error:nil
                            errorMessage:@"Error parsing user profile document"];
     [NYPLErrorLogger logUserProfileDocumentAuthError:pDocError
-                                             context:@"SignIn-settingsTab: unable to parse user profile doc"
+                                             summary:@"SignIn-settingsTab: unable to parse user profile doc"
                                              barcode:barcode];
     return;
   }
@@ -642,7 +642,7 @@ Authenticating with any of those barcodes should work.
   } else {
     NYPLLOG(@"Authorization ID (Barcode String) was nil.");
     [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoAuthorizationIdentifier
-                              context:@"SignIn-settingsTab"
+                              summary:@"SignIn-settingsTab"
                               message:@"The UserProfileDocument obtained from the server contained no authorization identifier."
                              metadata:@{
                                @"hashedBarcode": barcode.md5String
@@ -654,7 +654,7 @@ Authenticating with any of those barcodes should work.
   } else {
     NYPLLOG(@"Login Failed: No Licensor Token received or parsed from user profile document");
     [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoLicensorToken
-                              context:@"SignIn-settingsTab"
+                              summary:@"SignIn-settingsTab"
                               message:@"The UserProfileDocument obtained from the server contained no licensor token."
                              metadata:@{
                                @"hashedBarcode": barcode.md5String
@@ -749,7 +749,7 @@ Authenticating with any of those barcodes should work.
                               problemDocumentData:data
                                           barcode:barcode
                                               url:request.URL
-                                          context:@"SettingsAccountDetailVC-processCreds: Problem Doc parse error"
+                                          summary:@"SettingsAccountDetailVC-processCreds: Problem Doc parse error"
                                           message:@"Sign-in failed, got a corrupted problem doc"];
   } else if (problemDocument) {
     [NYPLErrorLogger logLoginError:error
@@ -952,7 +952,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
         if (self.selectedAccount.details.signUpUrl == nil) {
           // this situation should be impossible, but let's log it if it happens
           [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNilSignUpURL
-                                    context:@"SignUp Error in Settings: nil signUp URL"
+                                    summary:@"SignUp Error in Settings: nil signUp URL"
                                     message:nil
                                    metadata:@{
                                      @"selectedLibraryAccountUUID": self.selectedAccount.uuid,
@@ -1535,7 +1535,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
           }];
         } else {
           [NYPLErrorLogger logError:error
-                            context:@"Show/Hide PIN"
+                            summary:@"Show/Hide PIN"
                             message:@"Error while trying to show the PIN"
                            metadata:nil];
         }

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -465,7 +465,7 @@ Authenticating with any of those barcodes should work.
        UserProfileDocument *pDoc = [UserProfileDocument fromData:data error:&pDocError];
        if (!pDoc) {
          [NYPLErrorLogger logUserProfileDocumentAuthError:pDocError
-                                                  context:@"signOut"
+                                                  context:@"signOut: unable to parse user profile doc"
                                                   barcode:currentBarcode];
          [self showLogoutAlertWithError:pDocError responseCode:statusCode];
          [self removeActivityTitle];
@@ -543,25 +543,34 @@ Authenticating with any of those barcodes should work.
   NSString *tokenPassword = [licensorItems lastObject];
   [licensorItems removeLastObject];
   NSString *tokenUsername = [licensorItems componentsJoinedByString:@"|"];
+  NSString *deviceID = [self.selectedUserAccount deviceID];
   
   NYPLLOG(@"***DRM Deactivation Attempt***");
   NYPLLOG_F(@"\nLicensor: %@\n",licensor);
   NYPLLOG_F(@"Token Username: %@\n",tokenUsername);
   NYPLLOG_F(@"Token Password: %@\n",tokenPassword);
   NYPLLOG_F(@"UserID: %@\n",[self.selectedUserAccount userID]);
-  NYPLLOG_F(@"DeviceID: %@\n",[self.selectedUserAccount deviceID]);
+  NYPLLOG_F(@"DeviceID: %@\n",deviceID);
   
   [[NYPLADEPT sharedInstance]
    deauthorizeWithUsername:tokenUsername
    password:tokenPassword
    userID:[self.selectedUserAccount userID]
-   deviceID:[self.selectedUserAccount deviceID]
+   deviceID:deviceID
    completion:^(BOOL success, NSError *error) {
      
      if(!success) {
        // Even though we failed, let the user continue to log out.
        // The most likely reason is a user changing their PIN.
-       [NYPLErrorLogger logDeauthorizationError:error];
+       [NYPLErrorLogger logError:error
+                         context:@"User lost an activation on signout: ADEPT error"
+                         message:nil
+                        metadata:@{
+                          @"DeviceID": deviceID ?: @"N/A",
+                          @"Licensor": licensor ?: @"N/A",
+                          @"AdobeTokenUsername": tokenUsername,
+                          @"AdobeTokenPassword": tokenPassword,
+                        }];
      }
      else {
        NYPLLOG(@"***Successful DRM Deactivation***");
@@ -623,7 +632,7 @@ Authenticating with any of those barcodes should work.
                                   error:nil
                            errorMessage:@"Error parsing user profile document"];
     [NYPLErrorLogger logUserProfileDocumentAuthError:pDocError
-                                             context:@"SignIn-settingsTab"
+                                             context:@"SignIn-settingsTab: unable to parse user profile doc"
                                              barcode:barcode];
     return;
   }
@@ -740,7 +749,7 @@ Authenticating with any of those barcodes should work.
                               problemDocumentData:data
                                           barcode:barcode
                                               url:request.URL
-                                          context:@"SettingsAccountDetailVC-processCreds"
+                                          context:@"SettingsAccountDetailVC-processCreds: Problem Doc parse error"
                                           message:@"Sign-in failed, got a corrupted problem doc"];
   } else if (problemDocument) {
     [NYPLErrorLogger logLoginError:error
@@ -942,9 +951,13 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
       {
         if (self.selectedAccount.details.signUpUrl == nil) {
           // this situation should be impossible, but let's log it if it happens
-          [NYPLErrorLogger logSignUpError:nil
-                                     code:NYPLErrorCodeNilSignUpURL
-                                  message:@"signUpUrl from selected account is nil"];
+          [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNilSignUpURL
+                                    context:@"SignUp Error in Settings: nil signUp URL"
+                                    message:nil
+                                   metadata:@{
+                                     @"selectedLibraryAccountUUID": self.selectedAccount.uuid,
+                                     @"selectedLibraryAccountName": self.selectedAccount.name,
+                                   }];
           return;
         }
 

--- a/Simplified/NYPLSettingsAccountsList.swift
+++ b/Simplified/NYPLSettingsAccountsList.swift
@@ -137,7 +137,7 @@
         } else {
           self.showLoadingUI(loadState: .failure)
           NYPLErrorLogger.logError(withCode: .apiCall,
-                                   context: "NYPLSettingsAccountsList",
+                                   summary: "NYPLSettingsAccountsList",
                                    message: "Accounts list failed to load",
                                    metadata: [
                                     "currentLibrary": self.manager.currentAccount?.debugDescription ?? "N/A"])

--- a/Simplified/NYPLSignInBusinessLogic.swift
+++ b/Simplified/NYPLSignInBusinessLogic.swift
@@ -172,13 +172,11 @@ class NYPLSignInBusinessLogic: NSObject {
     // below) we'll run into an error soon after, at the 1st screen of the flow.
     if NYPLSecrets.cardCreatorUsername == nil {
       NYPLErrorLogger.logError(withCode: NYPLErrorCode.cardCreatorCredentialsDecodeFail,
-                               context: NYPLErrorLogger.Context.signUp.rawValue,
-                               message: "Unable to decode cardCreator username")
+                               context: "CardCreator username decode error from NYPLSecrets")
     }
     if NYPLSecrets.cardCreatorPassword == nil {
       NYPLErrorLogger.logError(withCode: NYPLErrorCode.cardCreatorCredentialsDecodeFail,
-                               context: NYPLErrorLogger.Context.signUp.rawValue,
-                               message: "Unable to decode cardCreator password")
+                               context:"CardCreator password decode error from NYPLSecrets")
     }
 
     return (username: NYPLSecrets.cardCreatorUsername ?? "",

--- a/Simplified/NYPLSignInBusinessLogic.swift
+++ b/Simplified/NYPLSignInBusinessLogic.swift
@@ -172,11 +172,11 @@ class NYPLSignInBusinessLogic: NSObject {
     // below) we'll run into an error soon after, at the 1st screen of the flow.
     if NYPLSecrets.cardCreatorUsername == nil {
       NYPLErrorLogger.logError(withCode: NYPLErrorCode.cardCreatorCredentialsDecodeFail,
-                               context: "CardCreator username decode error from NYPLSecrets")
+                               summary: "CardCreator username decode error from NYPLSecrets")
     }
     if NYPLSecrets.cardCreatorPassword == nil {
       NYPLErrorLogger.logError(withCode: NYPLErrorCode.cardCreatorCredentialsDecodeFail,
-                               context:"CardCreator password decode error from NYPLSecrets")
+                               summary:"CardCreator password decode error from NYPLSecrets")
     }
 
     return (username: NYPLSecrets.cardCreatorUsername ?? "",

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -60,8 +60,7 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
       NYPLErrorLogger.logError(err, message: "URLSession became invalid")
     } else {
       NYPLErrorLogger.logError(withCode: .invalidURLSession,
-                               context: NYPLErrorLogger.Context.infrastructure.rawValue,
-                               message: "URLSession became invalid")
+                               context: "URLSessionDelegate: session became invalid")
     }
 
     taskInfoLock.lock()
@@ -182,7 +181,7 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
       guard !httpResponse.isFailure() else {
         logMetadata["response"] = httpResponse
         logMetadata[NSLocalizedDescriptionKey] = NSLocalizedString("UnknownRequestError", comment: "A generic error message for when a network request fails")
-        let err = NSError(domain: NYPLErrorLogger.Context.infrastructure.rawValue,
+        let err = NSError(domain: "Api call with failure HTTP status",
                           code: NYPLErrorCode.responseFail.rawValue,
                           userInfo: logMetadata)
         currentTaskInfo.completion(.failure(err))
@@ -214,7 +213,7 @@ extension URLSessionTask {
 
     let err = NSError.makeFromProblemDocument(
       problemDoc,
-      domain: NYPLErrorLogger.Context.infrastructure.rawValue,
+      domain: "Api call failure: problem document available",
       code: NYPLErrorCode.apiCall.rawValue,
       userInfo: userInfo)
 

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -60,7 +60,7 @@ class NYPLNetworkResponder: NSObject, URLSessionDelegate, URLSessionDataDelegate
       NYPLErrorLogger.logError(err, message: "URLSession became invalid")
     } else {
       NYPLErrorLogger.logError(withCode: .invalidURLSession,
-                               context: "URLSessionDelegate: session became invalid")
+                               summary: "URLSessionDelegate: session became invalid")
     }
 
     taskInfoLock.lock()


### PR DESCRIPTION
**What's this do?**
- replaces some error logging methods with more generic ones that allow more details available at the call site to be logged.
- Updates the terminology to use "Summary" instead of "Context" because this matches better what's seen on Crashlytics.  After using Crashlytics for a while we've seen that grouping too many error instances (with different error reasons) under the same "context" makes it very hard to find a specific error reason. The word Summary in the log method signatures encourages more clearly to provide a more focused title to the error report.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2992

**How should this be tested? / Do these changes have associated tests?**
This shouldn't need any more QA than what's already covered in the regression we'll do for the next release. There's no functional changes here.

**Dependencies for merging? Releasing to production?**
none

**Has the application documentation been updated for these changes?**
y

**Did someone actually run this code to verify it works?**
@ettore 