### PR TITLE
SIMPLY-3059 Fix OE sign-in panel

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -581,7 +581,6 @@
 		73FCA32025005BA4001B0C5D /* NYPLProblemReportViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 085D31D61BE29E38007F7672 /* NYPLProblemReportViewController.m */; };
 		73FCA32125005BA4001B0C5D /* NYPLHoldsNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 11C5DCF11976D1E0005A9945 /* NYPLHoldsNavigationController.m */; };
 		73FCA32225005BA4001B0C5D /* NYPLRemoteViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A42E0DF01B3F5A490095EBAE /* NYPLRemoteViewController.m */; };
-		73FCA32325005BA4001B0C5D /* NYPLWelcomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6202A031DD52B8600C99553 /* NYPLWelcomeScreen.swift */; };
 		73FCA32425005BA4001B0C5D /* NYPLSettingsAccountURLSessionChallengeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 73A3EAEC2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m */; };
 		73FCA32525005BA4001B0C5D /* NYPLOPDSAttribute.m in Sources */ = {isa = PBXBuildFile; fileRef = 110AD83B19E497D6005724C3 /* NYPLOPDSAttribute.m */; };
 		73FCA32625005BA4001B0C5D /* NYPLCatalogUngroupedFeed.m in Sources */ = {isa = PBXBuildFile; fileRef = 1114A6A0195884CB007507A2 /* NYPLCatalogUngroupedFeed.m */; };
@@ -2943,7 +2942,6 @@
 				73FCA32025005BA4001B0C5D /* NYPLProblemReportViewController.m in Sources */,
 				73FCA32125005BA4001B0C5D /* NYPLHoldsNavigationController.m in Sources */,
 				73FCA32225005BA4001B0C5D /* NYPLRemoteViewController.m in Sources */,
-				73FCA32325005BA4001B0C5D /* NYPLWelcomeScreen.swift in Sources */,
 				73FCA32425005BA4001B0C5D /* NYPLSettingsAccountURLSessionChallengeHandler.m in Sources */,
 				73FCA32525005BA4001B0C5D /* NYPLOPDSAttribute.m in Sources */,
 				73FCA32625005BA4001B0C5D /* NYPLCatalogUngroupedFeed.m in Sources */,

--- a/Simplified/NYPLCatalogNavigationController.m
+++ b/Simplified/NYPLCatalogNavigationController.m
@@ -276,7 +276,9 @@
   if (UIAccessibilityIsVoiceOverRunning()) {
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
   }
-  
+
+  // TODO: SIMPLY-3048 refactor better in a extension
+#ifdef SIMPLYE
   NYPLSettings *settings = [NYPLSettings sharedSettings];
   
   if (settings.userHasSeenWelcomeScreen == NO) {
@@ -318,6 +320,7 @@
       completion();
     }
   }
+#endif
 }
 
 -(void) welcomeScreenCompletionHandlerForAccount:(Account *const)account

--- a/Simplified/NYPLConfiguration.h
+++ b/Simplified/NYPLConfiguration.h
@@ -24,10 +24,6 @@
 
 + (UIColor *)readerBackgroundSepiaColor;
 
-+ (UIColor *)iconLogoBlueColor;
-
-+ (UIColor *)iconLogoGreenColor;
-
 + (NSString *)systemFontName;
 
 + (NSString *)systemFontFamilyName;

--- a/Simplified/NYPLConfiguration.m
+++ b/Simplified/NYPLConfiguration.m
@@ -79,17 +79,6 @@
   return [UIColor yellowColor];
 }
 
-+(UIColor *)iconLogoBlueColor {
-  if (@available(iOS 13, *)) {
-    return [UIColor colorNamed: @"ColorIconLogoBlue"];
-  }
-  return [UIColor colorWithRed:17.0/255.0 green:50.0/255.0 blue:84.0/255.0 alpha:1.0];
-}
-
-+(UIColor *)iconLogoGreenColor {
-  return [UIColor colorWithRed:141.0/255.0 green:199.0/255.0 blue:64.0/255.0 alpha:1.0];
-}
-
 // Set for the whole app via UIView+NYPLFontAdditions.
 + (NSString *)systemFontName
 {

--- a/Simplified/NYPLKeychain.m
+++ b/Simplified/NYPLKeychain.m
@@ -107,7 +107,7 @@
   }
   
   OSStatus status = SecItemDelete((__bridge CFDictionaryRef) dictionary);
