### PR TITLE
Refactor switchLibrary functionality removing code triplication

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -206,6 +206,9 @@
 		73085E3525030D27008F6244 /* SEMigrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E3425030D27008F6244 /* SEMigrations.swift */; };
 		73085E3625030D27008F6244 /* SEMigrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E3425030D27008F6244 /* SEMigrations.swift */; };
 		73085E3A25030D80008F6244 /* OEMigrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E3725030D66008F6244 /* OEMigrations.swift */; };
+		730EE001251567820038DD9F /* NYPLLibraryNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 730EE000251567820038DD9F /* NYPLLibraryNavigationController.m */; };
+		730EE002251567820038DD9F /* NYPLLibraryNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 730EE000251567820038DD9F /* NYPLLibraryNavigationController.m */; };
+		730EE003251567820038DD9F /* NYPLLibraryNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 730EE000251567820038DD9F /* NYPLLibraryNavigationController.m */; };
 		730FC05025127FA2004D7C2D /* NYPLSettings+OE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730FC04F25127FA2004D7C2D /* NYPLSettings+OE.swift */; };
 		730FC05125128224004D7C2D /* NYPLSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */; };
 		730FC05225128225004D7C2D /* NYPLSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */; };
@@ -1150,6 +1153,8 @@
 		73085E252502EDF0008F6244 /* NYPLSettingsSplitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLSettingsSplitViewController.swift; sourceTree = "<group>"; };
 		73085E3425030D27008F6244 /* SEMigrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEMigrations.swift; sourceTree = "<group>"; };
 		73085E3725030D66008F6244 /* OEMigrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OEMigrations.swift; sourceTree = "<group>"; };
+		730EDFFF251567820038DD9F /* NYPLLibraryNavigationController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NYPLLibraryNavigationController.h; sourceTree = "<group>"; };
+		730EE000251567820038DD9F /* NYPLLibraryNavigationController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NYPLLibraryNavigationController.m; sourceTree = "<group>"; };
 		730FC04F25127FA2004D7C2D /* NYPLSettings+OE.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NYPLSettings+OE.swift"; sourceTree = "<group>"; };
 		730FC05425128D63004D7C2D /* OETutorialViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OETutorialViewController.swift; sourceTree = "<group>"; };
 		730FC05525128D64004D7C2D /* OETutorialEligibilityViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OETutorialEligibilityViewController.swift; sourceTree = "<group>"; };
@@ -1806,6 +1811,8 @@
 				738CB2052509A87700891F31 /* NYPLConfiguration+SE.swift */,
 				73225DEA250B471400EF1877 /* NYPLRootTabBarController+OE.swift */,
 				739ECB2D25108EE800691A70 /* NYPLRootTabBarController+SE.swift */,
+				730EDFFF251567820038DD9F /* NYPLLibraryNavigationController.h */,
+				730EE000251567820038DD9F /* NYPLLibraryNavigationController.m */,
 			);
 			path = AppInfrastructure;
 			sourceTree = "<group>";
@@ -2893,6 +2900,7 @@
 				7347F0C2245A4DE200558D7F /* NYPLKeychainManager.swift in Sources */,
 				7347312725142D2D00BE3D2C /* NYPLCookiesWebViewController.swift in Sources */,
 				7347F0C3245A4DE200558D7F /* NYPLErrorLogger.swift in Sources */,
+				730EE002251567820038DD9F /* NYPLLibraryNavigationController.m in Sources */,
 				7360D0D624BFCB9700C8AD16 /* NYPLUserFriendlyError.swift in Sources */,
 				7347F0C4245A4DE200558D7F /* NYPLOPDSEntryGroupAttributes.m in Sources */,
 				21C504782513C9F00016A6C8 /* JWKResponse.swift in Sources */,
@@ -2974,6 +2982,7 @@
 				73FCA2CD25005BA4001B0C5D /* NYPLReaderBookmarkCell.swift in Sources */,
 				73FCA2CE25005BA4001B0C5D /* NYPLOpenSearchDescription.m in Sources */,
 				73FCA2CF25005BA4001B0C5D /* NYPLReaderTOCElement.m in Sources */,
