### PR TITLE
SIMPLY-3092 Fixes for Clever authentication in Open eBooks

### DIFF
--- a/OpenEbooks/OpenEbooks.entitlements
+++ b/OpenEbooks/OpenEbooks.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:dev-librarysimplified.pantheonsite.io</string>
+	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>7262U6ST2R.org.nypl.labs.SharedKeychainGroup</string>
+	</array>
+</dict>
+</plist>

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 		733FF9C02530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */; };
 		7340DA6224B7E45C00361387 /* URLResponse+NYPL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */; };
 		7340DA6824B7F27900361387 /* NYPLBook+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340DA6724B7F27900361387 /* NYPLBook+Additions.swift */; };
+		73422119252FE4950053DA9E /* NYPLSignInViewController+OESelectAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73422116252FE4950053DA9E /* NYPLSignInViewController+OESelectAuth.swift */; };
 		734731232514235900BE3D2C /* NYPLAppDelegate+SE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734731222514235900BE3D2C /* NYPLAppDelegate+SE.swift */; };
 		734731242514235900BE3D2C /* NYPLAppDelegate+SE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734731222514235900BE3D2C /* NYPLAppDelegate+SE.swift */; };
 		734731262514236A00BE3D2C /* NYPLAppDelegate+OE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734731252514236A00BE3D2C /* NYPLAppDelegate+OE.swift */; };
@@ -492,6 +493,8 @@
 		735771A9253763E800067CEA /* NYPLBookRegistryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735771A7253763E800067CEA /* NYPLBookRegistryMock.swift */; };
 		735771AB2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735771AA2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift */; };
 		735771AC2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735771AA2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift */; };
+		735771AE2537687D00067CEA /* NYPLUniversalLinksSettingsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735771AD2537687D00067CEA /* NYPLUniversalLinksSettingsMock.swift */; };
+		735771AF2537687D00067CEA /* NYPLUniversalLinksSettingsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735771AD2537687D00067CEA /* NYPLUniversalLinksSettingsMock.swift */; };
 		735771B12537691800067CEA /* NYPLDRMAuthorizingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735771B02537691800067CEA /* NYPLDRMAuthorizingMock.swift */; };
 		735771B22537691800067CEA /* NYPLDRMAuthorizingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735771B02537691800067CEA /* NYPLDRMAuthorizingMock.swift */; };
 		7358EE7C250062BD00DDA0CC /* OEImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7358EE7B250062BD00DDA0CC /* OEImages.xcassets */; };
@@ -538,6 +541,7 @@
 		738EF2E72405EBAD00F388FB /* GoogleDataTransport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 738EF2E52405EBAD00F388FB /* GoogleDataTransport.framework */; };
 		738EF2EA2405EC1100F388FB /* FirebaseInstallations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 738EF2E42405EBAD00F388FB /* FirebaseInstallations.framework */; };
 		738EF2EC2405EC5900F388FB /* PromisesObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 738EF2EB2405EC5900F388FB /* PromisesObjC.framework */; };
+		739062D025358B7300D0743D /* NYPLSettings+OE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730FC04F25127FA2004D7C2D /* NYPLSettings+OE.swift */; };
 		739062D225358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739062D125358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift */; };
 		739062D325358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739062D125358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift */; };
 		739062D425358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739062D125358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift */; };
