### PR TITLE
SIMPLY-3052 Show EULA on 1st launch for OE

### DIFF
--- a/OpenEbooks/eula.html
+++ b/OpenEbooks/eula.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>End User License Agreement</title>
+</head>
+<body>
+<font face="arial">
+	<p><strong>Open eBooks App</br>
+End User License Agreement</strong></p>
+
+<p>Last Updated: 05/01/2016</p>
+
+<div>
+
+<p>This End User License Agreement (“EULA”) is a legal agreement made between The New York Public Library, Astor, Lenox, and Tilden Foundations (“NYPL”) and you (“you” and “your”) as a licensee and user of NYPL Open eBooks’ machine-readable object code (“the Software”), an eReader application for mobile devices developed and distributed by NYPL for the purpose of providing qualified low-income children free access to ebooks (“Content”) as described at <a href="https://openebooks.net/about.html">https://openebooks.net/about.html</a> (last visited 05/01/2016).  The Open eBooks initiative has been spearheaded by NYPL, Digital Public Library of America (“DPLA”) and First Book (“FB”) (collectively, the “Open eBooks Parties” and each individually an “Open eBooks Party”) in conjunction with and support from The White House, The United States Institute of Museum and Library Services (“IMLS”), book distributor Baker & Taylor Inc. (“B&T”) and Content publishers. By clicking the "Accept" button associated with this EULA or using the Software, you are confirming your acceptance of the Software and are agreeing to become bound by this EULA. If you do not agree to be bound by these terms, then you may not use the Software. Failure to abide by the terms of this EULA may result in termination of your access to the Software, Content, and any related websites or applications controlled by any of the Open eBook Parties. Notwithstanding the foregoing, software having a separate end user license agreement shall be covered by such a separate end user license agreement and shall be expressly excluded from the definition of Software.</p>
+
+<strong>I. Grant of License to Software </strong>
+
+<p>A. NYPL grants you a non-exclusive, non-assignable, non-transferable, limited license to the Software in machine-readable code only for your personal, non-commercial use. The Software is licensed as a single product, and not sold. </p>
+
+<p>B. You shall not: </p>
+
+<p>(1)	copy, rent, lease, sell, repair, transfer, assign, sublicense, disassemble, circumvent,  reverse engineer or decompile, modify or alter the Software including, but not limited to, translating or creating derivative works, under any circumstances;</br>
+(2)	separate the Software into its component parts for independent use;</br>
+(3)	remove any proprietary notices and/or labels on or in the Software; and/or</br>
+(4)	use the Software for any commercial or illegal purpose. </br></p>
+
+<p>C. End User Terms Required by Adobe. The Software contains Adobe DRM (“the Adobe Software”) licensed in an arrangement with Adobe Systems Incorporated (“Adobe”), a Delaware corporation having a place of business at 345 Park Avenue, San Jose, CA 95110-2704, and with webqem pty ltd (the “Adobe Supplier”), a corporation having a place of business at 59 Backland Road, Atlanta, GA 30342. As a condition of that license, you agree to be bound by the specific terms of this subsection. This subsection limits your use of the Adobe Software, and also requires you to use the Adobe License Signing Service (the “Adobe Service”), and comply with its terms, when using the Adobe Software.  You agree as follows: </p>
+
+<p>1.	No Modification or Reverse Engineering </p>
+
+<p>You specifically acknowledge and agree that other than as expressly set forth in this EULA, you shall not modify, port, adapt or translate the Adobe Software or its documentation. You will not reverse-engineer, decompile, disassemble, or otherwise attempt to derive the source code of the Adobe Software not supplied to you in source code form. Notwithstanding the foregoing, decompiling the Adobe Software is permitted to the extent that the laws of a jurisdiction give you the right to do so to obtain information necessary to render the Adobe Software interoperable with other software; provided, however, that you must first request such information from Adobe or the Adobe Supplier, and Adobe or the Adobe Supplier may, in their discretion, either provide such information to you or impose reasonable conditions, including a reasonable fee, on such use of the Adobe Software to ensure that Adobe and the Adobe Supplier’s proprietary rights in the Adobe Software are protected. </p>
+
+<p>2.	Proprietary Notices</p>
+
+<p>You agree that as a condition of your rights hereunder, each copy of the Adobe Software and its documentation shall contain the same proprietary notices of Adobe, the Adobe Supplier, and their suppliers that appear in such Adobe Software or documentation provided by the Adobe Supplier, and as otherwise may be reasonably required by the Adobe Supplier. </p>
+
+<p>3.	Ownership </p>
+
+<p>Adobe, the Adobe Supplier, and their suppliers are the sole and exclusive owners of all rights, title and interest, including all trademarks, copyrights, patents, trade names, trade secrets, and other intellectual property rights in and to the Adobe Software. Except for the rights expressly granted in this EULA, you are not granted any rights to patents, copyrights, trade secrets, trade names, trademarks (whether or not registered), or any other rights, franchises or licenses with respect to the Adobe Software or its documentation, and you agree that you will not exceed the scope of the licenses granted herein. There are no implied licenses granted under this EULA, and all rights not expressly granted to you in this EULA are reserved. </p>
+
+<p>4.	Log-In Information</p>
+
+<p>To gain access to and use the Adobe Service, you may be required to create an ID and password or other log-in ID and password issued by Adobe (“Log-In Information”). You are responsible for all activity occurring under your Log-In Information, and you must keep your Log-In Information confidential and not share your Log-In Information with third parties. Adobe has no obligation or responsibility with regard to your use, distribution, disclosure, or management of Log-In Information. Notwithstanding the foregoing, Adobe may require you to change your Log-In Information if such Log-In Information is inconsistent with the terms of this EULA. </p>
+
+<p>5.	The Adobe Service</p>
+
+<p>You will use the Adobe Software only when the Adobe Software is integrated with the Adobe Service. You agree that Adobe will collect, transmit and use the eBook Transaction Data to provide the Adobe Service and to enable billing under the applicable pricing models. You have adequate rights to allow Adobe, for such collection, use and sharing of eBook Transaction Data. eBook Transaction Data means all the data required to provide the Adobe Service, for digital content, primarily eBooks; which shall include but is not limited to the Adobe Software version, fulfillment ID, transaction type (permanent or expiring), eBook metadata like geo, subscription ID, price, currency, epub version, resource type (epub/PDF), or users Internet Protocol. </p>
+
+<p>6.	Use Restrictions </p>
+
+<p>a)	In connection with your access or use of the Adobe Service, you will not:  introduce a virus, worm, Trojan horse or other harmful software code or similar files that may damage the operation of a third party’s computer or property or information;</br>
+
+b)	use the Adobe Service in any manner that could damage, disable, overburden, or impair any server, or the network(s) connected to any server or interfere with any other party’s use and enjoyment of the Adobe Service; </br>
+
+c)	attempt to gain unauthorized access to service, materials, other accounts, computer systems or networks connected to any server or to the Adobe Service, through hacking, password mining, or any other means; </br>
+
+d)	obtain or attempt to obtain any materials or information through any means not intentionally made available through the Adobe Service; </br>
+
+e)	host, on a subscription basis or otherwise, the Adobe Service, including any related application, to permit a third party to use the Adobe Service to create, transmit, or protect any content; </br>
+
+f)	engage in any systematic extraction of data or data fields, including without limitation email addresses; </br>
+
+g)	disclose, harvest, or otherwise collect information, including email addresses, or other private Information about any third party without the party’s express consent; </br>
+
+h)	transmit junk mail, spam, surveys, contests, pyramid schemes, chain letters, or other unsolicited e-mail or duplicative messages; </br>
+
+i)	sell, lease, or rent access to or use of the Adobe Service, or otherwise transfer any rights to use the Adobe Service under this EULA (including without limitation, on a timeshare or service bureau basis); or </br>
+
+j)	defraud, defame, abuse, harass, stalk, threaten, or otherwise violate the legal rights (such as rights of privacy and publicity) of others.</br> </p>
+
+<p>7.	Termination of Service </p>
+
+<p>Upon your material breach of a provision of this EULA respecting the Adobe Service, Adobe or the Adobe Supplier may discontinue your access to the Adobe Service. </p>
+
+<p>8.	Termination of Vendor ID </p>
+
+<p>Adobe or the Adobe Supplier may terminate any Vendor ID in the event that it believes, in its sole and absolute discretion, that continued use of the Vendor ID, may compromise the effectiveness of the Adobe Software or the Adobe Service. </p>
+<p>D. Violation of any of the above restrictions may result in a termination of your ability to access the Software. NYPL reserves any and all rights or remedies that may be available in the event of your breach of this EULA.  </p>
+
+<strong>II. Grant of License to eBook Content Accessed Through the Software</strong>
+
+<p>A. Multiple Providers; Multiple Licenses.  The Open eBook Parties may provide their own Content, but have also arranged for you to access the services and Content contributed by publishers, as well as Content from other suppliers (collectively, the “Third Party Content Suppliers”). The Content provided by each of the Third Party Content Suppliers is governed by the applicable Third Party Content Supplier’s own terms and conditions, all of which you must agree to and comply with in order to use the Software and access the Content.  The Open eBook Parties may add new Third Party Content Suppliers from time to time, with notice on its website, and you agree that you will be bound by the terms and conditions of any of these additional Third Party Content Suppliers if you use Content from them. <a href="app_acknowledgments.html">Credits and Acknowledgements</a> section of the Open eBooks app directs you to the terms of some of the different Third Party Content Suppliers, which set out the conditions under which you are licensed to use their Content. </p>
+
+<p>B. Responsibility for Terms. You are solely responsible for knowing the terms and conditions of the different Third Party Content Suppliers in order to use Content from them. Any information provided in this section about the terms of Third Party Content Suppliers is provided for your convenience only, and you acknowledge that any information provided in this section may not reflect the current or accurate terms governing the Third Party Content Suppliers.  You are encouraged to check regularly for updates to the terms of the Third Party Content Suppliers.</p>
+
+<p>C. Independent Transactions. The Open eBook Parties make no representations and shall have no liability or obligation whatsoever in relation to your use of any Content accessed through the Software. Any transaction completed with any of the Third Party Content Suppliers through the Software, and any dispute concerning the terms of service of any of the Third Party Content Suppliers, is between you and the relevant third party, and not the Open eBook Parties.  </p>
+
+<p>D. Violation of any of the above restrictions may result in a termination of your ability to access the Content. </p>
+
+<strong>III.  Ownership</strong>
+<p>A.  Copyright</p>
+<p>Copyright laws and international copyright treaties, as well as other intellectual property laws and treaties, protect the Software and Content. The Software and Content is licensed, not sold and no ownership rights in the Software and Content are transferred to you at any time. You acknowledge and warrant that nothing in this EULA gives you any right, title or interest in the Software and Content. </p>
+<p>B.  Use of the Software with Copyrighted Material</p>
+<p>The Software is capable of being used by you to store, process and use Content created by you and third parties. Such Content may be protected by copyright, other intellectual property laws, and/or agreements. You agree to use the Software only in compliance with all such laws and agreements that apply to such Content. You agree that the NYPL may take appropriate measures to protect the copyright of Content stored, processed or used by the Software. Such measures include, but are not limited to, counting the frequency of your backup and restoration through certain Software features, refusal to accept your request to enable restoration of data, and termination of this EULA in the event of your illegitimate use of the Software or Content.</p>
+
+<strong>IV. Trademarks</strong>
+
+<p>All text, graphics, user interfaces, visual interfaces, photographs, trademarks (whether or not registered), logos, sounds, music, and artwork (collectively, “Marks”), including but not limited to the design, structure, selection, coordination, expression, “look and feel” and arrangement of such Marks, contained on the Software is owned, controlled or licensed by or to Open eBooks Parties and their suppliers, and is protected by trade dress, copyright, patent and trademark laws, and various other intellectual property rights and unfair competition laws. The Marks of Open eBooks Parties and suppliers may not be used without prior written consent of the relevant Open eBooks Parties or suppliers, as the case may be.</p>
+
+<strong>V. Age of Users </strong>
+
+<p>If you are under 18 years of age, you must obtain permission from a parent, legal guardian or school official in order to accept the EULA for the Software.  In compliance with the Children's Online Privacy Protection Act ("COPPA"), as such may be amended from time to time, if you are under the age of 13, you are asked not to provide any information to us either through downloading any Software, using the Software, participating in or entering any promotions, contests or sweepstakes related to the Software, or through any other activity. If we have any knowledge that you are under 13 years of age and without express parental consent, any information you submit will likely not be retained by us, as described in <a href="privacy.html">OEI's Privacy Policy</a> (last visited 05/01/2016). Children using the Internet require special protection, and parents, guardians and school officials should explain Internet safety to their children. Parents, guardians and school officials are urged to spend time online with their children to become familiar with the types of Content available on the Software and the Internet in general. Control tools are available from online services and software manufacturers to help create a safer environment for children. </p>
+
+<strong>VI. Feedback; Usage Data </strong>
+
+<p>Any feedback or suggestions regarding the Software provided by you (“Suggestions”), and any related intellectual property rights, shall be and hereby is non-exclusively licensed to NYPL by you on a perpetual, royalty-free, worldwide, and irrevocable basis. You acknowledge and understand that in connection with your use of the Software and/or Content (“Usage Data”) certain information regarding your use of the Software may be transmitted to the Open eBook Parties and Third Party Content Suppliers. This Usage Data may be collected and used by the Open eBook Parties and Third Party Content Suppliers to provide support services to you, to better tailor the Software to your use, to improve the Software generally, and for research, development, and fundraising purposes.  You hereby consent to such activities.  All Usage Data collection is subject to OEI's Privacy Policy located at <a href="https://openebooks.net/privacy.html">https://openebooks.net/privacy.html</a> (last visited 05/01/2016). </p>
+
+<strong>VII. Privacy Policy </strong>
+
+<p>For information about data protection and collection practices, please read OEI's Privacy Policy located at <a href="https://openebooks.net/privacy.html">https://openebooks.net/privacy.html</a> (last visited 05/01/2016), which is incorporated herein by reference. You agree to the use of your data in accordance with OEI’s Privacy Policy. </p>
+
+<strong>VIII. No Warranties; No Support </strong>
+
+<p>THE SOFTWARE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY OF ANY KIND. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW, THE OPEN EBOOK PARTIES AND THIRD PARTY CONTENT SUPPLIERS DISCLAIM ALL WARRANTIES, REPRESENTATIONS, CONDITIONS, AND DUTIES, WHETHER EXPRESS OR IMPLIED, REGARDING THE SOFTWARE AND/OR CONTENT, INCLUDING, WITHOUT LIMITATION, ANY AND ALL IMPLIED WARRANTIES OF MERCHANTABILITY, ACCURACY, RESULTS OF USE, RELIABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT OF THIRD PARTY RIGHTS. FURTHER, THE OPEN EBOOK PARTIES AND THIRD PART CONTENT SUPPLIERS DISCLAIM ANY WARRANTY THAT YOUR USE OF THE SOFTWARE AND/OR CONTENT WILL BE UNINTERRUPTED, SECURE, TIMELY OR ERROR FREE. YOU ACKNOWLEDGE AND AGREE THAT THIS EULA DOES NOT ENTITLE YOU TO ANY SUPPORT FOR THE SOFTWARE AND/OR CONTENT. NO ADVICE OR INFORMATION, WHETHER ORAL OR IN WRITING, OBTAINED BY YOU FROM THE OPEN EBOOK PARTIES OR THIRD PARTY CONTENT SUPPLIERS WILL CREATE ANY WARRANTY NOT EXPRESSLY STATED IN THIS EULA.  </p>
+
+<strong>IX. Limitation of Liability </strong>
+
+<p>THE SOFTWARE IS BEING PROVIDED BY NYPL FREE OF CHARGE. ACCORDINGLY, YOU AGREE THAT EACH OF THE OPEN EBOOKS PARTIES AND THE THIRD PARTY CONTENT SUPPLIERS SHALL HAVE NO LIABILITY ARISING FROM OR RELATED TO YOUR ACCESS TO AND/OR USE OF THE SOFTWARE AND/OR CONTENT (OR THE OPEN EBOOK PARTIES' SUSPENSION OR TERMINATION OF SUCH ACCESS AND/OR USE). REGARDLESS OF WHETHER ANY REMEDY SET FORTH HEREIN FAILS OF ITS ESSENTIAL PURPOSE OR OTHERWISE, AND EXCEPT FOR BODILY INJURY, IN NO EVENT SHALL THE OPEN EBOOK PARTIES OR THEIR OFFICERS, TRUSTEES, AGENTS, EMPLOYEES, THE THIRD PARTY CONTENT SUPPLIERS OR ANY OF THE OPEN EBOOKS PARTIES BE LIABLE TO YOU OR TO ANY THIRD PARTY UNDER ANY TORT, CONTRACT, NEGLIGENCE, STRICT LIABILITY OR OTHER LEGAL OR EQUITABLE THEORY FOR ANY LOST PROFITS, LOST OR CORRUPTED DATA, COMPUTER FAILURE OR MALFUNCTION, INTERRUPTION OF BUSINESS, OR OTHER SPECIAL, INDIRECT, INCIDENTAL, PUNITIVE, OR CONSEQUENTIAL DAMAGES OF ANY KIND ARISING OUT OF THE USE OR INABILITY TO USE THE SOFTWARE AND/OR CONTENT, EVEN IF THE THIRD PARTY CONTENT SUPPLIERS OR ANY OF THE OPEN EBOOKS PARTIES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH LOSS OR DAMAGES AND WHETHER OR NOT SUCH LOSS OR DAMAGES ARE FORESEEABLE.  </p>
+
+<strong>X. Indemnification</strong>
+
+<p>You agree to indemnify, defend, and hold harmless the Open eBook Parties and their officers, trustees, employees, agents, and their suppliers from any claim or demand, including reasonable attorneys' fees, arising from or in any way related to your use of the Software and/or Content, and/or violation of this EULA.  The Open eBook Parties shall provide you with written notice of any such claim or demand. The Open eBook Parties and Third Party Content Suppliers reserve the right to assume the exclusive defense and control of any matter subject to indemnification by you, which shall not excuse your indemnity obligations. In the event of any settlement of an action, you agree to obtain the relevant Open eBook Parties’ prior written consent to the settlement. </p>
+
+<strong>XI. Digital Millennium Copyright Act </strong>
+
+<p>The Digital Millennium Copyright Act of 1998 (the "DMCA") provides recourse for copyright owners, if you believe in good faith that Content on the Software infringes your copyright, you (or your agent) may send notice to the relevant parties listed in the <a href="https://openebooks.net/app_acknowledgments.html">Credits and Acknowledgements</a> requesting that the material be removed or access to it blocked. </p>
+
+<strong>XII. U.S. Government Rights </strong>
+
+<p>A. The Software licensed hereunder is provided with restricted rights applicable to private and public licenses alike. Without limiting the foregoing, any use, duplication, modification, reproduction, operation, performance, release or disclosure of the Software by the U.S. Government is subject to restrictions as set forth in this EULA and as provided in DFARS 227.7202-1(a) and 227.7202-3(a) (1995), DFARS 252.227-7013 (c)(1)(ii)(OCT 1988), FAR 12.212(a)(1995), FAR 52.227-19, or FAR 52.227-14, as applicable. </p>
+
+<p>B. You agree that by using the Software and accessing Content that: (i) you do not reside in a country subject to embargo or export controls by the U.S. Government; (ii) you are not on the List of Denied Persons as published by the U.S. government; and (iii) you will not use the Software or any Content for any illegal purpose. </p>
+
+<strong>XIII. General Terms</strong>
+
+<p>A. Governing Law.  This EULA shall be governed, interpreted, and enforced by the laws of the State of New York. Any legal action brought involving the Software, Content, and/or EULA shall be brought only in the courts of the State of New York, in the County of New York, or in the federal courts located in such state (and county). Both you and the Open eBook Parties submit to venue and jurisdiction in these courts. In the event that an action or claim arises outside of the exclusive jurisdiction specified herein which names any of the Open eBook Parties as a party, the relevant Open eBook Parties and you specifically agree to initiate, consent to and/or cooperate with any and all efforts to remove the matter to the exclusive jurisdiction named herein, or otherwise take any and all reasonable actions to achieve the objectives of this provision.</p>
+
+<p>B. Entire Agreement. This EULA constitutes the entire agreement and understanding between you and NYPL and supersedes all prior and contemporaneous agreements, understandings, negotiations and proposals, oral or written.</p>
+
+<p>C. Severability. In the event that a court of competent jurisdiction determines that any portion of this EULA is unenforceable, said unenforceability shall not affect any other provision of this EULA.</p>
+
+<strong>XIV. Modification of the EULA and Software </strong>
+
+<p>A. NYPL may modify any of the terms and conditions contained in this EULA at any time and in NYPL’s sole discretion. </p>
+
+<p>B. NYPL may release subsequent versions and/or updated versions of the Software and require you to use the most current version by releasing an automatic update and/or disabling the previous version.  </p>
+
+<p>C. NYPL may conduct maintenance on, stop providing, and/or change the method of access to the Software, and/or Content at any time, with or without notice to you. </p>
+
+<p>D. IF ANY MODIFICATION IS UNACCEPTABLE TO YOU, YOUR SOLE RECOURSE IS TO TERMINATE THIS EULA BY DISCONTINUING USE OF THE SOFTWARE AND REMOVING IT FROM YOUR MOBILE DEVICE. YOUR CONTINUED USAGE OF THE SOFTWARE AND/OR CONTENT FOLLOWING NYPL’S MODIFICATION CONSTITUTES YOUR IRREVOCABLE AND BINDING ACCEPTANCE OF THE CHANGE. </p>
+
+<strong>XV. Termination </strong>
+
+<p>A. The term of this EULA ("Term") shall continue indefinitely unless terminated by NYPL or you in accordance with the provisions herein.</p>
+
+<p>B. NYPL reserves the right, in its sole discretion (for any reason or for no reason) and at any time without notice to you, to modify, suspend or discontinue the Software and/or Content, and/or suspend or terminate your rights under this EULA to access and/or use the Software and/or Content. You may terminate this EULA by discontinuing use of the Software and removing it from your mobile device. </p>
+
+<p>C. Upon termination of this EULA, you shall promptly delete and remove any and all Software and Content in your possession or under your control. Any termination of access to the Software and/or Content will also immediately terminate any and all licenses granted to you hereunder. All disclaimers of warranties and limitation of liability set forth in this EULA shall survive any termination of this EULA.</p>
+
+<strong>XVI. Compliance </strong>
+
+<p>NYPL reserves the right to take steps NYPL believes are reasonably necessary or appropriate to enforce and/or verify compliance with any part of this EULA. You acknowledge and agree that the Open eBook Parties may preserve any transmittal or communication by you with the Open eBook Parties or any third party through the Software or otherwise to this end.  You are advised that any library record or other information collected by NYPL, pursuant to New York CPLR §4509, subject to disclosure upon subpoena, court order, or as otherwise authorized by applicable law. </p>
+
+<strong>XVII. Waiver </strong>
+
+<p>The failure of the Open eBook Parties to exercise or enforce any right or provision of this EULA shall not operate as a waiver of such right or provision, nor shall any course of conduct between the Open eBook Parties and you or any other party be deemed to modify any provision of this EULA.</p>
+
+<strong>XVIII. Automatic Update Feature </strong>
+
+<p>From time to time, NYPL or third parties may automatically update or otherwise modify the Software, including, but not limited to, for purposes of enhancement of security functions, error correction and improvement of functions, at such time as you interact with NYPL's or third parties' servers, or otherwise. Such updates or modifications may delete or change the nature of features or other aspects of the Software, including functions you may rely upon. You hereby agree that such activities may occur at NYPL’s sole discretion and that NYPL may condition continued use of the Software upon your complete installation or acceptance of such update or modifications. Any updates/modifications shall be deemed to be, and shall constitute part of, the Software for purposes of this EULA. By acceptance of this EULA, you consent to such update/modification.</p>
+
+<strong>XIX. Third Party Beneficiaries </strong>
+
+<p>Each Open eBooks Party and Third Party Content Supplier is an express intended third party beneficiary of, and shall have the right to enforce, each provision of this EULA to the extent applicable to such party.</p>
+
+<strong>XX. Contact </strong>
+
+<p>All questions concerning this EULA, Software and/or Content shall be directed to <a href="mailto:openebooks@firstbook.org">openebooks@firstbook.org</a>.</p>
+
+	</div>
+</font>
+</body>
+</html>

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -540,6 +540,8 @@
 		73CEF831252699DD006B2820 /* FirebaseCrashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73CEF82F252699C9006B2820 /* FirebaseCrashlytics.framework */; };
 		73CEF832252699DD006B2820 /* FirebaseCrashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73CEF82F252699C9006B2820 /* FirebaseCrashlytics.framework */; };
 		73DE53312525A386003E2C56 /* NYPLLibraryAccountURLsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE53302525A386003E2C56 /* NYPLLibraryAccountURLsProvider.swift */; };
