### PR TITLE
SIMPLY-3179 Surface problem document content for borrowing errors

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -2840,7 +2840,7 @@
 		};
 		73DA43AD2404CA9500985482 /* Crashlytics */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			files = (
 			);
 			inputFileListPaths = (
@@ -2855,7 +2855,7 @@
 			);
 			outputPaths = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
 			shellScript = "\"${PROJECT_DIR}/scripts/firebase/run\"\n";
 		};

--- a/Simplified/ErrorHandling/NYPLAlertUtils.swift
+++ b/Simplified/ErrorHandling/NYPLAlertUtils.swift
@@ -106,26 +106,42 @@ import UIKit
       return
     }
 
+    var titleWasAdded = false
+    var detailWasAdded = false
     if append == false {
-      alert.title = document.title
-      alert.message = document.detail
-      return
+      if let problemDocTitle = document.title, !problemDocTitle.isEmpty {
+        alert.title = document.title
+        titleWasAdded = true
+      }
+      if let problemDocDetail = document.detail, !problemDocDetail.isEmpty {
+        alert.message = document.detail
+        detailWasAdded = true
+        if titleWasAdded {
+          // now we know we set both the alert's title and message, and since
+          // we are not appending (i.e. we are replacing what was on the
+          // existing alert), we are done.
+          return
+        }
+      }
     }
 