+				730EE003251567820038DD9F /* NYPLLibraryNavigationController.m in Sources */,
 				73FCA2D025005BA4001B0C5D /* UpdateCheck.swift in Sources */,
 				739ECB292510207E00691A70 /* NYPLCatalogNavigationController+OE.swift in Sources */,
 				73FCA2D125005BA4001B0C5D /* NYPLReaderTOCViewController.m in Sources */,
@@ -3296,6 +3305,7 @@
 				2DEF10BA201ECCEA0082843A /* NYPLMyBooksSimplifiedBearerToken.m in Sources */,
 				2DF321831DC3B83500E1858F /* NYPLAnnotations.swift in Sources */,
 				21EC1B8F2501538600A12384 /* AudioBookVendors+Extensions.swift in Sources */,
+				730EE001251567820038DD9F /* NYPLLibraryNavigationController.m in Sources */,
 				E6BA02B81DE4B6F600F76404 /* RemoteHTMLViewController.swift in Sources */,
 				8CE9C471237F84820072E964 /* NYPLBookDetailsProblemDocumentViewController.swift in Sources */,
 				A4BA1D131B43046B006F83DF /* NYPLCatalogGroupedFeed.m in Sources */,

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -209,6 +209,13 @@
 		730EE001251567820038DD9F /* NYPLLibraryNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 730EE000251567820038DD9F /* NYPLLibraryNavigationController.m */; };
 		730EE002251567820038DD9F /* NYPLLibraryNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 730EE000251567820038DD9F /* NYPLLibraryNavigationController.m */; };
 		730EE003251567820038DD9F /* NYPLLibraryNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 730EE000251567820038DD9F /* NYPLLibraryNavigationController.m */; };
+		730EDFEA2515378C0038DD9F /* KeychainStoredVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0857A0FE247835FF00C7984E /* KeychainStoredVariable.swift */; };
+		730EDFEF251537AF0038DD9F /* NYPLSessionCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0857A0F62478337D00C7984E /* NYPLSessionCredentials.swift */; };
+		730EDFF02515380D0038DD9F /* NYPLAnnouncementBusinessLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175E480724EF36520066A6CF /* NYPLAnnouncementBusinessLogic.swift */; };
+		730EDFF12515383B0038DD9F /* NYPLAnnouncementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175E480D24EF46EA0066A6CF /* NYPLAnnouncementViewController.swift */; };
+		730EDFF22515384F0038DD9F /* NYPLLoginCellTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089E430B24A2459100310360 /* NYPLLoginCellTypes.swift */; };
+		730EDFF3251538630038DD9F /* NYPLSamlIDPCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0826CD2824AA21B2000F4030 /* NYPLSamlIDPCell.swift */; };
+		730EDFF42515386B0038DD9F /* NYPLLibraryDescriptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0826CD2E24AA2801000F4030 /* NYPLLibraryDescriptionCell.swift */; };
 		730FC05025127FA2004D7C2D /* NYPLSettings+OE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730FC04F25127FA2004D7C2D /* NYPLSettings+OE.swift */; };
 		730FC05125128224004D7C2D /* NYPLSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */; };
 		730FC05225128225004D7C2D /* NYPLSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */; };
@@ -2768,10 +2775,12 @@
 				73085E3625030D27008F6244 /* SEMigrations.swift in Sources */,
 				21C5047F2513C9FA0016A6C8 /* AudioBookVendorsHelper.swift in Sources */,
 				7347F04C245A4DE200558D7F /* NYPLXML.m in Sources */,
+				730EDFF22515384F0038DD9F /* NYPLLoginCellTypes.swift in Sources */,
 				731A5B1324621F2B00B5E663 /* NYPLSignInBusinessLogic.swift in Sources */,
 				7347F04D245A4DE200558D7F /* NYPLBookCell.m in Sources */,
 				7347F04E245A4DE200558D7F /* NSURL+NYPLURLAdditions.m in Sources */,
 				7347F04F245A4DE200558D7F /* NYPLAsync.m in Sources */,
