### PR TITLE
SIMPLY-3219 Unable to see NYPL sign-in info

### DIFF
--- a/Simplified/Accounts/User/NYPLUserAccount.swift
+++ b/Simplified/Accounts/User/NYPLUserAccount.swift
@@ -19,7 +19,14 @@ private enum StorageKey: String {
   case cookies = "NYPLAccountAuthCookiesKey"
 
   func keyForLibrary(uuid libraryUUID: String?) -> String {
-    guard let libraryUUID = libraryUUID else { return self.rawValue }
+    guard
+      // historically user data for NYPL has not used keys that contain the
+      // library UUID.
+      let libraryUUID = libraryUUID,
+      libraryUUID != AccountsManager.shared.NYPLAccountUUID else {
+        return self.rawValue
+    }
+
     return "\(self.rawValue)_\(libraryUUID)"
   }
 }
@@ -161,11 +168,8 @@ private enum StorageKey: String {
     defer {
       shared.accountInfoLock.unlock()
     }
-    if let uuid = libraryUUID, uuid != AccountsManager.shared.NYPLAccountUUID {
-      shared.libraryUUID = uuid
-    } else {
-      shared.libraryUUID = nil
-    }
+
+    shared.libraryUUID = libraryUUID
 
     return shared
   }


### PR DESCRIPTION
**What's this do?**
Background: since at least v3.3.5 and probably earlier, user info is stored in the keychain using keys whose names have the library UUID appended to the "raw" key name (such as "barcode"). One exception is the NYPL account, for which historically the library UUID has not been appended.

Recent SAML code (shipped in 3.6.0) added the `NYPLUserAccount::libraryUUID` property, used to set the key names only once instead of each time we need to read the `NYPLUserAccount::sharedAccount` computed property, and also to get the `authDefinition` property. However this code also introduced a regression (checkin 92ff20c) by defaulting to `nil` the libraryUUID for NYPL, which leads to wrong `authDefinition` values.

This fix restores the original intention, leaving nil-handling only to the task of determining keychain key names for NYPL.

@Neckk since this was your change, it would be extremely helpful if you can review this in-depth because this is touching a delicate/fragile area of the codebase. @jce1028 tagging you as well in case Jacek needs authorization from you for this.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3219

**How should this be tested? / Do these changes have associated tests?**
See ticket.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 