### PR TITLE
SIMPLY-3153 Added support for books with content-type of application/octet-stream

### DIFF
--- a/Simplified/NYPLBookAcquisitionPath.h
+++ b/Simplified/NYPLBookAcquisitionPath.h
@@ -12,6 +12,7 @@ static NSString * const _Nonnull ContentTypeFindaway = @"application/vnd.library
 static NSString * const _Nonnull ContentTypeOpenAccessAudiobook = @"application/audiobook+json";
 static NSString * const _Nonnull ContentTypeOpenAccessPDF = @"application/pdf";
 static NSString * const _Nonnull ContentTypeFeedbooksAudiobook = @"application/audiobook+json;profile=\"http://www.feedbooks.com/audiobooks/access-restriction\"";
+static NSString * const _Nonnull ContentTypeOctetStream = @"application/octet-stream";
 extern NSString * const _Nonnull ContentTypeOverdriveAudiobook;
 
 

--- a/Simplified/NYPLBookAcquisitionPath.h
+++ b/Simplified/NYPLBookAcquisitionPath.h
@@ -4,15 +4,15 @@
 // enum.
 #import "NYPLOPDSAcquisition.h"
 
-static NSString * const _Nonnull ContentTypeOPDSCatalog = @"application/atom+xml;type=entry;profile=opds-catalog";
-static NSString * const _Nonnull ContentTypeAdobeAdept = @"application/vnd.adobe.adept+xml";
-static NSString * const _Nonnull ContentTypeBearerToken = @"application/vnd.librarysimplified.bearer-token+json";
-static NSString * const _Nonnull ContentTypeEpubZip = @"application/epub+zip";
-static NSString * const _Nonnull ContentTypeFindaway = @"application/vnd.librarysimplified.findaway.license+json";
-static NSString * const _Nonnull ContentTypeOpenAccessAudiobook = @"application/audiobook+json";
-static NSString * const _Nonnull ContentTypeOpenAccessPDF = @"application/pdf";
-static NSString * const _Nonnull ContentTypeFeedbooksAudiobook = @"application/audiobook+json;profile=\"http://www.feedbooks.com/audiobooks/access-restriction\"";
-static NSString * const _Nonnull ContentTypeOctetStream = @"application/octet-stream";
+extern NSString * const _Nonnull ContentTypeOPDSCatalog;
+extern NSString * const _Nonnull ContentTypeAdobeAdept;
+extern NSString * const _Nonnull ContentTypeBearerToken;
+extern NSString * const _Nonnull ContentTypeEpubZip;
+extern NSString * const _Nonnull ContentTypeFindaway;
+extern NSString * const _Nonnull ContentTypeOpenAccessAudiobook;
+extern NSString * const _Nonnull ContentTypeOpenAccessPDF;
+extern NSString * const _Nonnull ContentTypeFeedbooksAudiobook;
+extern NSString * const _Nonnull ContentTypeOctetStream;
 extern NSString * const _Nonnull ContentTypeOverdriveAudiobook;
 
 

--- a/Simplified/NYPLBookAcquisitionPath.m
+++ b/Simplified/NYPLBookAcquisitionPath.m
@@ -2,6 +2,15 @@
 
 #import "NYPLBookAcquisitionPath.h"
 
+NSString * const _Nonnull ContentTypeOPDSCatalog = @"application/atom+xml;type=entry;profile=opds-catalog";
+NSString * const _Nonnull ContentTypeAdobeAdept = @"application/vnd.adobe.adept+xml";
+NSString * const _Nonnull ContentTypeBearerToken = @"application/vnd.librarysimplified.bearer-token+json";
+NSString * const _Nonnull ContentTypeEpubZip = @"application/epub+zip";
+NSString * const _Nonnull ContentTypeFindaway = @"application/vnd.librarysimplified.findaway.license+json";
+NSString * const _Nonnull ContentTypeOpenAccessAudiobook = @"application/audiobook+json";
+NSString * const _Nonnull ContentTypeOpenAccessPDF = @"application/pdf";
+NSString * const _Nonnull ContentTypeFeedbooksAudiobook = @"application/audiobook+json;profile=\"http://www.feedbooks.com/audiobooks/access-restriction\"";
+NSString * const _Nonnull ContentTypeOctetStream = @"application/octet-stream";
 NSString * const _Nonnull ContentTypeOverdriveAudiobook = @"application/vnd.overdrive.circulation.api+json;profile=audiobook";
 
 @interface NYPLBookAcquisitionPath ()

--- a/Simplified/NYPLBookAcquisitionPath.m
+++ b/Simplified/NYPLBookAcquisitionPath.m
@@ -41,7 +41,8 @@ NSString * const _Nonnull ContentTypeOverdriveAudiobook = @"application/vnd.over
       ContentTypeOpenAccessAudiobook,
       ContentTypeOpenAccessPDF,
       ContentTypeFeedbooksAudiobook,
-      ContentTypeOverdriveAudiobook
+      ContentTypeOverdriveAudiobook,
+      ContentTypeOctetStream
     ]];
   }
 
@@ -62,7 +63,8 @@ NSString * const _Nonnull ContentTypeOverdriveAudiobook = @"application/vnd.over
         ContentTypeOpenAccessPDF,
         ContentTypeOpenAccessAudiobook,
         ContentTypeFeedbooksAudiobook,
-        ContentTypeOverdriveAudiobook
+        ContentTypeOverdriveAudiobook,
+        ContentTypeOctetStream
       ]],
       ContentTypeAdobeAdept: [NSSet setWithArray:@[ContentTypeEpubZip]],
       ContentTypeBearerToken: [NSSet setWithArray:@[


### PR DESCRIPTION
**What's this do?**
Adds support for books with `Content-type` of `application/octet-stream`.

**Why are we doing this? (w/ JIRA link if applicable)**
Columbia University Libraries - Demo books fail to download because of that unsupported content type.
https://jira.nypl.org/browse/SIMPLY-3153

**How should this be tested? / Do these changes have associated tests?**
Open Columbia University Libraries - Demo library and download "Mathematical Theory of Advanced Computing"

**Dependencies for merging? Releasing to production?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@vladimirfedorov 