### PR TITLE
SIMPLY-3091: refactor AppDelegate and NYPLSettings

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1788,6 +1788,8 @@
 			isa = PBXGroup;
 			children = (
 				739ECB2325101CCE00691A70 /* NSNotification+NYPL.swift */,
+				A823D81F192BABA400B55DE2 /* NYPLAppDelegate.h */,
+				A823D820192BABA400B55DE2 /* NYPLAppDelegate.m */,
 				738CB1FF2509A61E00891F31 /* NYPLConfiguration+OE.swift */,
 				738CB2052509A87700891F31 /* NYPLConfiguration+SE.swift */,
 				739ECB2D25108EE800691A70 /* NYPLRootTabBarController+SE.swift */,
@@ -2043,8 +2045,6 @@
 				2DF321821DC3B83500E1858F /* NYPLAnnotations.swift */,
 				175E480724EF36520066A6CF /* NYPLAnnouncementBusinessLogic.swift */,
 				175E480D24EF46EA0066A6CF /* NYPLAnnouncementViewController.swift */,
-				A823D81F192BABA400B55DE2 /* NYPLAppDelegate.h */,
-				A823D820192BABA400B55DE2 /* NYPLAppDelegate.m */,
 				A93F9F9621CDACF700BD3B0C /* NYPLAppReviewPrompt.swift */,
 				E66AE32F1DC0FCFC00124AE2 /* NYPLCirculationAnalytics.swift */,
 				116A5EB71947B57500491A21 /* NYPLConfiguration.h */,

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -206,7 +206,7 @@
 		73085E3525030D27008F6244 /* SEMigrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E3425030D27008F6244 /* SEMigrations.swift */; };
 		73085E3625030D27008F6244 /* SEMigrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E3425030D27008F6244 /* SEMigrations.swift */; };
 		73085E3A25030D80008F6244 /* OEMigrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E3725030D66008F6244 /* OEMigrations.swift */; };
-		730FC05025127FA2004D7C2D /* OESettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730FC04F25127FA2004D7C2D /* OESettings.swift */; };
+		730FC05025127FA2004D7C2D /* NYPLSettings+OE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730FC04F25127FA2004D7C2D /* NYPLSettings+OE.swift */; };
 		730FC05125128224004D7C2D /* NYPLSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */; };
 		730FC05225128225004D7C2D /* NYPLSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */; };
 		730FC05725128D64004D7C2D /* OETutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730FC05425128D63004D7C2D /* OETutorialViewController.swift */; };
@@ -227,6 +227,12 @@
 		733875672423E540000FEB67 /* NYPLCaching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733875662423E540000FEB67 /* NYPLCaching.swift */; };
 		7340DA6224B7E45C00361387 /* URLResponse+NYPL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */; };
 		7340DA6824B7F27900361387 /* NYPLBook+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340DA6724B7F27900361387 /* NYPLBook+Additions.swift */; };
+		734731232514235900BE3D2C /* NYPLAppDelegate+SE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734731222514235900BE3D2C /* NYPLAppDelegate+SE.swift */; };
+		734731242514235900BE3D2C /* NYPLAppDelegate+SE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734731222514235900BE3D2C /* NYPLAppDelegate+SE.swift */; };
+		734731262514236A00BE3D2C /* NYPLAppDelegate+OE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734731252514236A00BE3D2C /* NYPLAppDelegate+OE.swift */; };
+		7347312725142D2D00BE3D2C /* NYPLCookiesWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089E42C5249A823800310360 /* NYPLCookiesWebViewController.swift */; };
+		7347312925142FE200BE3D2C /* NYPLSettings+SE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7347312825142FE200BE3D2C /* NYPLSettings+SE.swift */; };
+		7347312A25142FE200BE3D2C /* NYPLSettings+SE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7347312825142FE200BE3D2C /* NYPLSettings+SE.swift */; };
 		7347F038245A4DE200558D7F /* NYPLCirculationAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66AE32F1DC0FCFC00124AE2 /* NYPLCirculationAnalytics.swift */; };
 		7347F039245A4DE200558D7F /* NYPLBookState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171966A824170819007BB87E /* NYPLBookState.swift */; };
 		7347F03A245A4DE200558D7F /* UpdateCheckShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC8D9DD1D09F9B4007DD125 /* UpdateCheckShim.swift */; };
@@ -452,7 +458,7 @@
 		7347F133245A508400558D7F /* NYPLCardCreator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7347F132245A508400558D7F /* NYPLCardCreator.framework */; };
 		7347F135245A50CA00558D7F /* NYPLCardCreator.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7347F132245A508400558D7F /* NYPLCardCreator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		735350B724918432006021BD /* URLRequest+NYPLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735350B624918432006021BD /* URLRequest+NYPLTests.swift */; };
-		7353940C250854A90043C800 /* OESettingsSetUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7353940B250854A90043C800 /* OESettingsSetUp.swift */; };
+		7353940C250854A90043C800 /* NYPLSettingsSplitViewController+OE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7353940B250854A90043C800 /* NYPLSettingsSplitViewController+OE.swift */; };
 		7353940D25085DBB0043C800 /* NYPLPresentationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E192502DE88008F6244 /* NYPLPresentationUtils.swift */; };
 		7353940E25085DBC0043C800 /* NYPLPresentationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E192502DE88008F6244 /* NYPLPresentationUtils.swift */; };
 		7358EE7C250062BD00DDA0CC /* OEImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7358EE7B250062BD00DDA0CC /* OEImages.xcassets */; };