+				730EDFEF251537AF0038DD9F /* NYPLSessionCredentials.swift in Sources */,
 				7347F050245A4DE200558D7F /* NYPLReloadView.m in Sources */,
 				7347F051245A4DE200558D7F /* NYPLReachabilityManager.m in Sources */,
 				7347F052245A4DE200558D7F /* NYPLReadiumViewSyncManager.m in Sources */,
@@ -2779,6 +2788,7 @@
 				7347F054245A4DE200558D7F /* NYPLBackgroundExecutor.swift in Sources */,
 				21C5047C2513C9F60016A6C8 /* AudioBookVendors+Extensions.swift in Sources */,
 				7347F055245A4DE200558D7F /* NYPLProblemDocument.swift in Sources */,
+				730EDFF12515383B0038DD9F /* NYPLAnnouncementViewController.swift in Sources */,
 				7347F056245A4DE200558D7F /* NYPLReturnPromptHelper.swift in Sources */,
 				7347F057245A4DE200558D7F /* NYPLReaderBookmarkCell.swift in Sources */,
 				7347F058245A4DE200558D7F /* NYPLOpenSearchDescription.m in Sources */,
@@ -2801,6 +2811,7 @@
 				7347F067245A4DE200558D7F /* NYPLUserNotifications.swift in Sources */,
 				7347F068245A4DE200558D7F /* NYPLCatalogLane.m in Sources */,
 				7347F069245A4DE200558D7F /* NYPLBookNormalCell.m in Sources */,
+				730EDFF02515380D0038DD9F /* NYPLAnnouncementBusinessLogic.swift in Sources */,
 				7353940E25085DBC0043C800 /* NYPLPresentationUtils.swift in Sources */,
 				7347F06A245A4DE200558D7F /* NYPLCatalogNavigationController.m in Sources */,
 				7347F06B245A4DE200558D7F /* NYPLEntryPointView.swift in Sources */,
@@ -2820,6 +2831,7 @@
 				7347F078245A4DE200558D7F /* NYPLAppTheme.swift in Sources */,
 				7347F079245A4DE200558D7F /* UIColor+NYPLColorAdditions.m in Sources */,
 				7347F07A245A4DE200558D7F /* URLRequest+NYPL.swift in Sources */,
+				730EDFF42515386B0038DD9F /* NYPLLibraryDescriptionCell.swift in Sources */,
 				7347F07B245A4DE200558D7F /* NYPLCatalogFeedViewController.m in Sources */,
 				7347F07C245A4DE200558D7F /* NYPLBookDownloadingCell.m in Sources */,
 				7347F07D245A4DE200558D7F /* NYPLTenPrintCoverView+NYPLImageAdditions.m in Sources */,
@@ -2868,6 +2880,7 @@
 				7347F0A1245A4DE200558D7F /* NYPLDirectoryManager.swift in Sources */,
 				7347F0A2245A4DE200558D7F /* NYPLContentTypeBadge.swift in Sources */,
 				7347F0A3245A4DE200558D7F /* NYPLZXingEncoder.m in Sources */,
+				730EDFEA2515378C0038DD9F /* KeychainStoredVariable.swift in Sources */,
 				7347F0A4245A4DE200558D7F /* NYPLProblemReportViewController.m in Sources */,
 				73AA32D824EF0853000C90B2 /* URLResponse+NYPL.swift in Sources */,
 				7347F0A5245A4DE200558D7F /* NYPLHoldsNavigationController.m in Sources */,
@@ -2884,6 +2897,7 @@
 				7347F0B1245A4DE200558D7F /* NSURLRequest+NYPLURLRequestAdditions.m in Sources */,
 				7347F0B2245A4DE200558D7F /* NYPLRootTabBarController.m in Sources */,
 				7347F0B3245A4DE200558D7F /* ExtendedNavBarView.swift in Sources */,
+				730EDFF3251538630038DD9F /* NYPLSamlIDPCell.swift in Sources */,
 				7347F0B4245A4DE200558D7F /* OPDS2Link.swift in Sources */,
 				7347F0B5245A4DE200558D7F /* NYPLBookAuthor.swift in Sources */,
 				7347F0B6245A4DE200558D7F /* NYPLCatalogSearchViewController.m in Sources */,
