### PR TITLE
SIMPLY-3092 Refactor sign in + sign out requests to Business Logic class

### DIFF
--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -325,8 +325,9 @@ fileprivate let nullString = "null"
   ///   hashed.
   class func logUserProfileDocumentAuthError(_ error: NSError?,
                                              summary: String,
-                                             barcode: String?) {
-    var userInfo = [String : Any]()
+                                             barcode: String?,
+                                             metadata: [String: Any]? = nil) {
+    var userInfo = metadata ?? [String : Any]()
     addAccountInfoToMetadata(&userInfo)
     userInfo = additionalInfo(severity: .error, metadata: userInfo)
     if let barcode = barcode {

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -589,35 +589,18 @@ Authenticating with any of those barcodes should work.
   }
 }
 
-- (NSURLRequest *)makeRequestForIntent:(NSString *)intent
-{
-  NSMutableURLRequest *const request =
-  [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[[self.selectedAccount details] userProfileUrl]]];
-  request.timeoutInterval = self.businessLogic.requestTimeoutInterval;
-
-  if (self.businessLogic.selectedAuthentication.isOauth || self.businessLogic.selectedAuthentication.isSaml) {
-    if (self.authToken) {
-      NSString *authorization = [@"Bearer " stringByAppendingString:self.authToken];
-      [request addValue:authorization forHTTPHeaderField:@"Authorization"];
-    } else {
-      NYPLLOG(@"Auth token expected, but none is available.");
-      [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeValidationWithoutAuthToken
-                                summary:[intent stringByAppendingString:@"-settingsTab"]
-                                message:@"There is no token available during oauth/saml authentication validation."
-                               metadata:nil];
-    }
-  }
-
-  return request;
-}
-
 - (void)performLogOut
 {
 #if defined(FEATURE_DRM_CONNECTOR)
 
   [self setActivityTitleWithText:NSLocalizedString(@"SigningOut", nil)];
 
-  NSURLRequest *const request = [self makeRequestForIntent:@"SignOut"];
+  // we need to make this request (which is identical to the sign-in request)
+  // because in order for the Adobe deactivation to be successful, it has
+  // to use a fresh Adobe token provided by the CM, since it may have expired.
+  NSURLRequest *const request = [self.businessLogic
+                                 makeRequestFor:NYPLAuthRequestTypeSignOut
+                                 context:@"Settings Tab"];
   NSString * const currentBarcode = [[self selectedUserAccount] barcode];
   NSURLSessionDataTask *const task =
   [self.session
@@ -631,13 +614,20 @@ Authenticating with any of those barcodes should work.
        NSError *pDocError = nil;
        UserProfileDocument *pDoc = [UserProfileDocument fromData:data error:&pDocError];
        if (!pDoc) {
+         NYPLLOG_F(@"Unable to parse user profile at sign out (HTTP: %ld): Adobe device deauthorization won't be possible.", (long)statusCode);
          [NYPLErrorLogger logUserProfileDocumentAuthError:pDocError
-                                                  summary:@"signOut: unable to parse user profile doc"
-                                                  barcode:currentBarcode];
+                                                  summary:@"SignOut: unable to parse user profile doc"
+                                                  barcode:currentBarcode
+                                                 metadata:@{
+                                                   @"Request": request.loggableString,
+                                                   @"Response": response ?: @"N/A",
+                                                 }];
          [self showLogoutAlertWithError:pDocError responseCode:statusCode];
          [self removeActivityTitle];
        } else {
          if (pDoc.drm.count > 0 && pDoc.drm[0].vendor && pDoc.drm[0].clientToken) {
+           // Set the fresh Adobe token info into the user account so that the
+           // following `deauthorizeDevice` call can use it.
            [self.selectedUserAccount setLicensor:[pDoc.drm[0] licensor]];
            NYPLLOG_F(@"\nLicensor Token Updated: %@\nFor account: %@", pDoc.drm[0].clientToken, self.selectedUserAccount.userID);
          } else {
@@ -766,7 +756,9 @@ Authenticating with any of those barcodes should work.
     [[UIApplication sharedApplication] beginIgnoringInteractionEvents];
   });
 
-  NSURLRequest *const request = [self makeRequestForIntent:@"SignIn"];
+  NSURLRequest *const request = [self.businessLogic
+                                 makeRequestFor:NYPLAuthRequestTypeSignIn
+                                 context:@"Settings Tab"];
 
   __weak __auto_type weakSelf = self;
   NSURLSessionDataTask *const task =
@@ -810,7 +802,8 @@ Authenticating with any of those barcodes should work.
                            errorMessage:@"Error parsing user profile document"];
     [NYPLErrorLogger logUserProfileDocumentAuthError:pDocError
                                              summary:@"SignIn-settingsTab: unable to parse user profile doc"
-                                             barcode:barcode];
+                                             barcode:barcode
+                                            metadata:nil];
     return;
   }
 

