### PR TITLE
SIMPLY-2820 Fix R2 bookmark create bug

### DIFF
--- a/Simplified/NYPLReadiumBookmark.swift
+++ b/Simplified/NYPLReadiumBookmark.swift
@@ -6,9 +6,9 @@
   var chapter:String?
   var page:String?
 
-  var location:String
+  var location:String?
   var idref:String
-  var contentCFI:String
+  var contentCFI:String?
   var progressWithinChapter:Float = 0.0
   var progressWithinBook:Float = 0.0
 
@@ -36,7 +36,7 @@
         device:String?)
   {
     //Obj-C Nil Check
-    guard let contentCFI = contentCFI, let idref = idref, let location = location else {
+    guard let idref = idref else {
       Log.error(#file, "Bookmark failed init due to nil parameter.")
       return nil
     }
@@ -84,11 +84,11 @@
 
   var dictionaryRepresentation:NSDictionary {
     return ["annotationId":self.annotationId ?? "",
-            "contentCFI":self.contentCFI,
+            "contentCFI":self.contentCFI ?? "",
             "idref":self.idref,
             "chapter":self.chapter ?? "",
             "page":self.page ?? "",
-            "location":self.location,
+            "location":self.location ?? "",
             "time":self.time,
             "device":self.device ?? "",
             "progressWithinChapter":self.progressWithinChapter,

--- a/Simplified/Reader2/NYPLBookmarkR2Location.swift
+++ b/Simplified/Reader2/NYPLBookmarkR2Location.swift
@@ -46,9 +46,14 @@ extension NYPLReadiumBookmark {
       return nil
     }
 
+    var position: Int? = nil
+    if let page = page, let pos = Int(page) {
+      position = pos
+    }
+    
     let locations = Locator.Locations(progression: Double(progressWithinChapter),
                                       totalProgression: Double(progressWithinBook),
-                                      position: nil)
+                                      position: position)
     let locator = Locator(href: link.href,
                           type: publication.metadata.type ?? MediaType.xhtml.string,
                           title: self.chapter,

--- a/Simplified/Reader2/NYPLReaderBookmarksBusinessLogic.swift
+++ b/Simplified/Reader2/NYPLReaderBookmarksBusinessLogic.swift
@@ -90,6 +90,11 @@ class NYPLReaderBookmarksBusinessLogic: NSObject, NYPLReadiumViewSyncManagerDele
       return nil
     }
     let totalProgress = Float(total)
+    
+    var page: String? = nil
+    if let position = bookmarkLoc.locator.locations.position {
+      page = "\(position)"
+    }
 
     let registry = NYPLBookRegistry.shared()
     let registryLoc = registry.location(forIdentifier: book.identifier)
@@ -126,7 +131,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject, NYPLReadiumViewSyncManagerDele
       contentCFI: cfi,
       idref: idref,
       chapter: chapter,
-      page: nil,
+      page: page,
       location: registryLoc?.locationString,
       progressWithinChapter: chapterProgress,
       progressWithinBook: totalProgress,

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -252,10 +252,6 @@ class NYPLBaseReaderViewController: UIViewController, NYPLBackgroundWorkOwner, L
     guard let bookmark = bookmarksBusinessLogic.addBookmark(location) else {
       let alert = NYPLAlertUtils.alert(title: "Bookmarking Error",
                                        message: "A bookmark could not be created on the current page.")
-      let action = UIAlertAction(title: NSLocalizedString("OK", comment: ""),
-                                 style: .default,
-                                 handler: nil)
-      alert.addAction(action)
       NYPLAlertUtils.presentFromViewControllerOrNil(alertController: alert,
                                                     viewController: self,
                                                     animated: true,


### PR DESCRIPTION
**What's this do?**
Fixing a bug of bookmark create failed in R2 reader
Also fix the double "Ok" on the fail alert
Note:
There is a bug navigating to the bookmark in R2 reader.
The readium team has located this issue and has a PR opened for it. [PR link](https://github.com/readium/r2-navigator-swift/pull/142)
We need to upgrade our r2-navigator once they have this issue fixed.

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-2820](https://jira.nypl.org/browse/SIMPLY-2820)

**How should this be tested? / Do these changes have associated tests?**
Open a book that never been open in R1, create a bookmark and check if it exist in the bookmark list

**Dependencies for merging? Releasing to production?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 