@@ -3458,7 +3472,7 @@
 				PRODUCT_NAME = SimplyE;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "SimplyE Development";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG FEATURE_DRM_CONNECTOR";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG FEATURE_DRM_CONNECTOR SIMPLYE";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplified/SimplyE-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -3509,7 +3523,7 @@
 				PRODUCT_NAME = SimplyE;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = NYPL_AdHoc_Wildcard;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = FEATURE_DRM_CONNECTOR;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FEATURE_DRM_CONNECTOR SIMPLYE";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplified/SimplyE-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.2;

--- a/Simplified/AppInfrastructure/NYPLLibraryNavigationController.h
+++ b/Simplified/AppInfrastructure/NYPLLibraryNavigationController.h
@@ -1,0 +1,22 @@
+//
+//  NYPLLibraryNavigationController.h
+//  Simplified
+//
+//  Created by Ettore Pasquini on 9/18/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@class Account;
+
+@interface NYPLLibraryNavigationController : UINavigationController
+
+#ifdef SIMPLYE
+- (void)setNavigationLeftBarButtonForVC:(UIViewController *)vc;
+- (void)switchLibrary;
+- (void)updateCatalogFeedSettingCurrentAccount:(Account *)account;
+#endif
+
+@end
+

--- a/Simplified/AppInfrastructure/NYPLLibraryNavigationController.m
+++ b/Simplified/AppInfrastructure/NYPLLibraryNavigationController.m
@@ -1,0 +1,113 @@
+//
+//  NYPLLibraryNavigationController.m
+//  Simplified
+//
+//  Created by Ettore Pasquini on 9/18/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+#import "SimplyE-Swift.h"
+
+#if defined(FEATURE_DRM_CONNECTOR)
+#import <ADEPT/ADEPT.h>
+#endif
+
+#import "NYPLLibraryNavigationController.h"
+#import "NYPLBookRegistry.h"
+#import "NYPLRootTabBarController.h"
+#import "NYPLCatalogNavigationController.h"
+
+#ifdef SIMPLYE
+// TODO: SIMPLY-3053 this #ifdef can be removed once this ticket is done
+#import "NYPLSettingsPrimaryTableViewController.h"
+#endif
+
+
+@interface NYPLLibraryNavigationController ()
+
+@end
+
+@implementation NYPLLibraryNavigationController
+
+#ifdef SIMPLYE
+- (void)setNavigationLeftBarButtonForVC:(UIViewController *)vc
+{
+  vc.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc]
+                                         initWithImage:[UIImage imageNamed:@"Catalog"] style:(UIBarButtonItemStylePlain)
+                                         target:self
+                                         action:@selector(switchLibrary)];
+  vc.navigationItem.leftBarButtonItem.accessibilityLabel = NSLocalizedString(@"AccessibilitySwitchLibrary", nil);
+}
+
+- (void)switchLibrary
+{
+  UIViewController *viewController = self.visibleViewController;
+
+  UIAlertControllerStyle style;
+  if (viewController && viewController.navigationItem.leftBarButtonItem) {
+    style = UIAlertControllerStyleActionSheet;
+  } else {
+    style = UIAlertControllerStyleAlert;
+  }
+
+  UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"PickYourLibrary", nil) message:nil preferredStyle:style];
+  alert.popoverPresentationController.barButtonItem = viewController.navigationItem.leftBarButtonItem;
+  alert.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp;
+
+  NSArray *accounts = [[NYPLSettings sharedSettings] settingsAccountsList];
+
+  for (int i = 0; i < (int)accounts.count; i++) {
+    Account *account = [[AccountsManager sharedInstance] account:accounts[i]];
+    if (!account) {
+      continue;
+    }
+
+    [alert addAction:[UIAlertAction actionWithTitle:account.name style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
+
+      BOOL workflowsInProgress;
+#if defined(FEATURE_DRM_CONNECTOR)
+      workflowsInProgress = ([NYPLADEPT sharedInstance].workflowsInProgress || [NYPLBookRegistry sharedRegistry].syncing == YES);
+#else
+      workflowsInProgress = ([NYPLBookRegistry sharedRegistry].syncing == YES);
+#endif
+
+      if (workflowsInProgress) {
+        [self presentViewController:[NYPLAlertUtils
+                                     alertWithTitle:@"PleaseWait"
+                                     message:@"PleaseWaitMessage"]
+                           animated:YES
+                         completion:nil];
+      } else {
+        [[NYPLBookRegistry sharedRegistry] save];
+        [self updateCatalogFeedSettingCurrentAccount:account];
+      }
+    }]];
+  }
+
+  [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"ManageAccounts", nil) style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
+    NSUInteger tabCount = [[[NYPLRootTabBarController sharedController] viewControllers] count];
+    UISplitViewController *splitViewVC = [[[NYPLRootTabBarController sharedController] viewControllers] lastObject];
+    UINavigationController *masterNavVC = [[splitViewVC viewControllers] firstObject];
+    [masterNavVC popToRootViewControllerAnimated:NO];
+    [[NYPLRootTabBarController sharedController] setSelectedIndex:tabCount-1];
+    NYPLSettingsPrimaryTableViewController *tableVC = [[masterNavVC viewControllers] firstObject];
+    [tableVC.delegate settingsPrimaryTableViewController:tableVC didSelectItem:NYPLSettingsPrimaryTableViewControllerItemAccount];
+  }]];
+
+  [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil) style:(UIAlertActionStyleCancel) handler:nil]];
+
+  [[NYPLRootTabBarController sharedController] safelyPresentViewController:alert animated:YES completion:nil];
+}
+
+- (void)updateCatalogFeedSettingCurrentAccount:(Account *)account
+{
+  [AccountsManager shared].currentAccount = account;
+  NYPLCatalogNavigationController * catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
+  [catalog updateFeedAndRegistryOnAccountChange];
+
+  UIViewController *visibleVC = self.visibleViewController;
+  visibleVC.navigationItem.title = [AccountsManager shared].currentAccount.name;
+}
+#endif
+
+@end