--- a/Simplified/SignInLogic/NYPLBasicAuth.swift
+++ b/Simplified/SignInLogic/NYPLBasicAuth.swift
@@ -9,50 +9,49 @@
 import Foundation
 
 @objc class NYPLBasicAuth: NSObject {
-    typealias BasicAuthCompletionHandler = (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+  typealias BasicAuthCompletionHandler = (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
 
-    @objc static func authHandler(challenge: URLAuthenticationChallenge,
-                                  completionHandler: @escaping BasicAuthCompletionHandler)
-    {
-        switch challenge.protectionSpace.authenticationMethod {
-        case NSURLAuthenticationMethodHTTPBasic:
-            let account = NYPLUserAccount.sharedAccount()
-            if let barcode = account.barcode, let pin = account.PIN {
-                authCustomHandler(challenge: challenge,
-                                  completionHandler: completionHandler,
-                                  username: barcode,
-                                  password: pin)
-            } else {
-                completionHandler(.cancelAuthenticationChallenge, nil)
-            }
+  @objc static func authHandler(challenge: URLAuthenticationChallenge,
+                                completionHandler: @escaping BasicAuthCompletionHandler)
+  {
+    switch challenge.protectionSpace.authenticationMethod {
+    case NSURLAuthenticationMethodHTTPBasic:
+      let account = NYPLUserAccount.sharedAccount()
+      if let barcode = account.barcode, let pin = account.PIN {
+        authCustomHandler(challenge: challenge,
+                          completionHandler: completionHandler,
+                          username: barcode,
+                          password: pin)
+      } else {
+        completionHandler(.cancelAuthenticationChallenge, nil)
+      }
 
-        case NSURLAuthenticationMethodServerTrust:
-            completionHandler(.performDefaultHandling, nil)
+    case NSURLAuthenticationMethodServerTrust:
+      completionHandler(.performDefaultHandling, nil)
 
-        default:
-            completionHandler(.rejectProtectionSpace, nil)
-        }
+    default:
+      completionHandler(.rejectProtectionSpace, nil)
     }
+  }
 
-    @objc static func authCustomHandler(challenge: URLAuthenticationChallenge!,
-                                        completionHandler: @escaping BasicAuthCompletionHandler,
-                                        username: String,
-                                        password: String)
-    {
-        switch challenge.protectionSpace.authenticationMethod {
-        case NSURLAuthenticationMethodHTTPBasic:
-            if challenge.previousFailureCount == 0 {
-                let credentials = URLCredential(user: username,
-                                                password: password,
-                                                persistence: .none)
-                completionHandler(.useCredential, credentials)
-            } else {
-                completionHandler(.cancelAuthenticationChallenge, nil)
-            }
+  @objc static func authCustomHandler(challenge: URLAuthenticationChallenge!,
+                                      completionHandler: @escaping BasicAuthCompletionHandler,
+                                      username: String,
+                                      password: String)
+  {
+    switch challenge.protectionSpace.authenticationMethod {
+    case NSURLAuthenticationMethodHTTPBasic:
+      if challenge.previousFailureCount == 0 {
+        let credentials = URLCredential(user: username,
+                                        password: password,
+                                        persistence: .none)
+        completionHandler(.useCredential, credentials)
+      } else {
+        completionHandler(.cancelAuthenticationChallenge, nil)
+      }
 
-        default:
-            completionHandler(.rejectProtectionSpace, nil)
-        }
+    default:
+      completionHandler(.rejectProtectionSpace, nil)
     }
-
+  }
 }


### PR DESCRIPTION
**What's this do?**
- First refactors (in objc) the construction of sign in/sign out request in Setting tab VC. This also removes an erroneous `if` introduced in the previous PR that was hiding a sign-out error that was preventing Adobe device deactivation.
- Then refactors that to swift in the NYPLSignInBusinessLogic class, this way refactoring also the request-creation logic from NYPLAccountSignInViewController.
- Adds documentation after [chatting](https://librarysimplified.slack.com/archives/CKC8S59NJ/p1602882778082000?thread_ts=1602871744.079100&cid=CKC8S59NJ) with @gioneill and @io7m about why we need to issue a sign out request that is really a sign-in request: this is because we need a fresh Adobe token to successfully deactivate the Adobe device.

**Why are we doing this? (w/ JIRA link if applicable)**
This is part of the Clever work for OE but also applies to SE. 
https://jira.nypl.org/browse/SIMPLY-3092

**How should this be tested? / Do these changes have associated tests?**
Sign in and out via Clever several times. The device should be deactivated successfully and you should not run into "reached max number of activation" errors from Adobe.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 