@@ -1144,7 +1150,7 @@
 		73085E252502EDF0008F6244 /* NYPLSettingsSplitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLSettingsSplitViewController.swift; sourceTree = "<group>"; };
 		73085E3425030D27008F6244 /* SEMigrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEMigrations.swift; sourceTree = "<group>"; };
 		73085E3725030D66008F6244 /* OEMigrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OEMigrations.swift; sourceTree = "<group>"; };
-		730FC04F25127FA2004D7C2D /* OESettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OESettings.swift; sourceTree = "<group>"; };
+		730FC04F25127FA2004D7C2D /* NYPLSettings+OE.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NYPLSettings+OE.swift"; sourceTree = "<group>"; };
 		730FC05425128D63004D7C2D /* OETutorialViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OETutorialViewController.swift; sourceTree = "<group>"; };
 		730FC05525128D64004D7C2D /* OETutorialEligibilityViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OETutorialEligibilityViewController.swift; sourceTree = "<group>"; };
 		730FC05625128D64004D7C2D /* OETutorialWelcomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OETutorialWelcomeViewController.swift; sourceTree = "<group>"; };
@@ -1159,11 +1165,14 @@
 		733875662423E540000FEB67 /* NYPLCaching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLCaching.swift; sourceTree = "<group>"; };
 		7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLResponse+NYPL.swift"; sourceTree = "<group>"; };
 		7340DA6724B7F27900361387 /* NYPLBook+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLBook+Additions.swift"; sourceTree = "<group>"; };
+		734731222514235900BE3D2C /* NYPLAppDelegate+SE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLAppDelegate+SE.swift"; sourceTree = "<group>"; };
+		734731252514236A00BE3D2C /* NYPLAppDelegate+OE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLAppDelegate+OE.swift"; sourceTree = "<group>"; };
+		7347312825142FE200BE3D2C /* NYPLSettings+SE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSettings+SE.swift"; sourceTree = "<group>"; };
 		7347F123245A4DE200558D7F /* SimplyE.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SimplyE.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7347F132245A508400558D7F /* NYPLCardCreator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = NYPLCardCreator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		735350B624918432006021BD /* URLRequest+NYPLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+NYPLTests.swift"; sourceTree = "<group>"; };
 		735394012508161A0043C800 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
-		7353940B250854A90043C800 /* OESettingsSetUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OESettingsSetUp.swift; sourceTree = "<group>"; };
+		7353940B250854A90043C800 /* NYPLSettingsSplitViewController+OE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSettingsSplitViewController+OE.swift"; sourceTree = "<group>"; };
 		7358EE7B250062BD00DDA0CC /* OEImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = OEImages.xcassets; path = OpenEbooks/Resources/OEImages.xcassets; sourceTree = "<group>"; };
 		7358EE902500642900DDA0CC /* OELaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = OELaunchScreen.xib; path = OpenEbooks/Resources/OELaunchScreen.xib; sourceTree = "<group>"; };
 		7358EE922500675700DDA0CC /* Open-eBooks-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Open-eBooks-Info.plist"; path = "OpenEbooks/Open-eBooks-Info.plist"; sourceTree = "<group>"; };
@@ -1764,12 +1773,13 @@
 		73085E222502EDC6008F6244 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */,
+				730FC04F25127FA2004D7C2D /* NYPLSettings+OE.swift */,
+				7347312825142FE200BE3D2C /* NYPLSettings+SE.swift */,
 				73085E242502EDEF008F6244 /* NYPLSettingsPrimaryTableItem.swift */,
 				73085E232502EDEE008F6244 /* NYPLSettingsPrimaryTableViewController.swift */,
 				73085E252502EDF0008F6244 /* NYPLSettingsSplitViewController.swift */,
-				5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */,
-				730FC04F25127FA2004D7C2D /* OESettings.swift */,
-				7353940B250854A90043C800 /* OESettingsSetUp.swift */,
+				7353940B250854A90043C800 /* NYPLSettingsSplitViewController+OE.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -1790,10 +1800,12 @@
 				739ECB2325101CCE00691A70 /* NSNotification+NYPL.swift */,
 				A823D81F192BABA400B55DE2 /* NYPLAppDelegate.h */,
 				A823D820192BABA400B55DE2 /* NYPLAppDelegate.m */,
+				734731252514236A00BE3D2C /* NYPLAppDelegate+OE.swift */,
+				734731222514235900BE3D2C /* NYPLAppDelegate+SE.swift */,
 				738CB1FF2509A61E00891F31 /* NYPLConfiguration+OE.swift */,
 				738CB2052509A87700891F31 /* NYPLConfiguration+SE.swift */,
-				739ECB2D25108EE800691A70 /* NYPLRootTabBarController+SE.swift */,
 				73225DEA250B471400EF1877 /* NYPLRootTabBarController+OE.swift */,
+				739ECB2D25108EE800691A70 /* NYPLRootTabBarController+SE.swift */,
 			);
 			path = AppInfrastructure;
 			sourceTree = "<group>";
@@ -2730,6 +2742,7 @@
 				7347F03A245A4DE200558D7F /* UpdateCheckShim.swift in Sources */,
 				7347F03B245A4DE200558D7F /* APIKeys.swift in Sources */,
 				7347F03C245A4DE200558D7F /* NYPLAttributedString.m in Sources */,
+				734731242514235900BE3D2C /* NYPLAppDelegate+SE.swift in Sources */,
 				7347F03D245A4DE200558D7F /* NYPLUserAccount.swift in Sources */,
 				7347F03F245A4DE200558D7F /* NYPLAgeCheck.swift in Sources */,
 				7347F040245A4DE200558D7F /* Log.swift in Sources */,