@@ -1243,6 +1247,7 @@
 		733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+OAuth.swift"; sourceTree = "<group>"; };
 		7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLResponse+NYPL.swift"; sourceTree = "<group>"; };
 		7340DA6724B7F27900361387 /* NYPLBook+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLBook+Additions.swift"; sourceTree = "<group>"; };
+		73422116252FE4950053DA9E /* NYPLSignInViewController+OESelectAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInViewController+OESelectAuth.swift"; sourceTree = "<group>"; };
 		734731222514235900BE3D2C /* NYPLAppDelegate+SE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLAppDelegate+SE.swift"; sourceTree = "<group>"; };
 		734731252514236A00BE3D2C /* NYPLAppDelegate+OE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLAppDelegate+OE.swift"; sourceTree = "<group>"; };
 		7347312825142FE200BE3D2C /* NYPLSettings+SE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSettings+SE.swift"; sourceTree = "<group>"; };
@@ -1254,6 +1259,7 @@
 		7357719F2537635600067CEA /* NYPLSignInBusinessLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSignInBusinessLogicTests.swift; sourceTree = "<group>"; };
 		735771A7253763E800067CEA /* NYPLBookRegistryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBookRegistryMock.swift; sourceTree = "<group>"; };
 		735771AA2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLLibraryAccountsProviderMock.swift; sourceTree = "<group>"; };
+		735771AD2537687D00067CEA /* NYPLUniversalLinksSettingsMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUniversalLinksSettingsMock.swift; sourceTree = "<group>"; };
 		735771B02537691800067CEA /* NYPLDRMAuthorizingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLDRMAuthorizingMock.swift; sourceTree = "<group>"; };
 		7358EE7B250062BD00DDA0CC /* OEImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = OEImages.xcassets; sourceTree = "<group>"; };
 		7358EE902500642900DDA0CC /* OELaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OELaunchScreen.xib; sourceTree = "<group>"; };
@@ -1284,6 +1290,7 @@
 		738EF2E42405EBAD00F388FB /* FirebaseInstallations.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseInstallations.framework; path = Carthage/Build/iOS/FirebaseInstallations.framework; sourceTree = "<group>"; };
 		738EF2E52405EBAD00F388FB /* GoogleDataTransport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleDataTransport.framework; path = Carthage/Build/iOS/GoogleDataTransport.framework; sourceTree = "<group>"; };
 		738EF2EB2405EC5900F388FB /* PromisesObjC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromisesObjC.framework; path = Carthage/Build/iOS/PromisesObjC.framework; sourceTree = "<group>"; };
+		739062CF25358A3700D0743D /* OpenEbooks.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenEbooks.entitlements; sourceTree = "<group>"; };
 		739062D125358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSignInBusinessLogicUIDelegate.swift; sourceTree = "<group>"; };
 		739ECB2325101CCE00691A70 /* NSNotification+NYPL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSNotification+NYPL.swift"; sourceTree = "<group>"; };
 		739ECB282510207E00691A70 /* NYPLCatalogs+OE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLCatalogs+OE.swift"; sourceTree = "<group>"; };
@@ -1952,6 +1959,7 @@
 				731A5B1124621F2B00B5E663 /* NYPLSignInBusinessLogic.swift */,
 				733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */,
 				739062D125358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift */,
+				73422116252FE4950053DA9E /* NYPLSignInViewController+OESelectAuth.swift */,
 				73B501C024F48D4B00FBAD7D /* NYPLUserAccountFrontEndValidation.swift */,
 			);
 			path = SignInLogic;
@@ -1983,8 +1991,9 @@
 			isa = PBXGroup;
 			children = (
 				735771A7253763E800067CEA /* NYPLBookRegistryMock.swift */,
-				735771AA2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift */,
 				735771B02537691800067CEA /* NYPLDRMAuthorizingMock.swift */,
+				735771AA2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift */,
+				735771AD2537687D00067CEA /* NYPLUniversalLinksSettingsMock.swift */,
 				7375AE5925382AC900C85211 /* NYPLUserAccountMock.swift */,
 			);
 			path = Mocks;