--- a/Simplified/Catalog/NYPLCatalogNavigationController.h
+++ b/Simplified/Catalog/NYPLCatalogNavigationController.h
@@ -1,7 +1,9 @@
 // Despite the name, this class has nothing to do with OPDS navigation feeds. It's simply the
 // UINavigationController for the catalog portion of the application.
 
-@interface NYPLCatalogNavigationController : UINavigationController
+#import "NYPLLibraryNavigationController.h"
+
+@interface NYPLCatalogNavigationController : NYPLLibraryNavigationController
 
 - (id)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (id)initWithNavigationBarClass:(Class)navigationBarClass

--- a/Simplified/Catalog/NYPLCatalogNavigationController.m
+++ b/Simplified/Catalog/NYPLCatalogNavigationController.m
@@ -1,25 +1,11 @@
+#import "SimplyE-Swift.h"
 #import "NYPLCatalogFeedViewController.h"
 #import "NYPLConfiguration.h"
-
 #import "NYPLCatalogNavigationController.h"
-
 #import "NYPLAccountSignInViewController.h"
 #import "NYPLBookRegistry.h"
 #import "NYPLRootTabBarController.h"
-#import "NYPLMyBooksNavigationController.h"
-#import "NYPLMyBooksViewController.h"
-#import "NYPLHoldsNavigationController.h"
-#ifdef SIMPLYE
-// TODO: SIMPLY-3053 this #ifdef can be removed once this ticket is done
-#import "NYPLSettingsPrimaryTableViewController.h"
-#endif
-#import "SimplyE-Swift.h"
-#import "NYPLAppDelegate.h"
 #import "NSString+NYPLStringAdditions.h"
-
-#if defined(FEATURE_DRM_CONNECTOR)
-#import <ADEPT/ADEPT.h>
-#endif
 
 @interface NYPLCatalogNavigationController()
 
@@ -59,17 +45,10 @@
 
 #ifdef SIMPLYE
   self.viewController.navigationItem.title = [AccountsManager shared].currentAccount.name;
