### PR TITLE
SIMPLY-3101: Disable Copy action for Open eBooks in eReader

### DIFF
--- a/Simplified/AppInfrastructure/NYPLLibraryNavigationController.m
+++ b/Simplified/AppInfrastructure/NYPLLibraryNavigationController.m
@@ -39,6 +39,7 @@
   vc.navigationItem.leftBarButtonItem.accessibilityLabel = NSLocalizedString(@"AccessibilitySwitchLibrary", nil);
 }
 
+// for converting this to Swift, see https://bit.ly/3mM9QoH
 - (void)switchLibrary
 {
   UIViewController *viewController = self.visibleViewController;

--- a/Simplified/Catalog/NYPLCatalogNavigationController.m
+++ b/Simplified/Catalog/NYPLCatalogNavigationController.m
@@ -245,7 +245,7 @@
 #endif
 }
 
--(void) welcomeScreenCompletionHandlerForAccount:(Account *const)account
+- (void)welcomeScreenCompletionHandlerForAccount:(Account *const)account
 {
   [[NYPLSettings sharedSettings] setUserHasSeenWelcomeScreen:YES];
   [[NYPLBookRegistry sharedRegistry] save];
@@ -253,8 +253,6 @@
   [self dismissViewControllerAnimated:YES completion:^{
     [self updateFeedAndRegistryOnAccountChange];
   }];
-//  [self updateFeedAndRegistryOnAccountChange];
-//  [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end

--- a/Simplified/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/NYPLMyBooksDownloadCenter.m
@@ -1241,10 +1241,10 @@ didFinishDownload:(BOOL)didFinishDownload
                                metadata:@{
                                  @"adeptError": adeptError ?: @"N/A",
                                  @"fileURLToRemove": adeptToURL ?: @"N/A",
-                                 @"book": book.loggableDictionary,
-                                 @"AdobeFulfilmmentID": fulfillmentID,
-                                 @"AdobeRights": rights,
-                                 @"AdobeTag": tag
+                                 @"book": book.loggableDictionary ?: @"N/A",
+                                 @"AdobeFulfilmmentID": fulfillmentID ?: @"N/A",
+                                 @"AdobeRights": rights ?: @"N/A",
+                                 @"AdobeTag": tag ?: @"N/A"
                                }];
       [self failDownloadForBook:book];
       return;
@@ -1267,10 +1267,10 @@ didFinishDownload:(BOOL)didFinishDownload
                                  @"copyError": copyError ?: @"N/A",
                                  @"fromURL": adeptToURL ?: @"N/A",
                                  @"destURL": destURL ?: @"N/A",
-                                 @"book": book.loggableDictionary,
-                                 @"AdobeFulfilmmentID": fulfillmentID,
-                                 @"AdobeRights": rights,
-                                 @"AdobeTag": tag
+                                 @"book": book.loggableDictionary ?: @"N/A",
+                                 @"AdobeFulfilmmentID": fulfillmentID ?: @"N/A",
+                                 @"AdobeRights": rights ?: @"N/A",
+                                 @"AdobeTag": tag ?: @"N/A"
                                }];
     }
   } else {
@@ -1280,10 +1280,10 @@ didFinishDownload:(BOOL)didFinishDownload
                              metadata:@{
                                @"adeptError": adeptError ?: @"N/A",
                                @"adeptToURL": adeptToURL ?: @"N/A",
-                               @"book": book.loggableDictionary,
-                               @"AdobeFulfilmmentID": fulfillmentID,
-                               @"AdobeRights": rights,
-                               @"AdobeTag": tag
+                               @"book": book.loggableDictionary ?: @"N/A",
+                               @"AdobeFulfilmmentID": fulfillmentID ?: @"N/A",
+                               @"AdobeRights": rights ?: @"N/A",
+                               @"AdobeTag": tag ?: @"N/A"
                              }];
   }
 

--- a/Simplified/WelcomeScreen/OETutorialChoiceViewController.swift
+++ b/Simplified/WelcomeScreen/OETutorialChoiceViewController.swift
@@ -41,7 +41,8 @@ class OETutorialChoiceViewController : UIViewController {
     
     title = NSLocalizedString("Log In", comment: "")
     
-    descriptionLabel.font = UIFont.systemFont(ofSize: 20.0)
+    descriptionLabel.font = UIFont(name: NYPLConfiguration.systemFontFamilyName(),
+                                   size: 20.0)
     descriptionLabel.text = NSLocalizedString("You need to login to access the collection.", comment: "")
     descriptionLabel.textAlignment = .center
     descriptionLabel.numberOfLines = 0

--- a/Simplified/WelcomeScreen/OETutorialEligibilityViewController.swift
+++ b/Simplified/WelcomeScreen/OETutorialEligibilityViewController.swift
@@ -31,7 +31,8 @@ class OETutorialEligibilityViewController : UIViewController {
     }
     
     self.descriptionLabel = UILabel(frame: CGRect.zero)
-    self.descriptionLabel.font = UIFont.systemFont(ofSize: 20.0)
+    self.descriptionLabel.font = UIFont(name: NYPLConfiguration.systemFontFamilyName(),
+                                        size: 20.0)
     self.descriptionLabel.text = NSLocalizedString("TutorialEligibilityViewControllerDescription", comment: "Description of Open eBooks app displayed during 1st launch tutorial")
     self.descriptionLabel.textAlignment = .center
     self.descriptionLabel.numberOfLines = 0

--- a/Simplified/WelcomeScreen/OETutorialWelcomeViewController.swift
+++ b/Simplified/WelcomeScreen/OETutorialWelcomeViewController.swift
@@ -34,7 +34,8 @@ class OETutorialWelcomeViewController : UIViewController {
     
     self.view.addSubview(self.logoImageView)
     
-    self.descriptionLabel.font = UIFont.systemFont(ofSize: 20.0)
+    self.descriptionLabel.font = UIFont(name: NYPLConfiguration.systemFontFamilyName(),
+                                        size: 20.0)
     self.descriptionLabel.text = NSLocalizedString("TutorialWelcomeViewControllerDescription", comment: "Welcome text for Open eBooks")
     self.descriptionLabel.textAlignment = .center
     self.descriptionLabel.numberOfLines = 0


### PR DESCRIPTION
**What's this do?**
Disables Copy action in contextual menu inside the eReader for OE. SimplyE is not affected.

Unrelated (in separate commits): fix fonts in OE tutorial and fixed a possible crash I observed in some cases for nil dictionary values.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3101

**How should this be tested? / Do these changes have associated tests?**
Open eReader for OE. Hold press on a word. On iOS 11+ you should not see the Copy option. On iOS <= 10 you will see it, but if you select it nothing should be copied.
Copy should still be available on SimplyE on all versions of iOS.

**Dependencies for merging? Releasing to production?**
Non breaking for SimplyE

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 