### PR TITLE
SIMPLY-3017 Add nil check before accessing cache

### DIFF
--- a/Simplified/NYPLBookCoverRegistry.m
+++ b/Simplified/NYPLBookCoverRegistry.m
@@ -252,7 +252,7 @@ static NSUInteger const memoryCacheInMegabytes = 2;
 
 - (UIImage *)cachedThumbnailImageForBook:(NYPLBook *const)book
 {
-  if(!book.imageThumbnailURL) {
+  if(!book.imageThumbnailURL || !self.session.configuration.URLCache) {
     return nil;
   }
   


### PR DESCRIPTION
**What's this do?**
Do a nil check before accessing cache to avoid crash

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-3017](https://jira.nypl.org/browse/SIMPLY-3017?filter=-1)

**How should this be tested? / Do these changes have associated tests?**
Unable to reproduce crash

**Dependencies for merging? Releasing to production?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 