-  
-  // The top-level view controller uses the same image used for the tab bar in place of the usual
-  // title text.
-  self.viewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc]
-                                                          initWithImage:[UIImage imageNamed:@"Catalog"] style:(UIBarButtonItemStylePlain)
-                                                          target:self
-                                                          action:@selector(switchLibrary)];
-  self.viewController.navigationItem.leftBarButtonItem.accessibilityLabel = NSLocalizedString(@"AccessibilitySwitchLibrary", nil);
-  
-  self.viewController.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Catalog", nil) style:UIBarButtonItemStylePlain target:nil action:nil];
+  [self setNavigationLeftBarButtonForVC:self.viewController];
 #endif
+
+  self.viewController.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Catalog", nil) style:UIBarButtonItemStylePlain target:nil action:nil];
 
   self.viewControllers = @[self.viewController];
 }
@@ -116,66 +95,6 @@
 }
 
 #ifdef SIMPLYE
-- (void)switchLibrary
-{
-  UIViewController *viewController = self.visibleViewController;
-
-  UIAlertControllerStyle style;
-  if (viewController && viewController.navigationItem.leftBarButtonItem) {
-    style = UIAlertControllerStyleActionSheet;
-  } else {
-    style = UIAlertControllerStyleAlert;
-  }
-
-  UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"PickYourLibrary", nil) message:nil preferredStyle:style];
-  alert.popoverPresentationController.barButtonItem = viewController.navigationItem.leftBarButtonItem;
-  alert.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp;
-
-  NSArray *accounts = [[NYPLSettings sharedSettings] settingsAccountsList];
-
-  for (int i = 0; i < (int)accounts.count; i++) {
-    Account *account = [[AccountsManager sharedInstance] account:accounts[i]];
-    if (!account) {
-      continue;
-    }
-
-    [alert addAction:[UIAlertAction actionWithTitle:account.name style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
-
-      BOOL workflowsInProgress;
-#if defined(FEATURE_DRM_CONNECTOR)
-      workflowsInProgress = ([NYPLADEPT sharedInstance].workflowsInProgress || [NYPLBookRegistry sharedRegistry].syncing == YES);
-#else
-      workflowsInProgress = ([NYPLBookRegistry sharedRegistry].syncing == YES);
-#endif
-
-      if (workflowsInProgress) {
-        [self presentViewController:[NYPLAlertUtils
-                                     alertWithTitle:@"PleaseWait"
-                                     message:@"PleaseWaitMessage"]
-                           animated:YES
-                         completion:nil];
-      } else {
-        [[NYPLBookRegistry sharedRegistry] save];
-        [self updateCatalogFeedSettingCurrentAccount:account];
-      }
-    }]];
-  }
-  
-  [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"ManageAccounts", nil) style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
-    NSUInteger tabCount = [[[NYPLRootTabBarController sharedController] viewControllers] count];
-    UISplitViewController *splitViewVC = [[[NYPLRootTabBarController sharedController] viewControllers] lastObject];
-    UINavigationController *masterNavVC = [[splitViewVC viewControllers] firstObject];
-    [masterNavVC popToRootViewControllerAnimated:NO];
-    [[NYPLRootTabBarController sharedController] setSelectedIndex:tabCount-1];
-    NYPLSettingsPrimaryTableViewController *tableVC = [[masterNavVC viewControllers] firstObject];
-    [tableVC.delegate settingsPrimaryTableViewController:tableVC didSelectItem:NYPLSettingsPrimaryTableViewControllerItemAccount];
-  }]];
-
-  [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil) style:(UIAlertActionStyleCancel) handler:nil]];
-
-  [[NYPLRootTabBarController sharedController] safelyPresentViewController:alert animated:YES completion:nil];
-}
-
 - (void)updateCatalogFeedSettingCurrentAccount:(Account *)account
 {
   [account loadAuthenticationDocumentUsingSignedInStateProvider:nil completion:^(BOOL success) {

--- a/Simplified/NYPLHoldsNavigationController.h
+++ b/Simplified/NYPLHoldsNavigationController.h
@@ -1,4 +1,6 @@
-@interface NYPLHoldsNavigationController : UINavigationController
+#import "NYPLLibraryNavigationController.h"
+
+@interface NYPLHoldsNavigationController : NYPLLibraryNavigationController
 
 - (id)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (id)initWithNavigationBarClass:(Class)navigationBarClass

--- a/Simplified/NYPLHoldsNavigationController.m
+++ b/Simplified/NYPLHoldsNavigationController.m
@@ -1,43 +1,24 @@
-#import "NYPLHoldsViewController.h"
-
-#import "NYPLHoldsNavigationController.h"
-
-#import "NYPLBookRegistry.h"
-#import "NYPLConfiguration.h"
-#import "NYPLRootTabBarController.h"
-#import "NYPLCatalogNavigationController.h"
-
-#ifdef SIMPLYE
-// TODO: SIMPLY-3053 this #ifdef can be removed once this ticket is done
-#import "NYPLSettingsPrimaryTableViewController.h"
-#endif
-
 #import "SimplyE-Swift.h"
 
-#if defined(FEATURE_DRM_CONNECTOR)
-#import <ADEPT/ADEPT.h>
-#endif
+#import "NYPLHoldsViewController.h"
+#import "NYPLHoldsNavigationController.h"
+
 
 @implementation NYPLHoldsNavigationController
 
-#pragma mark NSObject
+#pragma mark - NSObject
 
 - (instancetype)init
 {
-  NYPLHoldsViewController *holdsViewController = [[NYPLHoldsViewController alloc] init];
-  self = [super initWithRootViewController:holdsViewController];
+  NYPLHoldsViewController *vc = [[NYPLHoldsViewController alloc] init];
+  self = [super initWithRootViewController:vc];
   if(!self) return nil;
   
   self.tabBarItem.image = [UIImage imageNamed:@"Holds"];
-  [holdsViewController updateBadge];
+  [vc updateBadge];
 
 #ifdef SIMPLYE
-  holdsViewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc]
-                                                          initWithImage:[UIImage imageNamed:@"Catalog"] style:(UIBarButtonItemStylePlain)
-                                                          target:self
-                                                          action:@selector(switchLibrary)];
-  holdsViewController.navigationItem.leftBarButtonItem.accessibilityLabel = NSLocalizedString(@"AccessibilitySwitchLibrary", nil);
-  holdsViewController.navigationItem.leftBarButtonItem.enabled = YES;
+  [self setNavigationLeftBarButtonForVC:vc];
 #endif
 
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(currentAccountChanged) name:NSNotification.NYPLCurrentAccountDidChange object:nil];
@@ -50,14 +31,17 @@
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
+#pragma mark - UIViewController
+
 -(void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
   
-  NYPLHoldsViewController *viewController = (NYPLHoldsViewController *)self.visibleViewController;
-  
-  viewController.navigationItem.title = [AccountsManager shared].currentAccount.name;
+  UIViewController *visibleVC = self.visibleViewController;
+  visibleVC.navigationItem.title = [AccountsManager shared].currentAccount.name;
 }
+
+#pragma mark - Callbacks
 
 - (void)currentAccountChanged
 {
@@ -69,77 +53,5 @@
     [self popToRootViewControllerAnimated:NO];
   }
 }