@@ -2840,6 +2853,7 @@
 				7347F09A245A4DE200558D7F /* NYPLOPDSIndirectAcquisition.m in Sources */,
 				7347F09B245A4DE200558D7F /* NYPLMyBooksViewController.m in Sources */,
 				7347F09C245A4DE200558D7F /* NYPLBookDetailTableView.swift in Sources */,
+				7347312A25142FE200BE3D2C /* NYPLSettings+SE.swift in Sources */,
 				7347F09D245A4DE200558D7F /* Account.swift in Sources */,
 				7347F09E245A4DE200558D7F /* NYPLBookDownloadFailedCell.m in Sources */,
 				7347F09F245A4DE200558D7F /* NYPLBookDetailViewController.m in Sources */,
@@ -2877,6 +2891,7 @@
 				7347F0C0245A4DE200558D7F /* NYPLIndeterminateProgressView.m in Sources */,
 				7347F0C1245A4DE200558D7F /* NSString+NYPLStringAdditions.m in Sources */,
 				7347F0C2245A4DE200558D7F /* NYPLKeychainManager.swift in Sources */,
+				7347312725142D2D00BE3D2C /* NYPLCookiesWebViewController.swift in Sources */,
 				7347F0C3245A4DE200558D7F /* NYPLErrorLogger.swift in Sources */,
 				7360D0D624BFCB9700C8AD16 /* NYPLUserFriendlyError.swift in Sources */,
 				7347F0C4245A4DE200558D7F /* NYPLOPDSEntryGroupAttributes.m in Sources */,
@@ -2922,7 +2937,7 @@
 				73FCA2B025005BA4001B0C5D /* NYPLAnnouncementViewController.swift in Sources */,
 				73FCA2B125005BA4001B0C5D /* NYPLSettings.swift in Sources */,
 				73085E2F250308A3008F6244 /* NYPLSettingsPrimaryTableViewController.swift in Sources */,
-				730FC05025127FA2004D7C2D /* OESettings.swift in Sources */,
+				730FC05025127FA2004D7C2D /* NYPLSettings+OE.swift in Sources */,
 				73085E1A2502DE88008F6244 /* OETutorialChoiceViewController.swift in Sources */,
 				73FCA2B225005BA4001B0C5D /* NYPLBookContentType.swift in Sources */,
 				73FCA2B325005BA4001B0C5D /* NYPLAgeCheck.swift in Sources */,
@@ -2935,6 +2950,7 @@
 				73FCA2B825005BA4001B0C5D /* NYPLMainThreadChecker.swift in Sources */,
 				73FCA2B925005BA4001B0C5D /* NYPLConfiguration.m in Sources */,
 				73225DED250B4B9100EF1877 /* NYPLRootTabBarController+OE.swift in Sources */,
+				734731262514236A00BE3D2C /* NYPLAppDelegate+OE.swift in Sources */,
 				73FCA2BA25005BA4001B0C5D /* NYPLAlertUtils.swift in Sources */,
 				73FCA2BB25005BA4001B0C5D /* OPDS2Publication.swift in Sources */,
 				73FCA2BC25005BA4001B0C5D /* String+MD5.swift in Sources */,
@@ -3080,7 +3096,7 @@
 				73FCA34125005BA4001B0C5D /* NYPLOPDSEntryGroupAttributes.m in Sources */,
 				73FCA34225005BA4001B0C5D /* NYPLMyBooksDownloadCenter.m in Sources */,
 				73FCA34325005BA4001B0C5D /* NYPLProblemDocumentCacheManager.swift in Sources */,
-				7353940C250854A90043C800 /* OESettingsSetUp.swift in Sources */,
+				7353940C250854A90043C800 /* NYPLSettingsSplitViewController+OE.swift in Sources */,
 				73FCA34425005BA4001B0C5D /* NYPLBookDetailButtonsView.m in Sources */,
 				73FCA34525005BA4001B0C5D /* NYPLMyBooksSimplifiedBearerToken.m in Sources */,
 				73FCA34625005BA4001B0C5D /* NYPLAnnotations.swift in Sources */,
@@ -3123,6 +3139,7 @@
 				2D382BD71D08BA99002C423D /* Log.swift in Sources */,
 				11616E11196B0531003D60D9 /* NYPLBookRegistry.m in Sources */,
 				081387571BC574DA003DEA6A /* UILabel+NYPLAppearanceAdditions.m in Sources */,
+				734731232514235900BE3D2C /* NYPLAppDelegate+SE.swift in Sources */,
 				11369D48199527C200BB11F8 /* NYPLJSON.m in Sources */,
 				7327A89323EE017300954748 /* NYPLMainThreadChecker.swift in Sources */,
 				116A5EB91947B57500491A21 /* NYPLConfiguration.m in Sources */,
@@ -3200,6 +3217,7 @@
 				1195040B1994075B009FB788 /* NYPLReaderViewController.m in Sources */,
 				1183F33B194B775900DC322F /* NYPLCatalogLaneCell.m in Sources */,
 				7340DA6224B7E45C00361387 /* URLResponse+NYPL.swift in Sources */,
+				7347312925142FE200BE3D2C /* NYPLSettings+SE.swift in Sources */,
 				E6202A021DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.m in Sources */,
 				2198F910250A90EE000D9DAB /* AudioBookVendorsHelper.swift in Sources */,
 				113137E71A48DAB90082954E /* NYPLReaderReadiumView.m in Sources */,