-    var titleWasAdded = false
+    // at this point either the alert's title or message could be empty.
+    // Let's fill that up with what we have, either from the existing alert
+    // or from the problem document.
+
     if alert.title?.isEmpty ?? true {
       alert.title = document.title
       titleWasAdded = true
     }
 
     let existingMsg: String = {
-      if let existingMsg = alert.message, !existingMsg.isEmpty {
-        return existingMsg + "\n"
+      if let alertMsg = alert.message, !alertMsg.isEmpty {
+        return alertMsg + "\n"
       }
       return ""
     }()
 
-    let docDetail: String = document.detail ?? ""
+    let docDetail = detailWasAdded ? "" : (document.detail ?? "")
 
     if !titleWasAdded, let docTitle = document.title, !docTitle.isEmpty {
       alert.message = "\(existingMsg)\(docTitle)\n\(docDetail)"

--- a/Simplified/ErrorHandling/NYPLProblemDocument.swift
+++ b/Simplified/ErrorHandling/NYPLProblemDocument.swift
@@ -66,7 +66,7 @@ import Foundation
     return NYPLProblemDocument(dict)
   }
 
-  @objc var debugDictionary: [String: Any] {
+  @objc var dictionaryValue: [String: Any] {
     return [
       NYPLProblemDocument.typeKey: type ?? "",
       NYPLProblemDocument.titleKey: title ?? "",

--- a/Simplified/ErrorHandling/NYPLProblemDocument.swift
+++ b/Simplified/ErrorHandling/NYPLProblemDocument.swift
@@ -10,7 +10,14 @@ import Foundation
     "http://librarysimplified.org/terms/problem/loan-already-exists";
   static let TypeInvalidCredentials =
     "http://librarysimplified.org/terms/problem/credentials-invalid";
-  static let noStatus: Int = -1
+
+  private static let noStatus: Int = -1
+
+  private static let typeKey = "type"
+  private static let titleKey = "title"
+  private static let statusKey = "status"
+  private static let detailKey = "detail"
+  private static let instanceKey = "instance"
 
   /// Per RFC7807, this identifies the type of problem.
   let type: String?
@@ -29,15 +36,15 @@ import Foundation
   /// the problem.
   let instance: String?
   
-  fileprivate init(_ dict: [String : Any]) {
-    self.type = dict["type"] as? String
-    self.title = dict["title"] as? String
-    self.status = dict["status"] as? Int
-    self.detail = dict["detail"] as? String
-    self.instance = dict["instance"] as? String
+  private init(_ dict: [String : Any]) {
+    self.type = dict[NYPLProblemDocument.typeKey] as? String
+    self.title = dict[NYPLProblemDocument.titleKey] as? String
+    self.status = dict[NYPLProblemDocument.statusKey] as? Int
+    self.detail = dict[NYPLProblemDocument.detailKey] as? String
+    self.instance = dict[NYPLProblemDocument.instanceKey] as? String
     super.init()
   }
-  
+
   /**
     Factory method that creates a ProblemDocument from data
     @param data data with which to populate the ProblemDocument
@@ -61,11 +68,11 @@ import Foundation
 
   @objc var debugDictionary: [String: Any] {
     return [
-      "type": type ?? "",
-      "title": title ?? "",
-      "status": status ?? NYPLProblemDocument.noStatus,
-      "detail": detail ?? "",
-      "instance": instance ?? "",
+      NYPLProblemDocument.typeKey: type ?? "",
+      NYPLProblemDocument.titleKey: title ?? "",
+      NYPLProblemDocument.statusKey: status ?? NYPLProblemDocument.noStatus,
+      NYPLProblemDocument.detailKey: detail ?? "",
+      NYPLProblemDocument.instanceKey: instance ?? "",
     ]
   }
 }

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -210,7 +210,7 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
                           reason:@"Got problem document"
                     downloadTask:downloadTask
                         metadata:@{@"problemDocument":
-                                     problemDocument.debugDictionary}];
+                                     problemDocument.dictionaryValue}];
 
     [[NSFileManager defaultManager] removeItemAtURL:tmpSavedFileURL error:NULL];
     success = NO;

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -759,7 +759,7 @@ didCompleteWithError:(NSError *)error
             }];
             return;
           } else {
-            [NYPLAlertUtils setProblemDocumentWithController:alert document:[NYPLProblemDocument fromDictionary:error] append:YES];
+            [NYPLAlertUtils setProblemDocumentWithController:alert document:[NYPLProblemDocument fromDictionary:error] append:NO];
           }
         }
 

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -97,6 +97,7 @@ fileprivate let nullString = "null"
   case responseFail = 909
   case clientSideTransientError = 910
   case clientSideUserInterruption = 911
+  case problemDocAvailable = 912
 
   // DRM
   case epubDecodingError = 1000

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -249,7 +249,7 @@ fileprivate let nullString = "null"
     }
     let errorCode: Int
     if let problemDocument = problemDocument {
-      metadata["problemDocument"] = problemDocument.debugDictionary
+      metadata["problemDocument"] = problemDocument.dictionaryValue
       errorCode = NYPLErrorCode.loginErrorWithProblemDoc.rawValue
     } else {
       errorCode = NYPLErrorCode.remoteLoginError.rawValue

--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -89,7 +89,7 @@ completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
 
     if (error != nil) {
       // Note: NYPLNetworkExecutor already logged this error
-      NYPLAsyncDispatch(^{handler(nil, error.problemDocument.debugDictionary);});
+      NYPLAsyncDispatch(^{handler(nil, error.problemDocument.dictionaryValue);});
       return;
     }
 

--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -88,8 +88,8 @@ completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
                                     completion:^(NSData *data, NSURLResponse *response, NSError *error) {
 
     if (error != nil) {
-      // NYPLSession already logged this.
-      NYPLAsyncDispatch(^{handler(nil, nil);});
+      // Note: NYPLNetworkExecutor already logged this error
+      NYPLAsyncDispatch(^{handler(nil, error.problemDocument.debugDictionary);});
       return;
     }
 

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -141,14 +141,17 @@ extension NYPLNetworkResponder: URLSessionDataDelegate {
     // attempt parsing of Problem Document
     if task.response?.isProblemDocument() ?? false {
       let parseError: Error?
+      let code: NYPLErrorCode
       do {
         let problemDoc = try NYPLProblemDocument.fromData(responseData)
         let err = task.makeErrorFromProblemDocument(problemDoc)
         parseError = nil
+        code = NYPLErrorCode.problemDocAvailable
         logMetadata["problemDocument"] = problemDoc.debugDictionary
         currentTaskInfo.completion(.failure(err, task.response))
       } catch (let error) {
         parseError = error
+        code = NYPLErrorCode.parseProblemDocFail
         let responseString = String(data: responseData, encoding: .utf8) ?? "N/A"
         logMetadata["problemDocumentBody"] = responseString
         currentTaskInfo.completion(.failure(error as NYPLUserFriendlyError, task.response))
@@ -157,7 +160,7 @@ extension NYPLNetworkResponder: URLSessionDataDelegate {
         logMetadata["urlSessionError"] = error
       }
       NYPLErrorLogger.logNetworkError(parseError,
-                                      code: NYPLErrorCode.parseProblemDocFail,
+                                      code: code,
                                       summary: "Network request failed: Problem Document available",
                                       request: task.originalRequest,
                                       response: task.response,

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -147,7 +147,7 @@ extension NYPLNetworkResponder: URLSessionDataDelegate {
         let err = task.makeErrorFromProblemDocument(problemDoc)
         parseError = nil
         code = NYPLErrorCode.problemDocAvailable
-        logMetadata["problemDocument"] = problemDoc.debugDictionary
+        logMetadata["problemDocument"] = problemDoc.dictionaryValue
         currentTaskInfo.completion(.failure(err, task.response))
       } catch (let error) {
         parseError = error

--- a/Simplified/Network/NYPLRemoteViewController.m
+++ b/Simplified/Network/NYPLRemoteViewController.m
@@ -310,7 +310,7 @@
       [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeProblemDocMessageDisplayed
                                 summary:@"Catalog api fail: Problem Doc returned"
                                 message:@"Server-side api call (likely related to Catalog loading) failed"
-                               metadata:pDoc.debugDictionary];
+                               metadata:pDoc.dictionaryValue];
       alert = [NYPLAlertUtils alertWithTitle:pDoc.title message:pDoc.detail];
     }
     [self presentViewController:alert animated:YES completion:nil];

--- a/Simplified/Network/NYPLUserFriendlyError.swift
+++ b/Simplified/Network/NYPLUserFriendlyError.swift
@@ -29,15 +29,21 @@ extension NYPLUserFriendlyError {
 }
 
 extension NSError: NYPLUserFriendlyError {
-  private static let userFriendlyTitleKey = "userFriendlyTitle"
-  private static let userFriendlyMessageKey = "userFriendlyMessage"
+  private static let problemDocumentKey = "problemDocument"
 
-  var userFriendlyTitle: String? {
-    return userInfo[NSError.userFriendlyTitleKey] as? String
+  @objc var problemDocument: NYPLProblemDocument? {
+    return userInfo[NSError.problemDocumentKey] as? NYPLProblemDocument
   }
 
-  var userFriendlyMessage: String? {
-    return (userInfo[NSError.userFriendlyMessageKey] ?? userInfo[NSLocalizedDescriptionKey]) as? String
+  /// Feeds off of the `problemDocument` computed property
+  @objc var userFriendlyTitle: String? {
+    return problemDocument?.title
+  }
+
+  /// Feeds off of the `problemDocument` computed property or the localized
+  /// error description.
+  @objc var userFriendlyMessage: String? {
+    return (problemDocument?.detail ?? userInfo[NSLocalizedDescriptionKey]) as? String
   }
 
   /// Builds an NSError using the given problem document for its user-friendly
@@ -54,13 +60,7 @@ extension NSError: NYPLUserFriendlyError {
                                       code: Int,
                                       userInfo: [String: Any]?) -> NSError {
     var userInfo = userInfo ?? [String: Any]()
-    if let title = problemDoc.title {
-      userInfo[NSError.userFriendlyTitleKey] = title
-    }
-    if let detail = problemDoc.detail {
-      userInfo[NSError.userFriendlyMessageKey] = detail
-    }
-    
+    userInfo[NSError.problemDocumentKey] = problemDoc
     return NSError(domain: domain, code: code, userInfo: userInfo)
   }
 }


### PR DESCRIPTION
**What's this do?**
Displays the contents of the problem document (which are supposed to be user-friendly) when borrowing fails instead of the generic "borrow failed" error message.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3179

**How should this be tested? / Do these changes have associated tests?**
Borrow enough audiobooks (esp from Overdrive) so that you reach your loan limit. You should now see an error message that explains that you reached your loan limit, instead of the generic "borrow failed" that we have in 3.6.0.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 