-
-#ifdef SIMPLYE
-- (void)switchLibrary
-{
-  UIViewController *viewController = self.visibleViewController;
-
-  UIAlertControllerStyle style;
-  if (viewController && viewController.navigationItem.leftBarButtonItem) {
-    style = UIAlertControllerStyleActionSheet;
-  } else {
-    style = UIAlertControllerStyleAlert;
-  }
-
-  UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"PickYourLibrary", nil) message:nil preferredStyle:style];
-  alert.popoverPresentationController.barButtonItem = viewController.navigationItem.leftBarButtonItem;
-  alert.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp;
-
-  NSArray *accounts = [[NYPLSettings sharedSettings] settingsAccountsList];
-
-  for (int i = 0; i < (int)accounts.count; i++) {
-    Account *account = [[AccountsManager sharedInstance] account:accounts[i]];
-    if (!account) {
-      continue;
-    }
-
-    [alert addAction:[UIAlertAction actionWithTitle:account.name style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
-
-      BOOL workflowsInProgress;
-#if defined(FEATURE_DRM_CONNECTOR)
-      workflowsInProgress = ([NYPLADEPT sharedInstance].workflowsInProgress || [NYPLBookRegistry sharedRegistry].syncing == YES);
-#else
-      workflowsInProgress = ([NYPLBookRegistry sharedRegistry].syncing == YES);
-#endif
-
-      if (workflowsInProgress) {
-        [self presentViewController:[NYPLAlertUtils
-                                     alertWithTitle:@"PleaseWait"
-                                     message:@"PleaseWaitMessage"]
-                           animated:YES
-                         completion:nil];
-      } else {
-        [[NYPLBookRegistry sharedRegistry] save];
-        [self updateCatalogFeedSettingCurrentAccount:account];
-      }
-    }]];
-  }
-
-  [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"ManageAccounts", nil) style:(UIAlertActionStyleDefault) handler:^(__unused UIAlertAction *_Nonnull action) {
-    NSUInteger tabCount = [[[NYPLRootTabBarController sharedController] viewControllers] count];
-    UISplitViewController *splitViewVC = [[[NYPLRootTabBarController sharedController] viewControllers] lastObject];
-    UINavigationController *masterNavVC = [[splitViewVC viewControllers] firstObject];
-    [masterNavVC popToRootViewControllerAnimated:NO];
-    [[NYPLRootTabBarController sharedController] setSelectedIndex:tabCount-1];
-    NYPLSettingsPrimaryTableViewController *tableVC = [[masterNavVC viewControllers] firstObject];
-    [tableVC.delegate settingsPrimaryTableViewController:tableVC didSelectItem:NYPLSettingsPrimaryTableViewControllerItemAccount];
-  }]];
-
-  [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil) style:(UIAlertActionStyleCancel) handler:nil]];
-
-  [[NYPLRootTabBarController sharedController] safelyPresentViewController:alert animated:YES completion:nil];
-}
-
-- (void)updateCatalogFeedSettingCurrentAccount:(Account *)account
-{
-  [AccountsManager shared].currentAccount = account;
-  NYPLCatalogNavigationController * catalog = (NYPLCatalogNavigationController*)[NYPLRootTabBarController sharedController].viewControllers[0];
-  [catalog updateFeedAndRegistryOnAccountChange];
-
-  UIViewController *visibleVC = self.visibleViewController;
-  visibleVC.navigationItem.title = [AccountsManager shared].currentAccount.name;
-}
-#endif
 
 @end