@@ -2115,6 +2124,7 @@
 			isa = PBXGroup;
 			children = (
 				7358EE922500675700DDA0CC /* Open-eBooks-Info.plist */,
+				739062CF25358A3700D0743D /* OpenEbooks.entitlements */,
 				735FCB392506FACF009A8C95 /* ReaderClientCert.sig */,
 				738170142526504800BA2C44 /* GoogleService-Info.plist */,
 				73085E202502E2CD008F6244 /* OpenEBooks_OPDS2_Catalog_Feed.json */,
@@ -2347,11 +2357,11 @@
 		A823D82F192BABA400B55DE2 /* SimplifiedTests */ = {
 			isa = PBXGroup;
 			children = (
-				735771A6253763A000067CEA /* Mocks */,
 				2D2B47621D08F1ED007F7764 /* SimplyETests-Bridging-Header.h */,
 				A823D830192BABA400B55DE2 /* Supporting Files */,
 				7384C803242BCE5900D5F960 /* Date+NYPLAdditionsTests.swift */,
 				219901F224FD2DBE001BC727 /* JWK */,
+				735771A6253763A000067CEA /* Mocks */,
 				1763C0D524F460FE00A4D0E2 /* NYPLAnnouncementManagerTests.swift */,
 				2D8790A420129AF200E2763F /* NYPLBookAcquisitionPathTests.swift */,
 				173F0822241AAA4E00A64658 /* NYPLBookStateTests.swift */,
@@ -2361,6 +2371,7 @@
 				11C5DD171977335E005A9945 /* NYPLKeychainTests.m */,
 				5D73DA3D22A07B9A00162CB8 /* NYPLMyBooksDownloadCenterTests.swift */,
 				7307A5EC23FF1A8500DE53DE /* NYPLOpenSearchDescriptionTests.swift */,
+				7357719F2537635600067CEA /* NYPLSignInBusinessLogicTests.swift */,
 				111559EE19B8FA8E0003BE94 /* NYPLXMLTests.m */,
 				1183F34D194F775400DC322F /* OPDS */,
 				B51C1DFD22860563003B49A5 /* OPDS2CatalogsFeedTests.swift */,
@@ -2369,7 +2380,6 @@
 				2D2B47631D08F1ED007F7764 /* UpdateCheckTests.swift */,
 				5D3A28D322D3FBB90042B3BD /* UserProfileDocumentTests.swift */,
 				735350B624918432006021BD /* URLRequest+NYPLTests.swift */,
-				7357719F2537635600067CEA /* NYPLSignInBusinessLogicTests.swift */,
 			);
 			path = SimplifiedTests;
 			sourceTree = "<group>";
@@ -2974,6 +2984,7 @@
 				735771A02537635600067CEA /* NYPLSignInBusinessLogicTests.swift in Sources */,
 				21196605250956C000A6D0EF /* JWKResponse.swift in Sources */,
 				7375AE5A25382AC900C85211 /* NYPLUserAccountMock.swift in Sources */,
+				735771AE2537687D00067CEA /* NYPLUniversalLinksSettingsMock.swift in Sources */,
 				735771B12537691800067CEA /* NYPLDRMAuthorizingMock.swift in Sources */,
 				B51C1DFE22860563003B49A5 /* OPDS2CatalogsFeedTests.swift in Sources */,
 				5D73DA4322A080BA00162CB8 /* NYPLMyBooksDownloadCenterTests.swift in Sources */,
@@ -3003,6 +3014,7 @@
 				735771A52537635D00067CEA /* NYPLSignInBusinessLogicTests.swift in Sources */,
 				735DD0C82522A0540096D1F9 /* NYPLAnnouncementManagerTests.swift in Sources */,
 				7375AE5B25382AC900C85211 /* NYPLUserAccountMock.swift in Sources */,
+				735771AF2537687D00067CEA /* NYPLUniversalLinksSettingsMock.swift in Sources */,
 				735771B22537691800067CEA /* NYPLDRMAuthorizingMock.swift in Sources */,
 				735DD0CF2522A0730096D1F9 /* UpdateCheckTests.swift in Sources */,
 				735DD0CD2522A0730096D1F9 /* String+NYPLAdditionsTests.swift in Sources */,
@@ -3124,6 +3136,7 @@
 				086C45D724AE77CA00F5108E /* NYPLBasicAuth.swift in Sources */,
 				7347F08A245A4DE200558D7F /* NYPLBookLocation.m in Sources */,
 				7347F08B245A4DE200558D7F /* NYPLFacetView.m in Sources */,
+				739062D025358B7300D0743D /* NYPLSettings+OE.swift in Sources */,
 				7347F08C245A4DE200558D7F /* NYPLReaderContainerDelegate.mm in Sources */,
 				7347F08D245A4DE200558D7F /* ProblemReportEmail.swift in Sources */,
 				7347F08E245A4DE200558D7F /* NYPLBookCellDelegate.m in Sources */,
@@ -3334,6 +3347,7 @@
 				73FCA30325005BA4001B0C5D /* NYPLMyBooksDownloadInfo.m in Sources */,
 				73FCA30425005BA4001B0C5D /* NYPLBookLocation.m in Sources */,
 				73FCA30525005BA4001B0C5D /* NYPLFacetView.m in Sources */,
+				73422119252FE4950053DA9E /* NYPLSignInViewController+OESelectAuth.swift in Sources */,
 				73FCA30625005BA4001B0C5D /* NYPLReaderContainerDelegate.mm in Sources */,
 				73FCA30725005BA4001B0C5D /* ProblemReportEmail.swift in Sources */,
 				73FCA30825005BA4001B0C5D /* NYPLBookCellDelegate.m in Sources */,
@@ -3914,9 +3928,9 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
-				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
+				CODE_SIGN_ENTITLEMENTS = OpenEbooks/OpenEbooks.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3967,9 +3981,9 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
-				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
+				CODE_SIGN_ENTITLEMENTS = OpenEbooks/OpenEbooks.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Simplified/AppInfrastructure/NSNotification+NYPL.swift
+++ b/Simplified/AppInfrastructure/NSNotification+NYPL.swift
@@ -17,6 +17,7 @@ extension Notification.Name {
   static let NYPLUseBetaDidChange = Notification.Name("NYPLUseBetaDidChange")
   static let NYPLUserAccountDidChange = Notification.Name("NYPLUserAccountDidChangeNotification")
   static let NYPLDidSignOut = Notification.Name("NYPLDidSignOut")
+  static let NYPLIsSigningIn = Notification.Name("NYPLIsSigningIn")
 
   // TODO: i think this was called "OEAppDelegateDidReceiveCleverRedirectURL"
   // in kyle's branch
@@ -32,5 +33,6 @@ extension Notification.Name {
   public static let NYPLUseBetaDidChange = Notification.Name.NYPLUseBetaDidChange
   public static let NYPLUserAccountDidChange = Notification.Name.NYPLUserAccountDidChange
   public static let NYPLDidSignOut = Notification.Name.NYPLDidSignOut
+  public static let NYPLIsSigningIn = Notification.Name.NYPLIsSigningIn
   public static let NYPLAppDelegateDidReceiveCleverRedirectURL = Notification.Name.NYPLAppDelegateDidReceiveCleverRedirectURL
 }

--- a/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
@@ -36,7 +36,8 @@ extension NYPLAppDelegate {
 
   @objc func completeBecomingActive() {
     if !NYPLUserAccount.sharedAccount().hasCredentials()
-      && NYPLSettings.shared.userHasSeenWelcomeScreen {
+      && NYPLSettings.shared.userHasSeenWelcomeScreen
+      && !isSigningIn {
       
       OETutorialChoiceViewController.showLoginPicker(handler: nil)
     }

--- a/Simplified/AppInfrastructure/NYPLAppDelegate.h
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate.h
@@ -3,5 +3,5 @@
 @interface NYPLAppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (nonatomic) UIWindow *window;
-
+@property (nonatomic, readonly) BOOL isSigningIn;
 @end

--- a/Simplified/AppInfrastructure/NYPLAppDelegate.m
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate.m
@@ -28,7 +28,7 @@
 @property (nonatomic) AudiobookLifecycleManager *audiobookLifecycleManager;
 @property (nonatomic) NYPLReachability *reachabilityManager;
 @property (nonatomic) NYPLUserNotifications *notificationsManager;
-
+@property (nonatomic, readwrite) BOOL isSigningIn;
 @end
 
 @implementation NYPLAppDelegate
@@ -55,6 +55,10 @@ didFinishLaunchingWithOptions:(__attribute__((unused)) NSDictionary *)launchOpti
 
   self.notificationsManager = [[NYPLUserNotifications alloc] init];
   [self.notificationsManager authorizeIfNeeded];
+  [NSNotificationCenter.defaultCenter addObserver:self
+                                         selector:@selector(signingIn:)
+                                             name:NSNotification.NYPLIsSigningIn
+                                           object:nil];
 
   [[NetworkQueue shared] addObserverForOfflineQueue];
   self.reachabilityManager = [NYPLReachability sharedReachability];
@@ -176,6 +180,7 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))backgroundF
   [self.audiobookLifecycleManager willTerminate];
   [[NYPLBookRegistry sharedRegistry] save];
   [[NYPLReaderSettings sharedSettings] save];
+  [NSNotificationCenter.defaultCenter removeObserver:self];
 }
 
 - (void)application:(__unused UIApplication *)application
@@ -188,6 +193,11 @@ completionHandler:(void (^const)(void))completionHandler
 }
 
 #pragma mark -
+
+- (void)signingIn:(NSNotification *)notif
+{
+  self.isSigningIn = [notif.object boolValue];
+}
 
 - (void)beginCheckingForUpdates
 {

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -53,7 +53,6 @@ fileprivate let nullString = "null"
   case oauthPatronInfoDecodeFail = 313
   case unrecognizedUniversalLink = 314
   case validationWithoutAuthToken = 315
-  case signInRedirectError = 316
 
   // audiobooks
   case audiobookUserEvent = 400

--- a/Simplified/Settings/NYPLSettings+OE.swift
+++ b/Simplified/Settings/NYPLSettings+OE.swift
@@ -6,14 +6,15 @@
 //  Copyright © 2020 NYPL Labs. All rights reserved.
 //
 
-extension NYPLSettings {
-  /// Used to handle OAuth sign-ins. For example, Clever authentication uses
-  /// this URL for redirecting to the app after authenticating in Safari.
-  /// This requires configurion setting Universal Links on the server.
+extension NYPLSettings: NYPLUniversalLinksSettings {
+  /// Used to handle Clever sign-ins via OAuth in Open eBooks. 
   @objc var authenticationUniversalLink: URL {
-    return URL(string: "https://www.librarysimplified.org/callbacks/OpenEbooks")!
+    // TODO: SIMPLY-3050 this is a dev URL. Replace with production one.
+    return URL(string: "https://dev-librarysimplified.pantheonsite.io/callbacks/OpenEbooks")!
   }
+}
 
+extension NYPLSettings {
   static let userHasSeenWelcomeScreenKey = "NYPLSettingsUserFinishedTutorial"
 
   var settingsAccountsList: [String] {

--- a/Simplified/Settings/NYPLSettings+SE.swift
+++ b/Simplified/Settings/NYPLSettings+SE.swift
@@ -8,14 +8,14 @@
 
 import Foundation
 
-extension NYPLSettings {
-  /// Used to handle OAuth sign-ins. For example, Clever authentication uses
-  /// this URL for redirecting to the app after authenticating in Safari.
-  /// This requires configurion setting Universal Links on the server.
+extension NYPLSettings: NYPLUniversalLinksSettings {
+  /// Used to handle Clever and SAML sign-ins in SimplyE.
   @objc var authenticationUniversalLink: URL {
     return URL(string: "https://www.librarysimplified.org/callbacks/SimplyE")!
   }
+}
 
+extension NYPLSettings {
   static let userHasSeenWelcomeScreenKey = "NYPLUserHasSeenWelcomeScreenKey"
   
   var settingsAccountsList: [String] {

--- a/Simplified/Settings/NYPLSettings.swift
+++ b/Simplified/Settings/NYPLSettings.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+@objc protocol NYPLUniversalLinksSettings: NSObjectProtocol {
+  /// The URL that will be used to redirect an external authentication flow
+  /// back to the our app. This URL will need to be provided to the external
+  /// service. For example, Clever authentication uses this URL to redirect
+  /// to the app after authenticating in Safari.
+  var authenticationUniversalLink: URL { get }
+}
+
 @objcMembers class NYPLSettings: NSObject {
   static let shared = NYPLSettings()
 

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.m
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.m
@@ -98,6 +98,7 @@ CGFloat const marginPadding = 2.0;
   self.businessLogic = [[NYPLSignInBusinessLogic alloc]
                         initWithLibraryAccountID:AccountsManager.shared.currentAccountId
                         libraryAccountsProvider:AccountsManager.shared
+                        universalLinksSettings: NYPLSettings.shared
                         bookRegistry:[NYPLBookRegistry sharedRegistry]
                         userAccountProvider:[NYPLUserAccount class]
                         uiDelegate:self
@@ -920,6 +921,10 @@ completionHandler:(void (^)(void))handler
 
 - (void)logIn
 {
+  [[NSNotificationCenter defaultCenter]
+   postNotificationName:NSNotification.NYPLIsSigningIn
+   object:@(YES)];
+
   if (self.businessLogic.selectedAuthentication.isOauth) {
     [self.businessLogic oauthLogIn];
   } else if (self.businessLogic.selectedAuthentication.isSaml) {

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+OAuth.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+OAuth.swift
@@ -34,7 +34,7 @@ extension NYPLSignInBusinessLogic {
 
     let redirectParam = URLQueryItem(
       name: "redirect_uri",
-      value: NYPLSettings.shared.authenticationUniversalLink.absoluteString)
+      value: universalLinksSettings.authenticationUniversalLink.absoluteString)
     urlComponents.queryItems?.append(redirectParam)
 
     guard let finalURL = urlComponents.url else {
@@ -78,8 +78,7 @@ extension NYPLSignInBusinessLogic {
     }
 
     let urlStr = url.absoluteString
-    // TODO: SIMPLY-3092 inject this NYPLSettings url
-    guard urlStr.hasPrefix(NYPLSettings.shared.authenticationUniversalLink.absoluteString),
+    guard urlStr.hasPrefix(universalLinksSettings.authenticationUniversalLink.absoluteString),
       universalLinkRedirectURLContainsPayload(urlStr) else {
 
       NYPLErrorLogger.logError(withCode: .unrecognizedUniversalLink,

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
@@ -42,6 +42,7 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider {
   private var juvenileCardCreationCoordinator: JuvenileFlowCoordinator?
 
   private let libraryAccountsProvider: NYPLLibraryAccountsProvider
+  let universalLinksSettings: NYPLUniversalLinksSettings
   private let bookRegistry: NYPLBookRegistrySyncing
 
   /// Provides the user account for a given library.
@@ -54,6 +55,7 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider {
 
   @objc init(libraryAccountID: String,
              libraryAccountsProvider: NYPLLibraryAccountsProvider,
+             universalLinksSettings: NYPLUniversalLinksSettings,
              bookRegistry: NYPLBookRegistrySyncing,
              userAccountProvider: NYPLUserAccountProvider.Type,
              uiDelegate: NYPLSignInBusinessLogicUIDelegate?,
@@ -61,6 +63,7 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider {
     self.uiDelegate = uiDelegate
     self.libraryAccountID = libraryAccountID
     self.libraryAccountsProvider = libraryAccountsProvider
+    self.universalLinksSettings = universalLinksSettings
     self.bookRegistry = bookRegistry
     self.userAccountProvider = userAccountProvider
     self.drmAuthorizer = drmAuthorizer
@@ -142,6 +145,8 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider {
         }
       }
     }
+
+    NotificationCenter.default.post(name: .NYPLIsSigningIn, object: false)
   }
 
   func setBarcode(_ barcode: String?, pin: String?) {

--- a/Simplified/SignInLogic/NYPLSignInViewController+OESelectAuth.swift
+++ b/Simplified/SignInLogic/NYPLSignInViewController+OESelectAuth.swift
@@ -1,0 +1,44 @@
+//
+//  NYPLSignInViewController+OESelectAuth.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 10/8/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+enum LoginChoice {
+  case firstBook, clever
+}
+
+extension NYPLAccountSignInViewController {
+  convenience init(loginChoice: LoginChoice) {
+    self.init()
+    self.businessLogic.selectAuthentication(forLoginChoice: loginChoice)
+  }
+}
+
+extension NYPLSignInBusinessLogic {
+  fileprivate func selectAuthentication(forLoginChoice loginChoice: LoginChoice) {
+    guard let authentications = libraryAccount?.details?.auths else {
+      return
+    }
+
+    let matches = authentications.filter {
+      switch loginChoice {
+      case .firstBook:
+        if $0.authType == .basic {
+          return true
+        }
+      case .clever:
+        if $0.authType == .oauthIntermediary {
+          return true
+        }
+      }
+      return false
+    }
+
+    selectedAuthentication = matches.first
+  }
+}

--- a/Simplified/WelcomeScreen/OETutorialChoiceViewController.swift
+++ b/Simplified/WelcomeScreen/OETutorialChoiceViewController.swift
@@ -100,30 +100,39 @@ class OETutorialChoiceViewController : UIViewController {
     completionHandler = nil
     oldCompletionHandler?.self()
   }
-  
+
   @objc func didSelectFirstBook() {
+    didSelectAuthenticationMethod(.firstBook)
+  }
+
+  @objc func didSelectClever() {
+    didSelectAuthenticationMethod(.clever)
+  }
+
+  private func didSelectAuthenticationMethod(_ loginChoice: LoginChoice) {
     let libAccount = AccountsManager.shared.currentAccount
     let userAccount = NYPLUserAccount.sharedAccount()
     if libAccount?.details == nil {
       libAccount?.loadAuthenticationDocument(using: userAccount) { success in
         if success {
-          NYPLAccountSignInViewController.requestCredentials(usingExistingBarcode: false, completionHandler: self.loginCompletionHandler)
+          self.presentSignInVC(for: loginChoice)
         } else {
-          let alert = NYPLAlertUtils.alert(title: "Bad Account Info", message: "Could not resolve OpenEBooks account data")
+          let alert = NYPLAlertUtils.alert(title: "Sign-in Error", message: "We could not find a match for the credentials provided.")
           self.present(alert, animated: true, completion: nil)
         }
       }
     } else {
-      NYPLAccountSignInViewController.requestCredentials(usingExistingBarcode: false, completionHandler: loginCompletionHandler)
+      presentSignInVC(for: loginChoice)
     }
   }
-  
-  @objc func didSelectClever() {
-    // TODO: SIMPLY-3050
-//    NYPLUserAccount.shared()?.removeAll()
-//    CleverLoginViewController.loginWithCompletionHandler(loginCompletionHandler)
+
+  private func presentSignInVC(for loginChoice: LoginChoice) {
+    let signInVC = NYPLAccountSignInViewController(loginChoice: loginChoice)
+    signInVC.present(usingExistingBarcode: false,
+                     authorizeImmediately: false,
+                     completionHandler: self.loginCompletionHandler)
   }
-  
+
   @objc func didSelectRequestCodes() {
     UIApplication.shared.open(NYPLConfiguration.openEBooksRequestCodesURL)
   }

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -216,6 +216,8 @@
 "Want a card for your child?" = "Want a card for your child?";
 "Cannot confirm library card eligibility." = "Cannot confirm library card eligibility.";
 "Please log out and try your card information again." = "Please log out and try your card information again.";
+"Sign-in Error" = "Sign-in Error";
+"We could not find a match for the credentials provided." = "We could not find a match for the credentials provided.";
 
 // NYPLSettingsEULAViewController
 "Accept" = "Accept";

--- a/Simplified/it.lproj/Localizable.strings
+++ b/Simplified/it.lproj/Localizable.strings
@@ -202,6 +202,8 @@
 "Want a card for your child?" = "Vuoi una tessera per i tuoi figli?";
 "Cannot confirm library card eligibility." = "Si è verificato un errore per il quale è impossibile verificare se la tua tessera è idonea.";
 "Please log out and try your card information again." = "Prova a disconnetterti e a riaccedere per cercare di risolvere questo problema.";
+"Sign-in Error" = "Errore di autenticazione";
+"We could not find a match for the credentials provided." = "Non è stato possibile trovare il tuo utente con le informazioni ricevute.";
 
 // NYPLSettingsEULAViewController
 "Accept" = "Accetta";

--- a/SimplifiedTests/Mocks/NYPLUniversalLinksSettingsMock.swift
+++ b/SimplifiedTests/Mocks/NYPLUniversalLinksSettingsMock.swift
@@ -1,0 +1,17 @@
+//
+//  NYPLUniversalLinksSettingsMock.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 10/14/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+@testable import SimplyE
+
+class NYPLUniversalLinksSettingsMock: NSObject, NYPLUniversalLinksSettings {
+  var authenticationUniversalLink: URL {
+    return URL(string: "https://example.com/univeral-link-redirect")!
+  }
+}
+

--- a/SimplifiedTests/NYPLSignInBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLSignInBusinessLogicTests.swift
@@ -19,6 +19,7 @@ class NYPLSignInBusinessLogicTests: XCTestCase {
     businessLogic = NYPLSignInBusinessLogic(
       libraryAccountID: libraryAccountMock.NYPLAccountUUID,
       libraryAccountsProvider: libraryAccountMock,
+      universalLinksSettings: NYPLUniversalLinksSettingsMock(),
       bookRegistry: NYPLBookRegistryMock(),
       userAccountProvider: NYPLUserAccountMock.self,
       uiDelegate: nil,


### PR DESCRIPTION
**What's this do?**
- Add new entitlement only for OE because we are in the process of shipping a new release and we should not change how SE is set up right now.
- Add NYPLIsSigningIn notification to address a bug in OE where the login choice picker would show up after redirection from Clever.
- Avoid tight coupling in NYPLSignInBusinessLogic via NYPLUniversalLinksSettings protocol.
- Add sign-in VC convenience initializer based on OE login choice, using refactor done recently in PR#1217.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3092

**How should this be tested? / Do these changes have associated tests?**
I used the sandbox school district  from here: https://github.com/NYPL-Simplified/operations/wiki/TestCardsOpenEbooks#clever
You can then sign in by typing in one of those student-IDs for both user id and password.
If you have a real school district to try this on it would be even better, of course.

**Dependencies for merging? Releasing to production?**
not affecting SimplyE.

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 