--- a/Simplified/AppInfrastructure/NSNotification+NYPL.swift
+++ b/Simplified/AppInfrastructure/NSNotification+NYPL.swift
@@ -17,6 +17,10 @@ extension Notification.Name {
   static let NYPLUseBetaDidChange = Notification.Name("NYPLUseBetaDidChange")
   static let NYPLUserAccountDidChange = Notification.Name("NYPLUserAccountDidChangeNotification")
   static let NYPLDidSignOut = Notification.Name("NYPLDidSignOut")
+
+  // TODO: i think this was called "OEAppDelegateDidReceiveCleverRedirectURL"
+  // in kyle's branch
+  static let NYPLAppDelegateDidReceiveCleverRedirectURL = Notification.Name("NYPLAppDelegateDidReceiveCleverRedirectURL")
 }
 
 @objc extension NSNotification {
@@ -28,4 +32,5 @@ extension Notification.Name {
   public static let NYPLUseBetaDidChange = Notification.Name.NYPLUseBetaDidChange
   public static let NYPLUserAccountDidChange = Notification.Name.NYPLUserAccountDidChange
   public static let NYPLDidSignOut = Notification.Name.NYPLDidSignOut
+  public static let NYPLAppDelegateDidReceiveCleverRedirectURL = Notification.Name.NYPLAppDelegateDidReceiveCleverRedirectURL
 }

--- a/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
@@ -1,0 +1,37 @@
+//
+//  NYPLAppDelegate+OE.swift
+//  Open eBooks
+//
+//  Created by Ettore Pasquini on 9/17/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+extension NYPLAppDelegate {
+  @objc func setUpRootVC() {
+    if NYPLSettings.shared.userHasSeenWelcomeScreen {
+      window.rootViewController = NYPLRootTabBarController.shared()
+    } else {
+      window.rootViewController = OETutorialViewController()
+    }
+  }
+
+  /// Handle all custom URL schemes specific to Open eBooks here.
+  /// - Parameter url: The URL to process.
+  /// - Returns: `true` if the app should handle the URL because it matches a
+  /// custom URL scheme we're registered to.
+  @objc(shouldHandleAppSpecificCustomURLSchemesForURL:)
+  func shouldHandleAppSpecificCustomURLSchemes(for url: URL) -> Bool {
+    if let scheme = url.scheme {
+      if scheme == "open-ebooks-clever" {
+        NotificationCenter.default
+          .post(name: .NYPLAppDelegateDidReceiveCleverRedirectURL,
+                object: url)
+        return true
+      }
+    }
+
+    return false
+  }
+}

--- a/Simplified/AppInfrastructure/NYPLAppDelegate+SE.swift
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate+SE.swift
@@ -1,0 +1,25 @@
+//
+//  NYPLAppDelegate+SE.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 9/17/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+extension NYPLAppDelegate {
+  @objc func setUpRootVC() {
+    //    self.window.rootViewController = SETutorialViewController()
+    window.rootViewController = NYPLRootTabBarController.shared()
+  }
+
+  /// Handle all custom URL schemes specific to SimplyE here.
+  /// - Parameter url: The URL to process
+  /// - Returns: `true` if the app should handle the URL because it matches a
+  /// custom URL scheme we're registered to.
+  @objc(shouldHandleAppSpecificCustomURLSchemesForURL:)
+  func shouldHandleAppSpecificCustomURLSchemes(for url: URL) -> Bool {
+    return false
+  }
+}

--- a/Simplified/AppInfrastructure/NYPLAppDelegate.h
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate.h
@@ -1,3 +1,5 @@
+@import UIKit;
+
 @interface NYPLAppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (nonatomic) UIWindow *window;

--- a/Simplified/AppInfrastructure/NYPLAppDelegate.m
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate.m
@@ -37,7 +37,7 @@ const NSTimeInterval MinimumBackgroundFetchInterval = 60 * 60 * 24;
 
 #pragma mark UIApplicationDelegate
 
