### PR TITLE
SIMPLY-3092 Refactor to allow customization before presenting sign-in modal

### DIFF
--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.h
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.h
@@ -1,3 +1,5 @@
+@class NYPLSignInBusinessLogic;
+
 /// This class handles all instances of signing into current account dynamically in many
 /// places in the app when necessary. Managing account sign in with settings is
 /// NYPLSettingsAccountDetailViewController.
@@ -7,12 +9,25 @@
 - (id)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 
+@property(readonly) NYPLSignInBusinessLogic *businessLogic;
+
+/**
+ * Presents itself to begin the login process.
+ *
+ * @param useExistingBarcode Should the screen be filled with the barcode when available?
+ * @param authorizeImmediately Should the authentication process begin automatically after presenting? For Oauth2 and SAML it would mean opening a webview.
+ * @param completionHandler Called upon successful authentication
+ */
+- (void)presentUsingExistingBarcode:(BOOL const)useExistingBarcode
+               authorizeImmediately:(BOOL)authorizeImmediately
+                  completionHandler:(void (^)(void))handler;
+
 /**
  * Present sign in view controller to begin a login process.
  *
  * @param useExistingBarcode      Should the screen be filled with barcode and pin when available?
  * @param authorizeImmediately  Should the authentication process begin automatically after presenting? For Oauth2 and SAML it would mean opening a webview
- * @param completionHandler         Completion handler that gets called uppon successful authentication
+ * @param completionHandler Called upon successful authentication.
  */
 + (void)requestCredentialsUsingExistingBarcode:(BOOL const)useExistingCredentials
                           authorizeImmediately:(BOOL)authorizeImmediately


### PR DESCRIPTION
**What's this do?**
Refactors static function to present Sign In modal to be non-static, so that the Sign In VC instance can be customized before presentation. This change here has no functional changes: the new `presentUsingExistingBarcode: authorizeImmediately:completionHandler:` is functionally identical to the old `requestCredentialsUsingExistingBarcode:authorizeImmediately:completionHandler:` beside adapting for not being a class method anymore.

**Why are we doing this? (w/ JIRA link if applicable)**
This is needed for the work on universal links. 
https://jira.nypl.org/browse/SIMPLY-3092

**How should this be tested? / Do these changes have associated tests?**
For regressions, opening the sign in modal should work the same as before.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 