### PR TITLE
SIMPLY-3168 Mention correct app name for each target

### DIFF
--- a/Simplified/NYPLAnnotations.swift
+++ b/Simplified/NYPLAnnotations.swift
@@ -46,7 +46,11 @@ import UIKit
         return
       } else if (!initialized && settings.userHasSeenFirstTimeSyncMessage == false) {
         Log.debug(#file, "Sync has never been initialized for the patron. Showing UIAlertController flow.")
+        #if OPENEBOOKS
+        let title = "Open eBooks Sync"
+        #else
         let title = "SimplyE Sync"
+        #endif
         let message = "Enable sync to save your reading position and bookmarks to your other devices.\n\nYou can change this any time in Settings."
         let alertController = UIAlertController.init(title: title, message: message, preferredStyle: .alert)
         let notNowAction = UIAlertAction.init(title: "Not Now", style: .default, handler: { action in

--- a/Simplified/NYPLBookCellDelegate.m
+++ b/Simplified/NYPLBookCellDelegate.m
@@ -318,7 +318,7 @@
 - (void)presentUnsupportedItemError
 {
   NSString *title = NSLocalizedString(@"Unsupported Item", nil);
-  NSString *message = NSLocalizedString(@"The item you are trying to open is not currently supported by SimplyE.", nil);
+  NSString *message = NSLocalizedString(@"The item you are trying to open is not currently supported.", nil);
   UIAlertController *alert = [NYPLAlertUtils alertWithTitle:title message:message];
   [NYPLAlertUtils presentFromViewControllerOrNilWithAlertController:alert viewController:nil animated:YES completion:nil];
 }

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -109,7 +109,7 @@
 
 // NYPLBookCellDelegate
 "Unsupported Item" = "Unsupported Item";
-"The item you are trying to open is not currently supported by SimplyE." = "The item you are trying to open is not currently supported by SimplyE.";
+"The item you are trying to open is not currently supported." = "The item you are trying to open is not currently supported.";
 "Corrupted Audiobook" = "Corrupted Audiobook";
 "The audiobook you are trying to open appears to be corrupted. Try downloading it again." = "The audiobook you are trying to open appears to be corrupted. Try downloading it again.";
 

--- a/Simplified/it.lproj/Localizable.strings
+++ b/Simplified/it.lproj/Localizable.strings
@@ -105,7 +105,7 @@
 
 // NYPLBookCellDelegate
 "Unsupported Item" = "Formato non supportato";
-"The item you are trying to open is not currently supported by SimplyE." = "Il libro che stai cercando di aprire non è ancora supportato da SimplyE.";
+"The item you are trying to open is not currently supported." = "Il libro che stai cercando di aprire non è ancora supportato.";
 "Corrupted Audiobook" = "Audiobook compromesso";
 "The audiobook you are trying to open appears to be corrupted. Try downloading it again." = "L'audiobook che stai cercando di ascoltare sembra avere dei problemi. Prova a scaricarlo di nuovo.";
 


### PR DESCRIPTION
**What's this do?**
Fixes mentions of the app name in relation to the target being built.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3168

**How should this be tested? / Do these changes have associated tests?**
Fresh install the app, sign in and go to the settings screen. If you never enabled Bookmarks Syncing an alert should pop up. This alert should not reference SimplyE.

**Dependencies for merging? Releasing to production?**
none

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 