+		73E64E6A252BB82600276953 /* NYPLEULAViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E64E65252BB82600276953 /* NYPLEULAViewController.swift */; };
+		73E64E6C252BB89A00276953 /* eula.html in Resources */ = {isa = PBXBuildFile; fileRef = 73E64E6B252BB89A00276953 /* eula.html */; };
 		73FB0AC924EB403D0072E430 /* NYPLBookContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FB0AC824EB403D0072E430 /* NYPLBookContentType.swift */; };
 		73FB0ACA24EB403D0072E430 /* NYPLBookContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FB0AC824EB403D0072E430 /* NYPLBookContentType.swift */; };
 		73FCA2A925005BA4001B0C5D /* NYPLLibraryDescriptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0826CD2E24AA2801000F4030 /* NYPLLibraryDescriptionCell.swift */; };
@@ -1277,6 +1279,8 @@
 		73DA43A72404BA5600985482 /* build_curl.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = build_curl.sh; path = scripts/build_curl.sh; sourceTree = SOURCE_ROOT; };
 		73DA43A82404BA5600985482 /* build-openssl-curl.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = "build-openssl-curl.sh"; path = "scripts/build-openssl-curl.sh"; sourceTree = SOURCE_ROOT; };
 		73DE53302525A386003E2C56 /* NYPLLibraryAccountURLsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLLibraryAccountURLsProvider.swift; sourceTree = "<group>"; };
+		73E64E65252BB82600276953 /* NYPLEULAViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLEULAViewController.swift; sourceTree = "<group>"; };
+		73E64E6B252BB89A00276953 /* eula.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = eula.html; sourceTree = "<group>"; };
 		73FB0AC824EB403D0072E430 /* NYPLBookContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NYPLBookContentType.swift; path = Models/NYPLBookContentType.swift; sourceTree = "<group>"; };
 		73FCA3A425005BA4001B0C5D /* Open eBooks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Open eBooks.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		841B55411B740F2700FAC1AF /* NYPLSettingsEULAViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYPLSettingsEULAViewController.h; sourceTree = "<group>"; };
@@ -1963,6 +1967,7 @@
 		738CB2092509AD3B00891F31 /* WelcomeScreen */ = {
 			isa = PBXGroup;
 			children = (
+				73E64E65252BB82600276953 /* NYPLEULAViewController.swift */,
 				E6202A031DD52B8600C99553 /* NYPLWelcomeScreenViewController.swift */,
 				73085E182502DE87008F6244 /* OETutorialChoiceViewController.swift */,
 				730FC05525128D64004D7C2D /* OETutorialEligibilityViewController.swift */,
@@ -2050,6 +2055,7 @@
 				73085E202502E2CD008F6244 /* OpenEBooks_OPDS2_Catalog_Feed.json */,
 				7358EE7B250062BD00DDA0CC /* OEImages.xcassets */,
 				7358EE902500642900DDA0CC /* OELaunchScreen.xib */,
+				73E64E6B252BB89A00276953 /* eula.html */,
 			);
 			path = OpenEbooks;
 			sourceTree = SOURCE_ROOT;
@@ -2665,6 +2671,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				73FCA38A25005BA4001B0C5D /* OFL.txt in Resources */,
+				73E64E6C252BB89A00276953 /* eula.html in Resources */,
 				73FCA38B25005BA4001B0C5D /* simplified.js in Resources */,
 				73FCA38C25005BA4001B0C5D /* NYPLProblemReportViewController.xib in Resources */,
 				73FCA38D25005BA4001B0C5D /* readium-shared-js_all.js in Resources */,
@@ -3325,6 +3332,7 @@
 				73FCA34125005BA4001B0C5D /* NYPLOPDSEntryGroupAttributes.m in Sources */,
 				73FCA34225005BA4001B0C5D /* NYPLMyBooksDownloadCenter.m in Sources */,
 				73FCA34325005BA4001B0C5D /* NYPLProblemDocumentCacheManager.swift in Sources */,
+				73E64E6A252BB82600276953 /* NYPLEULAViewController.swift in Sources */,
 				7353940C250854A90043C800 /* NYPLSettingsSplitViewController+OE.swift in Sources */,
 				73FCA34425005BA4001B0C5D /* NYPLBookDetailButtonsView.m in Sources */,
 				73FCA34525005BA4001B0C5D /* NYPLMyBooksSimplifiedBearerToken.m in Sources */,

--- a/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
@@ -10,10 +10,27 @@ import Foundation
 
 extension NYPLAppDelegate {
   @objc func setUpRootVC() {
-    if NYPLSettings.shared.userHasSeenWelcomeScreen {
-      window.rootViewController = NYPLRootTabBarController.shared()
+    if NYPLSettings.shared.userHasAcceptedEULA {
+      if NYPLSettings.shared.userHasSeenWelcomeScreen {
+        window.rootViewController = NYPLRootTabBarController.shared()
+      } else {
+        window.rootViewController = OETutorialViewController()
+      }
     } else {
-      window.rootViewController = OETutorialViewController()
+      let eulaURL = URL(string: "https://openebooks.net/app_user_agreement.html")!
+      let eulaVC = NYPLEULAViewController(onlineEULAURL: eulaURL) {
+        UIView.transition(
+          with: self.window,
+          duration: 0.5,
+          options: [.transitionCurlUp, .allowAnimatedContent, .layoutSubviews],
+          animations: {
+            self.window?.rootViewController = OETutorialViewController()
+        },
+          completion: nil
+        )
+      }
+      let eulaNavController = UINavigationController(rootViewController: eulaVC)
+      self.window?.rootViewController = eulaNavController
     }
   }
 

--- a/Simplified/AppInfrastructure/NYPLAppDelegate.m
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate.m
@@ -68,9 +68,7 @@ didFinishLaunchingWithOptions:(__attribute__((unused)) NSDictionary *)launchOpti
 
   [self beginCheckingForUpdates];
 
-#if !TARGET_OS_SIMULATOR
   [NYPLErrorLogger logNewAppLaunch];
-#endif
 
   return YES;
 }

--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -71,6 +71,18 @@ completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
   } else {
     cachePolicy = NSURLRequestUseProtocolCachePolicy;
   }
+
+  if (URL == nil) {
+    [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeNoURL
+                              summary:@"NYPLOPDSFeed: nil URL"
+                              message:nil
+                             metadata:@{
+                               @"shouldResetCache": @(shouldResetCache)
+                             }];
+    NYPLAsyncDispatch(^{handler(nil, nil);});
+    return;
+  }
+
   request = [[[NYPLNetworkExecutor shared] GET:URL
                                    cachePolicy:cachePolicy
                                     completion:^(NSData *data, NSURLResponse *response, NSError *error) {

--- a/Simplified/WelcomeScreen/NYPLEULAViewController.swift
+++ b/Simplified/WelcomeScreen/NYPLEULAViewController.swift
@@ -1,0 +1,171 @@
+import WebKit
+
+class NYPLEULAViewController : UIViewController {
+  private static let offlineEULAPathComponent = "eula.html"
+
+  private let onlineEULAURL: URL
+  private var acceptedEULAHandler: (()->Void)
+  private let webView: WKWebView
+  private let activityIndicatorView: UIActivityIndicatorView
+  private var attemptedLoadFromBundle = false
+  
+  init(onlineEULAURL: URL,
+       acceptedEULAHandler: @escaping ()->Void) {
+    self.onlineEULAURL = onlineEULAURL
+    self.acceptedEULAHandler = acceptedEULAHandler
+    self.webView = WKWebView.init()
+    self.activityIndicatorView = UIActivityIndicatorView.init(style: .gray)
+    super.init(nibName: nil, bundle: nil)
+    self.title = NSLocalizedString("EULA", comment: "Title for User Agreement")
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK:- UIViewController
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    if NYPLSettings.shared.userHasAcceptedEULA {
+      self.acceptedEULAHandler()
+      return
+    }
+    
+    self.navigationController?.isToolbarHidden = false
+    self.view.backgroundColor = NYPLConfiguration.backgroundColor()
+    
+    self.webView.frame = self.view.frame
+    self.webView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+    self.webView.backgroundColor = NYPLConfiguration.backgroundColor()
+    self.webView.navigationDelegate = self
+    self.view.addSubview(self.webView)
+
+    let rejectButton = UIButton.init(type: .system)
+    rejectButton.titleLabel?.font = UIFont.systemFont(ofSize: 21)
+    let rejectTitle = NSLocalizedString("Reject", comment: "Title for a Reject button")
+    
+    let acceptButton = UIButton.init(type: .system)
+    acceptButton.titleLabel?.font = UIFont.systemFont(ofSize: 21)
+    let acceptTitle = NSLocalizedString("Accept", comment: "Title for a Accept button")
+    
+    let rejectItem = UIBarButtonItem(title: rejectTitle,
+                                     style: .plain,
+                                     target: self,
+                                     action: #selector(rejectedEULA))
+    let acceptItem = UIBarButtonItem(title: acceptTitle,
+                                     style: .done,
+                                     target: self,
+                                     action: #selector(acceptedEULA))
+    let middleSpacer = UIBarButtonItem.init(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+    self.toolbarItems = [rejectItem, middleSpacer, acceptItem]
+    
+    activityIndicatorView.center = self.view.center
+    activityIndicatorView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    view.addSubview(activityIndicatorView)
+
+    loadWebView()
+  }
+  
+  @objc func acceptedEULA() {
+    NYPLSettings.shared.userHasAcceptedEULA = true
+    self.acceptedEULAHandler()
+  }
+  
+  @objc func rejectedEULA() {
+    NYPLSettings.shared.userHasAcceptedEULA = false
+    let alert = NYPLAlertUtils.alert(title: "NOTICE", message: "EULAHaveToAgree")
+    self.present(alert, animated: true, completion: nil)
+  }
+  
+  func loadWebView() {
+    activityIndicatorView.startAnimating()
+    let request = URLRequest(url: onlineEULAURL, timeoutInterval: 5.0)
+    self.webView.load(request)
+  }
+  
+  func loadWebViewFromBundle() {
+    // prevent possible infinite loop
+    attemptedLoadFromBundle = true
+
+    guard let filePath = Bundle.main.path(forResource: NYPLEULAViewController.offlineEULAPathComponent, ofType: nil) else {
+
+      NYPLErrorLogger.logError(
+        withCode: .noURL,
+        summary: "Fallback EULA file not Present in Bundle",
+        metadata: [
+          "hardcodedFileName": NYPLEULAViewController.offlineEULAPathComponent
+        ]
+      )
+
+      // reattempt loading web view: this is safe because if it fails again
+      // we will not reattempt to load from bundle anymore
+      loadWebView()
+      return
+    }
+
+    activityIndicatorView.startAnimating()
+    let fileURL = URL(fileURLWithPath: filePath)
+    webView.loadFileURL(fileURL, allowingReadAccessTo: fileURL)
+  }
+
+  func handleError(_ error: Error) {
+    activityIndicatorView.stopAnimating()
+    if !attemptedLoadFromBundle {
+      loadWebViewFromBundle()
+    } else {
+      NYPLErrorLogger.logError(
+        error,
+        summary: "Failed displaying EULA",
+        metadata: [
+          "webViewURL": webView.url?.absoluteString ?? "N/A"
+      ])
+    }
+  }
+}
+
+// MARK:- WKNavigationDelegate
+
+extension NYPLEULAViewController: WKNavigationDelegate {
+  func webView(_ webView: WKWebView,
+               decidePolicyFor navigationAction: WKNavigationAction,
+               decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    if navigationAction.request.url == onlineEULAURL {
+      return decisionHandler(.allow)
+    } else if navigationAction.request.url?.lastPathComponent == NYPLEULAViewController.offlineEULAPathComponent {
+      return decisionHandler(.allow)
+    }
+    return decisionHandler(.cancel)
+  }
+
+  func webView(_ webView: WKWebView,
+               decidePolicyFor navigationResponse: WKNavigationResponse,
+               decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+    if let response = navigationResponse.response as? HTTPURLResponse {
+      if response.statusCode < 200 || response.statusCode > 299 {
+        decisionHandler(.cancel)
+        return
+      }
+    }
+    decisionHandler(.allow)
+  }
+
+  // called only when the request succeeds
+  func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    activityIndicatorView.stopAnimating()
+  }
+
+  func webView(_ webView: WKWebView,
+               didFailProvisionalNavigation navigation: WKNavigation!,
+               withError error: Error) {
+    handleError(error)
+  }
+
+  func webView(_ webView: WKWebView,
+               didFail navigation: WKNavigation!,
+               withError error: Error) {
+    handleError(error)
+  }
+}

--- a/scripts/update-certificates.sh
+++ b/scripts/update-certificates.sh
@@ -10,7 +10,7 @@ cp ../Certificates/SimplyE/iOS/APIKeys.swift Simplified/AppInfrastructure/
 
 # SimplyE-specific stuff
 cp ../Certificates/SimplyE/iOS/GoogleService-Info.plist SimplyE/
-cp ../Certificates/SimplyE/iOS/ReaderClientCertProduction.sig SimplyE/Simplified/ReaderClientCert.sig
+cp ../Certificates/SimplyE/iOS/ReaderClientCertProduction.sig SimplyE/ReaderClientCert.sig
 
 # OpenEbooks-specific stuff
 cp ../Certificates/OpenEbooks/iOS/ReaderClientCert.sig OpenEbooks/


### PR DESCRIPTION
**What's this do?**
Displays the EULA at the first launch of Open eBooks. Some of this code was taken/adapted from [Kyle's original OE PR](https://github.com/NYPL-Simplified/Simplified-iOS/pull/1070/files).
Also fixing a newly introduced crash and a miss on the set-up scripts from a recent PR.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3052

**How should this be tested? / Do these changes have associated tests?**
1. Install OE from the store (1.8.1) and sign in or at least accept EULA.
2. Now install new OE (1.9.0). You should not see the EULA.
3. Sign out and remove any previous installation of OE. 
4. Fresh install OE, launch it: the EULA should be displayed before anything else.
5. Accept EULA and force quit the app. 
6. Reopen it: you should not see the EULA again

**Dependencies for merging? Releasing to production?**
This is not affecting SimplyE.

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 