--- a/Simplified/NYPLMyBooksNavigationController.h
+++ b/Simplified/NYPLMyBooksNavigationController.h
@@ -1,4 +1,6 @@
-@interface NYPLMyBooksNavigationController : UINavigationController
+#import "NYPLLibraryNavigationController.h"
+
+@interface NYPLMyBooksNavigationController : NYPLLibraryNavigationController
 
 - (id)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (id)initWithNavigationBarClass:(Class)navigationBarClass


### PR DESCRIPTION
**What's this do?**
The common "switchLibrary" logic (shared verbatim by the Holds and MyBooks nav controllers, and minimally differently in the Catalog nav controller) is now moved to a common superclass NYPLLibraryNavigationController.

The moved code does not have any changes whatsoever. Just a cut and paste. Similar story for `setNavigationLeftBarButtonForVC ` and `updateCatalogFeedSettingCurrentAccount`.

This also fixes the build for SimplyECardCreator target in a separate commit.

**Why are we doing this? (w/ JIRA link if applicable)**
There's no ticket for this but I noticed this code "triplication" while working on SIMPLY-3091 and I couldn't bear to see that any longer. The superclass solution is not super great either but it was quick, and it's definitely better than before, so in the limited time I have I decided to do that for now.

**How should this be tested? / Do these changes have associated tests?**
Perhaps I should create a note to make sure that the switchLibrary functionality is tested. If not I'll make sure QA knows about this.

**Dependencies for merging? Releasing to production?**
no

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 