-- (BOOL)application:(__attribute__((unused)) UIApplication *)application
+- (BOOL)application:(UIApplication *)app
 didFinishLaunchingWithOptions:(__attribute__((unused)) NSDictionary *)launchOptions
 {
 #if !TARGET_OS_SIMULATOR
@@ -51,7 +51,7 @@ didFinishLaunchingWithOptions:(__attribute__((unused)) NSDictionary *)launchOpti
   self.audiobookLifecycleManager = [[AudiobookLifecycleManager alloc] init];
   [self.audiobookLifecycleManager didFinishLaunching];
 
-  [[UIApplication sharedApplication] setMinimumBackgroundFetchInterval:MinimumBackgroundFetchInterval];
+  [app setMinimumBackgroundFetchInterval:MinimumBackgroundFetchInterval];
 
   if (@available (iOS 10.0, *)) {
     self.notificationsManager = [[NYPLUserNotifications alloc] init];
@@ -116,7 +116,7 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))backgroundF
 {
     if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb] && [userActivity.webpageURL.host isEqualToString:NYPLSettings.shared.authenticationUniversalLink.host]) {
         [[NSNotificationCenter defaultCenter]
-         postNotificationName:@"NYPLAppDelegateDidReceiveCleverRedirectURL"
+         postNotificationName:NSNotification.NYPLAppDelegateDidReceiveCleverRedirectURL
          object:userActivity.webpageURL];
 
         return YES;

--- a/Simplified/AppInfrastructure/NYPLAppDelegate.m
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate.m
@@ -66,17 +66,7 @@ didFinishLaunchingWithOptions:(__attribute__((unused)) NSDictionary *)launchOpti
   self.window.tintAdjustmentMode = UIViewTintAdjustmentModeNormal;
   [self.window makeKeyAndVisible];
 
-  //TODO: SIMPLY-3091 refactor this better in 2 source files
-#ifdef OPENEBOOKS
-  if ([[NYPLSettings shared] userHasSeenWelcomeScreen]) {
-    self.window.rootViewController = [NYPLRootTabBarController sharedController];
-  } else {
-    self.window.rootViewController = [[OETutorialViewController alloc] init];
-  }
-#else
-  //    self.window.rootViewController = SETutorialViewController()
-  self.window.rootViewController = [NYPLRootTabBarController sharedController];
-#endif
+  [self setUpRootVC];
 
   [self beginCheckingForUpdates];
 
@@ -129,6 +119,9 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))backgroundF
             openURL:(NSURL *)url
             options:(__unused NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
+  if ([self shouldHandleAppSpecificCustomURLSchemesForURL:url]) {
+    return YES;
+  }
 
   // URLs should be a permalink to a feed URL
   NSURL *entryURL = [url URLBySwappingForScheme:@"http"];

--- a/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
@@ -12,7 +12,7 @@ extension NYPLConfiguration {
   static let OpenEBooksUUID = "urn:uuid:e1a01c16-04e7-4781-89fd-b442dd1be001"
 
   static let circulationBaseURLProduction = "https://circulation.openebooks.us"
-  static let circulationBaseURLBeta = "http://qa.circulation.openebooks.us"
+  static let circulationBaseURLBeta = "http://qa-circulation.openebooks.us"
   static let circulationURL = URL(string: circulationBaseURLProduction)!
 
   static let openEBooksRequestCodesURL = URL(string: "http://openebooks.net/getstarted.html")!

--- a/Simplified/NYPLAccountSignInViewController.m
+++ b/Simplified/NYPLAccountSignInViewController.m
@@ -924,7 +924,7 @@ completionHandler:(void (^)(void))handler
 
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(handleRedirectURL:)
-                                               name: @"NYPLAppDelegateDidReceiveCleverRedirectURL"
+                                               name: NSNotification.NYPLAppDelegateDidReceiveCleverRedirectURL
                                              object:nil];
 
   [UIApplication.sharedApplication openURL: urlComponents.URL];
@@ -951,7 +951,7 @@ completionHandler:(void (^)(void))handler
     self.cookies = cookies;
 
     // process the last redirection url to get the oauth token
-    [self handleRedirectURL:[NSNotification notificationWithName:@"NYPLAppDelegateDidReceiveCleverRedirectURL"
+    [self handleRedirectURL:[NSNotification notificationWithName:NSNotification.NYPLAppDelegateDidReceiveCleverRedirectURL
                                                           object:url
                                                         userInfo:nil]];
 
@@ -988,9 +988,9 @@ completionHandler:(void (^)(void))handler
   [self validateCredentials];
 }
 
-- (void) handleRedirectURL: (NSNotification *) notification
+- (void)handleRedirectURL:(NSNotification *)notification
 {
-  [NSNotificationCenter.defaultCenter removeObserver: self name: @"NYPLAppDelegateDidReceiveCleverRedirectURL" object: nil];
+  [NSNotificationCenter.defaultCenter removeObserver: self name: NSNotification.NYPLAppDelegateDidReceiveCleverRedirectURL object: nil];
 
   NSURL *url = notification.object;
   if (![url.absoluteString hasPrefix:NYPLSettings.shared.authenticationUniversalLink.absoluteString]
@@ -1057,7 +1057,7 @@ completionHandler:(void (^)(void))handler
                                 summary:@"SignIn-modal"
                                 message:@"App couldn't parse the patron info delivered in oauth/saml redirection."
                                metadata:@{
-                                 @"patronInfo": patron
+                                 @"patronInfo": patron ?: @"N/A"
                                }];
     }
   }

--- a/Simplified/NYPLHoldsNavigationController.m
+++ b/Simplified/NYPLHoldsNavigationController.m
@@ -71,9 +71,9 @@
 }
 
 #ifdef SIMPLYE
-- (void) switchLibrary
+- (void)switchLibrary
 {
-  NYPLHoldsViewController *viewController = (NYPLHoldsViewController *)self.visibleViewController;
+  UIViewController *viewController = self.visibleViewController;
 
   UIAlertControllerStyle style;
   if (viewController && viewController.navigationItem.leftBarButtonItem) {
@@ -85,23 +85,23 @@
   UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"PickYourLibrary", nil) message:nil preferredStyle:style];
   alert.popoverPresentationController.barButtonItem = viewController.navigationItem.leftBarButtonItem;
   alert.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp;
-  
+
   NSArray *accounts = [[NYPLSettings sharedSettings] settingsAccountsList];
-  
+
   for (int i = 0; i < (int)accounts.count; i++) {
     Account *account = [[AccountsManager sharedInstance] account:accounts[i]];
     if (!account) {
       continue;
     }
-    
+
     [alert addAction:[UIAlertAction actionWithTitle:account.name style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
 
       BOOL workflowsInProgress;
-    #if defined(FEATURE_DRM_CONNECTOR)
+#if defined(FEATURE_DRM_CONNECTOR)
       workflowsInProgress = ([NYPLADEPT sharedInstance].workflowsInProgress || [NYPLBookRegistry sharedRegistry].syncing == YES);
-    #else
+#else
       workflowsInProgress = ([NYPLBookRegistry sharedRegistry].syncing == YES);
-    #endif
+#endif
 
       if (workflowsInProgress) {
         [self presentViewController:[NYPLAlertUtils
@@ -111,12 +111,11 @@
                          completion:nil];
       } else {
         [[NYPLBookRegistry sharedRegistry] save];
-        [AccountsManager shared].currentAccount = account;
-        [self reloadSelected];
+        [self updateCatalogFeedSettingCurrentAccount:account];
       }
     }]];
   }
