### PR TITLE
SIMPLY-2510 Refactor account update logic into swift, fix a retain cycle + bug locking up sign-in modal UI

### DIFF
--- a/Simplified/Accounts/Library/AccountsManager.swift
+++ b/Simplified/Accounts/Library/AccountsManager.swift
@@ -6,9 +6,15 @@ let currentAccountIdentifierKey  = "NYPLCurrentAccountIdentifier"
   var currentAccount: Account? {get}
 }
 
+@objc protocol NYPLLibraryAccountsProvider: NYPLCurrentLibraryAccountProvider {
+  var NYPLAccountUUID: String {get}
+  var currentAccountId: String? {get}
+  func account(_ uuid: String) -> Account?
+}
+
 /// Manage the library accounts for the app.
 /// Initialized with JSON.
-@objcMembers final class AccountsManager: NSObject, NYPLCurrentLibraryAccountProvider
+@objcMembers final class AccountsManager: NSObject, NYPLLibraryAccountsProvider
 {
   static let NYPLAccountUUIDs = [
     "urn:uuid:065c0c11-0d0f-42a3-82e4-277b18786949", //NYPL proper
@@ -16,7 +22,7 @@ let currentAccountIdentifierKey  = "NYPLCurrentAccountIdentifier"
     "urn:uuid:56906f26-2c9a-4ae9-bd02-552557720b99"  //Simplified Instant Classics
   ]
 
-  static let NYPLAccountUUID = NYPLAccountUUIDs[0]
+  let NYPLAccountUUID = AccountsManager.NYPLAccountUUIDs[0]
 
   static let shared = AccountsManager()
 
@@ -243,7 +249,7 @@ let currentAccountIdentifierKey  = "NYPLCurrentAccountIdentifier"
     }
   }
 
-  func account(_ uuid:String) -> Account? {
+  func account(_ uuid: String) -> Account? {
     // get accountSets dictionary first for thread-safety
     var accountSetsCopy = [String: [Account]]()
     var accountSetKey = ""

--- a/Simplified/Accounts/User/NYPLUserAccount.swift
+++ b/Simplified/Accounts/User/NYPLUserAccount.swift
@@ -158,7 +158,7 @@ private enum StorageKey: String {
     defer {
       shared.accountInfoLock.unlock()
     }
-    if let uuid = libraryUUID, uuid != AccountsManager.NYPLAccountUUID {
+    if let uuid = libraryUUID, uuid != AccountsManager.shared.NYPLAccountUUID {
       shared.libraryUUID = uuid
     } else {
       shared.libraryUUID = nil

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.m
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.m
@@ -938,8 +938,6 @@ completionHandler:(void (^)(void))handler
   [UIApplication.sharedApplication openURL:urlComponents.URL
                                    options:@{}
                          completionHandler:nil];
-  
-  [[UIApplication sharedApplication] beginIgnoringInteractionEvents];
 }
 
 - (void)samlLogIn
@@ -993,8 +991,6 @@ completionHandler:(void (^)(void))handler
   [self.PINTextField resignFirstResponder];
 
   [self setActivityTitleWithText:NSLocalizedString(@"Verifying", nil)];
-
-  [[UIApplication sharedApplication] beginIgnoringInteractionEvents];
 
   [self validateCredentials];
 }
@@ -1247,8 +1243,7 @@ completionHandler:(void (^)(void))handler
        }
        
        [weakSelf removeActivityTitle];
-       [[UIApplication sharedApplication] endIgnoringInteractionEvents];
-       
+
        if (error.code == NSURLErrorCancelled) {
          // We cancelled the request when asked to answer the server's challenge a second time
          // because we don't have valid credentials.
@@ -1372,7 +1367,6 @@ completionHandler:(void (^)(void))handler
 {
   [[NSOperationQueue mainQueue] addOperationWithBlock:^{
     [self removeActivityTitle];
-    [[UIApplication sharedApplication] endIgnoringInteractionEvents];
     
     if(success) {
       // no need to force a login, as I just logged successfully


### PR DESCRIPTION
**What's this do?**
3 things (see commits):
- refactors the duplicated logic for updating the user account after signing in. This was duplicated in Sign in VC modal and Sign In VC in Settings tab.
- Sign in VC modal had a retain cycle
- Both Sign In VCs have calls to completely block user interactions during sign in. This is dangerous and deprecated, especially because these calls are not balanced! So I removed most of them because they are more harmful than useful, except one were it's easy to see the balancing.

**Why are we doing this? (w/ JIRA link if applicable)**
this refactor is needed for facilitating https://jira.nypl.org/browse/SIMPLY-3092
but the real ticket is https://jira.nypl.org/browse/SIMPLY-2510

**How should this be tested? / Do these changes have associated tests?**
There are no new features here, so a regression of all the sign-in flows from both settings tab and sign-in modal will address these changes. 

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 