-  if (status != noErr) {
+  if (status != noErr && status != errSecItemNotFound) {
     NYPLLOG_F(@"Failed to REMOVE object from keychain group: %@. error: %d", groupID, (int)status);
   }
 }

--- a/Simplified/OpenEbooks/Resources/OEImages.xcassets/ColorBackground.colorset/Contents.json
+++ b/Simplified/OpenEbooks/Resources/OEImages.xcassets/ColorBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "250",
+          "green" : "250",
+          "red" : "250"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "5",
+          "green" : "5",
+          "red" : "5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Simplified/Settings/NYPLConfiguration+SimplyE.swift
+++ b/Simplified/Settings/NYPLConfiguration+SimplyE.swift
@@ -24,4 +24,18 @@ extension NYPLConfiguration {
       return UIColor.defaultLabelColor()
     }
   }
+
+  @objc static func iconLogoBlueColor() -> UIColor {
+    if #available(iOS 13, *) {
+      if let color = UIColor(named: "ColorIconLogoBlue") {
+        return color
+      }
+    }
+
+    return UIColor(red: 17.0/255.0, green: 50.0/255.0, blue: 84.0/255.0, alpha: 1.0)
+  }
+
+  @objc static func iconLogoGreenColor() -> UIColor {
+    return UIColor(red: 141.0/255.0, green: 199.0/255.0, blue: 64.0/255.0, alpha: 1.0)
+  }
 }

--- a/Simplified/Tutorial/OETutorialChoiceViewController.swift
+++ b/Simplified/Tutorial/OETutorialChoiceViewController.swift
@@ -48,7 +48,7 @@ class OETutorialChoiceViewController : UIViewController {
     descriptionLabel.sizeToFit()
     
     firstBookLoginButton.setImage(UIImage(named: "FirstbookLoginButton"), for: .normal)
-    firstBookLoginButton.addTarget(self, action: #selector(didSelectEnterCodes), for: .touchUpInside)
+    firstBookLoginButton.addTarget(self, action: #selector(didSelectFirstBook), for: .touchUpInside)
     firstBookLoginButton.sizeToFit()
     
     loginWithCleverButton.setImage(UIImage(named: "CleverLoginButton"), for: .normal)
@@ -100,7 +100,7 @@ class OETutorialChoiceViewController : UIViewController {
     oldCompletionHandler?.self()
   }
   
-  @objc func didSelectEnterCodes() {
+  @objc func didSelectFirstBook() {
     let libAccount = AccountsManager.shared.currentAccount
     let userAccount = NYPLUserAccount.sharedAccount()
     userAccount.removeBarcodeAndPIN()

--- a/Simplified/Utilities/NYPLPresentationUtils.swift
+++ b/Simplified/Utilities/NYPLPresentationUtils.swift
@@ -6,6 +6,17 @@
 //
 
 class NYPLPresentationUtils {
+  /// Presents the given view controller on top of the topmost currently
+  /// displayed view controller.
+  ///
+  /// If the input and topmost view controllers are both
+  /// UINavigationControllers, this method bails presentation if they
+  /// both contain a first view controller of the same type.
+  ///
+  /// - Parameters:
+  ///   - vc: The view controller to be presented.
+  ///   - animated: Whether to animate the presentation of not.
+  ///   - completion: Completion handler to be called when the presentation ends.
   class func safelyPresent(_ vc: UIViewController,
                            animated: Bool = true,
                            completion: (()->Void)? = nil) {
@@ -26,6 +37,18 @@ class NYPLPresentationUtils {
       }
       base = topBase
     }
+
+    if let baseNavController = base as? UINavigationController,
+      let inputNavController = vc as? UINavigationController,
+      baseNavController.viewControllers.count == inputNavController.viewControllers.count,
+      let baseVC = baseNavController.viewControllers.first,
+      let inputVC = inputNavController.viewControllers.first {
+
+      if type(of: baseVC) == type(of: inputVC) {
+        return
+      }
+    }
+
     base.present(vc, animated:animated, completion:completion)
   }
 }


### PR DESCRIPTION
**What's this do?**
Fixes the look and feel of the sign in panel for Open eBooks, using color settings in the xcassets and moving out some configuration related to only SimplyE. It also addresses some keychain warnings observed during launch of OE.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3059

**How should this be tested? / Do these changes have associated tests?**
This is just a subtask, no need to test at this point.

**Dependencies for merging? Releasing to production?**
Not a breaking change for SimplyE.

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 