-  
+
   [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"ManageAccounts", nil) style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
     NSUInteger tabCount = [[[NYPLRootTabBarController sharedController] viewControllers] count];
     UISplitViewController *splitViewVC = [[[NYPLRootTabBarController sharedController] viewControllers] lastObject];
@@ -126,20 +125,21 @@
     NYPLSettingsPrimaryTableViewController *tableVC = [[masterNavVC viewControllers] firstObject];
     [tableVC.delegate settingsPrimaryTableViewController:tableVC didSelectItem:NYPLSettingsPrimaryTableViewControllerItemAccount];
   }]];
-  
+
   [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil) style:(UIAlertActionStyleCancel) handler:nil]];
-  
+
   [[NYPLRootTabBarController sharedController] safelyPresentViewController:alert animated:YES completion:nil];
 }
-#endif
 
-- (void)reloadSelected
+- (void)updateCatalogFeedSettingCurrentAccount:(Account *)account
 {
+  [AccountsManager shared].currentAccount = account;
   NYPLCatalogNavigationController * catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
   [catalog updateFeedAndRegistryOnAccountChange];
-  
-  NYPLHoldsViewController *viewController = (NYPLHoldsViewController *)self.visibleViewController;
-  viewController.navigationItem.title = [AccountsManager shared].currentAccount.name;
+
+  UIViewController *visibleVC = self.visibleViewController;
+  visibleVC.navigationItem.title = [AccountsManager shared].currentAccount.name;
 }
+#endif
 
 @end

--- a/Simplified/NYPLMyBooksNavigationController.m
+++ b/Simplified/NYPLMyBooksNavigationController.m
@@ -72,9 +72,9 @@
 }
 
 #ifdef SIMPLYE
-- (void) switchLibrary
+- (void)switchLibrary
 {
-  NYPLMyBooksViewController *viewController = (NYPLMyBooksViewController *)self.visibleViewController;
+  UIViewController *viewController = self.visibleViewController;
 
   UIAlertControllerStyle style;
   if (viewController && viewController.navigationItem.leftBarButtonItem) {
@@ -86,9 +86,9 @@
   UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"PickYourLibrary", nil) message:nil preferredStyle:style];
   alert.popoverPresentationController.barButtonItem = viewController.navigationItem.leftBarButtonItem;
   alert.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp;
-  
+
   NSArray *accounts = [[NYPLSettings sharedSettings] settingsAccountsList];
-  
+
   for (int i = 0; i < (int)accounts.count; i++) {
     Account *account = [[AccountsManager sharedInstance] account:accounts[i]];
     if (!account) {
@@ -97,14 +97,14 @@
 
     [alert addAction:[UIAlertAction actionWithTitle:account.name style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
 
-      BOOL workflowsInProgress = false;
-    #if defined(FEATURE_DRM_CONNECTOR)
+      BOOL workflowsInProgress;
+#if defined(FEATURE_DRM_CONNECTOR)
       workflowsInProgress = ([NYPLADEPT sharedInstance].workflowsInProgress || [NYPLBookRegistry sharedRegistry].syncing == YES);
-    #else
+#else
       workflowsInProgress = ([NYPLBookRegistry sharedRegistry].syncing == YES);
-    #endif
+#endif
 
-      if(workflowsInProgress) {
+      if (workflowsInProgress) {
         [self presentViewController:[NYPLAlertUtils
                                      alertWithTitle:@"PleaseWait"
                                      message:@"PleaseWaitMessage"]
@@ -112,12 +112,11 @@
                          completion:nil];
       } else {
         [[NYPLBookRegistry sharedRegistry] save];
-        [AccountsManager shared].currentAccount = account;
-        [self reloadSelected];
+        [self updateCatalogFeedSettingCurrentAccount:account];
       }
     }]];
   }
-  
+
   [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"ManageAccounts", nil) style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
     NSUInteger tabCount = [[[NYPLRootTabBarController sharedController] viewControllers] count];
     UISplitViewController *splitViewVC = [[[NYPLRootTabBarController sharedController] viewControllers] lastObject];
@@ -127,21 +126,21 @@
     NYPLSettingsPrimaryTableViewController *tableVC = [[masterNavVC viewControllers] firstObject];
     [tableVC.delegate settingsPrimaryTableViewController:tableVC didSelectItem:NYPLSettingsPrimaryTableViewControllerItemAccount];
   }]];
-  
-  [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil) style:(UIAlertActionStyleCancel) handler:nil]];
-  
-  [[NYPLRootTabBarController sharedController] safelyPresentViewController:alert animated:YES completion:nil];
-  
-}
-#endif
 
-- (void)reloadSelected
+  [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil) style:(UIAlertActionStyleCancel) handler:nil]];
+
+  [[NYPLRootTabBarController sharedController] safelyPresentViewController:alert animated:YES completion:nil];
+}
+
+- (void)updateCatalogFeedSettingCurrentAccount:(Account *)account
 {
+  [AccountsManager shared].currentAccount = account;
   NYPLCatalogNavigationController * catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
   [catalog updateFeedAndRegistryOnAccountChange];
-  
-  NYPLMyBooksViewController *viewController = (NYPLMyBooksViewController *)self.visibleViewController;
-  viewController.navigationItem.title =  [AccountsManager shared].currentAccount.name;
+
+  UIViewController *visibleVC = self.visibleViewController;
+  visibleVC.navigationItem.title = [AccountsManager shared].currentAccount.name;
 }
+#endif
 
 @end

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -524,7 +524,7 @@ Authenticating with any of those barcodes should work.
 
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(handleRedirectURL:)
-                                               name: @"NYPLAppDelegateDidReceiveCleverRedirectURL"
+                                               name: NSNotification.NYPLAppDelegateDidReceiveCleverRedirectURL
                                              object:nil];
 
   [UIApplication.sharedApplication openURL: urlComponents.URL];
@@ -551,7 +551,7 @@ Authenticating with any of those barcodes should work.
     self.cookies = cookies;
 
     // process the last redirection url to get the oauth token
-    [self handleRedirectURL:[NSNotification notificationWithName:@"NYPLAppDelegateDidReceiveCleverRedirectURL"
+    [self handleRedirectURL:[NSNotification notificationWithName:NSNotification.NYPLAppDelegateDidReceiveCleverRedirectURL
                                                           object:url
                                                         userInfo:nil]];
 
@@ -588,7 +588,7 @@ Authenticating with any of those barcodes should work.
 
 - (void) handleRedirectURL: (NSNotification *) notification
 {
-  [NSNotificationCenter.defaultCenter removeObserver: self name: @"NYPLAppDelegateDidReceiveCleverRedirectURL" object: nil];
+  [NSNotificationCenter.defaultCenter removeObserver: self name: NSNotification.NYPLAppDelegateDidReceiveCleverRedirectURL object: nil];
 
   NSURL *url = notification.object;
   if (![url.absoluteString hasPrefix:NYPLSettings.shared.authenticationUniversalLink.absoluteString]

--- a/Simplified/OpenEbooks/Resources/OpenEBooks_OPDS2_Catalog_Feed.json
+++ b/Simplified/OpenEbooks/Resources/OpenEBooks_OPDS2_Catalog_Feed.json
@@ -8,38 +8,8 @@
           "rel": "http://opds-spec.org/catalog"
         },
         {
-          "href": "http://openebooks.net/app_user_agreement.html",
-          "type": "text/html",
-          "rel": "terms-of-service"
-        },
-        {
           "href": "https://circulation.openebooks.us/USOEI/authentication_document",
           "type": "application/vnd.opds.authentication.v1.0+json"
-        },
-        {
-          "href": "http://openebooks.net/app_privacy.html",
-          "type": "text/html",
-          "rel": "privacy-policy"
-        },
-        {
-          "href": "http://openebooks.net/app_acknowledgments.html",
-          "type": "text/html",
-          "rel": "copyright"
-        },
-        {
-          "href": "https://circulation.openebooks.us/USOEI/",
-          "type": "application/atom+xml;profile=opds-catalog;kind=acquisition",
-          "rel": "start"
-        },
-        {
-          "href": "https://circulation.openebooks.us/USOEI/loans/",
-          "type": "application/atom+xml;profile=opds-catalog;kind=acquisition",
-          "rel": "http://opds-spec.org/shelf"
-        },
-        {
-          "href": "https://circulation.openebooks.us/USOEI/patrons/me/",
-          "type": "vnd.librarysimplified/user-profile+json",
-          "rel": "http://librarysimplified.org/terms/rel/user-profile"
         },
         {
           "href": "https://openebooks.net/",

--- a/Simplified/Settings/NYPLSettings+OE.swift
+++ b/Simplified/Settings/NYPLSettings+OE.swift
@@ -1,27 +1,32 @@
 //
-//  OESettings.swift
+//  NYPLSettings+OE.swift
 //  Open eBooks
 //
 //  Created by Kyle Sakai.
 //  Copyright © 2020 NYPL Labs. All rights reserved.
 //
 
-class OESettings : NYPLSettings {
+extension NYPLSettings {
+  /// Used to handle OAuth sign-ins. For example, Clever authentication uses
+  /// this URL for redirecting to the app after authenticating in Safari.
+  /// This requires configurion setting Universal Links on the server.
+  @objc var authenticationUniversalLink: URL {
+    return URL(string: "https://www.librarysimplified.org/callbacks/OpenEbooks")!
+  }
+
   static let userHasAcceptedEULAKey = "OEUserHasAcceptedEULA"
-  
+
   var userHasAcceptedEULA: Bool {
     get {
-      return UserDefaults.standard.bool(forKey: OESettings.userHasAcceptedEULAKey)
+      return UserDefaults.standard.bool(forKey: NYPLSettings.userHasAcceptedEULAKey)
     }
     set(b) {
-      UserDefaults.standard.set(b, forKey: OESettings.userHasAcceptedEULAKey)
+      UserDefaults.standard.set(b, forKey: NYPLSettings.userHasAcceptedEULAKey)
       UserDefaults.standard.synchronize()
     }
   }
-  
-  // MARK: NYPLSettings
-  
-  override var settingsAccountsList: [String] {
+
+  var settingsAccountsList: [String] {
     get {
       if let libraryAccounts = UserDefaults.standard.array(forKey: NYPLSettings.settingsLibraryAccountsKey) {
         return libraryAccounts as! [String]

--- a/Simplified/Settings/NYPLSettings+SE.swift
+++ b/Simplified/Settings/NYPLSettings+SE.swift
@@ -1,0 +1,39 @@
+//
+//  NYPLSettings+SE.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 9/17/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+extension NYPLSettings {
+  /// Used to handle OAuth sign-ins. For example, Clever authentication uses
+  /// this URL for redirecting to the app after authenticating in Safari.
+  /// This requires configurion setting Universal Links on the server.
+  @objc var authenticationUniversalLink: URL {
+    return URL(string: "https://www.librarysimplified.org/callbacks/SimplyE")!
+  }
+
+  var settingsAccountsList: [String] {
+    get {
+      if let libraryAccounts = UserDefaults.standard.array(forKey: NYPLSettings.settingsLibraryAccountsKey) {
+        return libraryAccounts as! [String]
+      }
+
+      // Avoid crash in case currentLibrary isn't set yet
+      var accountsList = [String]()
+      if let currentLibrary = AccountsManager.shared.currentAccount?.uuid {
+        accountsList.append(currentLibrary)
+      }
+      accountsList.append(AccountsManager.NYPLAccountUUIDs[2])
+      self.settingsAccountsList = accountsList
+      return accountsList
+    }
+    set(newAccountsList) {
+      UserDefaults.standard.set(newAccountsList, forKey: NYPLSettings.settingsLibraryAccountsKey)
+      UserDefaults.standard.synchronize()
+    }
+  }
+}

--- a/Simplified/Settings/NYPLSettings.swift
+++ b/Simplified/Settings/NYPLSettings.swift
@@ -2,7 +2,11 @@ import Foundation
 
 @objcMembers class NYPLSettings: NSObject {
   static let shared = NYPLSettings()
-  
+
+  @objc class func sharedSettings() -> NYPLSettings {
+    return NYPLSettings.shared
+  }
+
   static let NYPLAboutSimplyEURLString = "https://librarysimplified.org/simplye/"
   static let NYPLUserAgreementURLString = "https://www.librarysimplified.org/EULA/"
   
@@ -15,13 +19,6 @@ import Foundation
   static let settingsLibraryAccountsKey = "NYPLSettingsLibraryAccountsKey"
   static private let versionKey = "NYPLSettingsVersionKey"
   
-  @objc class func sharedSettings() -> NYPLSettings {
-    return NYPLSettings.shared
-  }
-
-  // used to handle saml and oauth login. In case of the later, it needs to be configured as universal link
-  @objc var authenticationUniversalLink = URL(string: "https://librarysimplified.org/login")!
-
   // Set to nil (the default) if no custom feed should be used.
   var customMainFeedURL: URL? {
     get {
@@ -89,27 +86,6 @@ import Foundation
       UserDefaults.standard.set(b, forKey: NYPLSettings.useBetaLibrariesKey)
       UserDefaults.standard.synchronize()
       NotificationCenter.default.post(name: NSNotification.Name.NYPLUseBetaDidChange, object: self)
-    }
-  }
-  
-  var settingsAccountsList: [String] {
-    get {
-      if let libraryAccounts = UserDefaults.standard.array(forKey: NYPLSettings.settingsLibraryAccountsKey) {
-        return libraryAccounts as! [String]
-      }
-      
-      // Avoid crash in case currentLibrary isn't set yet
-      var accountsList = [String]()
-      if let currentLibrary = AccountsManager.shared.currentAccount?.uuid {
-        accountsList.append(currentLibrary)
-      }
-      accountsList.append(AccountsManager.NYPLAccountUUIDs[2])
-      self.settingsAccountsList = accountsList
-      return accountsList
-    }
-    set(newAccountsList) {
-      UserDefaults.standard.set(newAccountsList, forKey: NYPLSettings.settingsLibraryAccountsKey)
-      UserDefaults.standard.synchronize()
     }
   }
   

--- a/Simplified/Settings/NYPLSettingsSplitViewController+OE.swift
+++ b/Simplified/Settings/NYPLSettingsSplitViewController+OE.swift
@@ -1,5 +1,5 @@
 //
-//  OESettingsSetUp.swift
+//  NYPLSettingsSplitViewController+OE.swift
 //  Open eBooks
 //
 //  Created by Kyle Sakai.

--- a/Simplified/SimplyE-Bridging-Header.h
+++ b/Simplified/SimplyE-Bridging-Header.h
@@ -1,7 +1,4 @@
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-
+#import "NYPLAppDelegate.h"
 #import "NYPLConfiguration.h"
 #import "NYPLBook.h"
 #import "NYPLBookDetailView.h"

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "Hide" = "Hide";
 "Information" = "Information";
 "LibraryCard" = "Library Card";
+"Error Loading Library" = "Error Loading Library";
 "LibraryLoadError" = "We can’t get your library right now. Please close and reopen the app to try again.";
 "LogIn" = "Log In";
 "ManageAccounts" = "Manage Accounts";

--- a/Simplified/it.lproj/Localizable.strings
+++ b/Simplified/it.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "Hide" = "nascondere";
 "Information" = "Informazioni";
 "LibraryCard" = "Tessera della biblioteca";
+"Error Loading Library" = "Errore di accesso alla biblioteca";
+"LibraryLoadError" = "Non è possibile accedere alla tua biblioteca in questo momento. Prova a chiudere e riaprire l'app, oppure se il problema persiste riprova tra qualche minuto.";
 "LogIn" = "Accedi";
 "More..." = "Di Più…";
 "MoreBooks" = "Più %@ libri";


### PR DESCRIPTION
**What's this do?**
The AppDelegate and NYPLSettings have/will have similarities and differences between SimplyE and Open eBooks. Previously we dealt with these via ugly #ifdefs. This refactors the differences in separate files that are compiled or not depending on the target.

Other minor things:
- one notification name that will be needed for Clever authentication was expressed via duplicated string literals, which are error prone. Refactored that into a constant.
- Catalog, My Books and Holds navigation controllers have largely identical switchLibrary logic. Before refactoring it to remove this duplication (actually, triplication) I'm doing an intermediate step here.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3091

**How should this be tested? / Do these changes have associated tests?**
Nothing to test here really that won't be caught during a regression.

**Dependencies for merging? Releasing to production?**
Not a breaking change for SimplyE.

**Has the application documentation been updated for these changes?**
obviously 

**Did someone actually run this code to verify it works?**
@ettore 