### PR TITLE
SIMPLY-2510 Move SAML sign-in logic out of VCs

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -196,6 +196,9 @@
 		5DD5674522B303DF001F0C83 /* NYPLDeveloperSettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD5674422B303DF001F0C83 /* NYPLDeveloperSettingsTableViewController.swift */; };
 		5DD567AF22B95A30001F0C83 /* String+MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD567AE22B95A30001F0C83 /* String+MD5.swift */; };
 		5DD567B522B97344001F0C83 /* Data+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD567B422B97344001F0C83 /* Data+Base64.swift */; };
+		730263AC2540DE4200A53891 /* NYPLSAMLHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 730263AB2540DE4200A53891 /* NYPLSAMLHelper.m */; };
+		730263AD2540DE4200A53891 /* NYPLSAMLHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 730263AB2540DE4200A53891 /* NYPLSAMLHelper.m */; };
+		730263AE2540DE4200A53891 /* NYPLSAMLHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 730263AB2540DE4200A53891 /* NYPLSAMLHelper.m */; };
 		7307A5ED23FF1A8500DE53DE /* NYPLOpenSearchDescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7307A5EC23FF1A8500DE53DE /* NYPLOpenSearchDescriptionTests.swift */; };
 		7307A5F223FF22EC00DE53DE /* ZXingObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 145DA48D215441A70055DB93 /* ZXingObjC.framework */; };
 		73085E1A2502DE88008F6244 /* OETutorialChoiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E182502DE87008F6244 /* OETutorialChoiceViewController.swift */; };
@@ -1221,6 +1224,8 @@
 		5DD5677122B7ECE3001F0C83 /* NYPLSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSettings.swift; sourceTree = "<group>"; };
 		5DD567AE22B95A30001F0C83 /* String+MD5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+MD5.swift"; sourceTree = "<group>"; };
 		5DD567B422B97344001F0C83 /* Data+Base64.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Base64.swift"; sourceTree = "<group>"; };
+		730263AA2540DE4200A53891 /* NYPLSAMLHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NYPLSAMLHelper.h; sourceTree = "<group>"; };
+		730263AB2540DE4200A53891 /* NYPLSAMLHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NYPLSAMLHelper.m; sourceTree = "<group>"; };
 		7307A5EC23FF1A8500DE53DE /* NYPLOpenSearchDescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLOpenSearchDescriptionTests.swift; sourceTree = "<group>"; };
 		73085E182502DE87008F6244 /* OETutorialChoiceViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OETutorialChoiceViewController.swift; sourceTree = "<group>"; };
 		73085E192502DE88008F6244 /* NYPLPresentationUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLPresentationUtils.swift; sourceTree = "<group>"; };
@@ -1964,6 +1969,8 @@
 				739062D125358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift */,
 				73422116252FE4950053DA9E /* NYPLSignInViewController+OESelectAuth.swift */,
 				73B501C024F48D4B00FBAD7D /* NYPLUserAccountFrontEndValidation.swift */,
+				730263AA2540DE4200A53891 /* NYPLSAMLHelper.h */,
+				730263AB2540DE4200A53891 /* NYPLSAMLHelper.m */,
 			);
 			path = SignInLogic;
 			sourceTree = "<group>";
@@ -3147,6 +3154,7 @@
 				7347F093245A4DE200558D7F /* NYPLMigrationManager.swift in Sources */,
 				7347F094245A4DE200558D7F /* NYPLSettingsSplitViewController.m in Sources */,
 				7347F095245A4DE200558D7F /* Date+NYPLAdditions.swift in Sources */,
+				730263AD2540DE4200A53891 /* NYPLSAMLHelper.m in Sources */,
 				7347F096245A4DE200558D7F /* OPDS2AuthenticationDocument.swift in Sources */,
 				73FB0ACA24EB403D0072E430 /* NYPLBookContentType.swift in Sources */,
 				7347F097245A4DE200558D7F /* NYPLBookRegistryRecord.m in Sources */,
@@ -3413,6 +3421,7 @@
 				7353940C250854A90043C800 /* NYPLSettingsSplitViewController+OE.swift in Sources */,
 				73FCA34425005BA4001B0C5D /* NYPLBookDetailButtonsView.m in Sources */,
 				73FCA34525005BA4001B0C5D /* NYPLMyBooksSimplifiedBearerToken.m in Sources */,
+				730263AE2540DE4200A53891 /* NYPLSAMLHelper.m in Sources */,
 				73FCA34625005BA4001B0C5D /* NYPLAnnotations.swift in Sources */,
 				73FCA34725005BA4001B0C5D /* RemoteHTMLViewController.swift in Sources */,
 				73FCA34825005BA4001B0C5D /* NYPLBookDetailsProblemDocumentViewController.swift in Sources */,
@@ -3513,6 +3522,7 @@
 				733875672423E540000FEB67 /* NYPLCaching.swift in Sources */,
 				1107835E19816E3D0071AB1E /* UIView+NYPLViewAdditions.m in Sources */,
 				111E75831A815CFB00718AD7 /* NYPLSettingsPrimaryTableViewController.m in Sources */,
+				730263AC2540DE4200A53891 /* NYPLSAMLHelper.m in Sources */,
 				2199020824FD35DC001BC727 /* JWKResponse.swift in Sources */,
 				11E0208D197F05D9009DEA93 /* UIFont+NYPLSystemFontOverride.m in Sources */,
 				03690E291EB2B44300F75D5F /* NYPLReadiumBookmark.swift in Sources */,

--- a/Simplified/AppInfrastructure/SimplyE-Bridging-Header.h
+++ b/Simplified/AppInfrastructure/SimplyE-Bridging-Header.h
@@ -31,6 +31,7 @@
 #import "NYPLBookLocation.h"
 #import "NYPLAccountSignInViewController.h"
 #import "NYPLReloadView.h"
+#import "NYPLSAMLHelper.h"
 #import "UIView+NYPLViewAdditions.h"
 #if FEATURE_DRM_CONNECTOR
 #import "ADEPT/NYPLADEPTErrors.h"

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -518,54 +518,10 @@ Authenticating with any of those barcodes should work.
   if (self.businessLogic.selectedAuthentication.isOauth) {
     [self.businessLogic oauthLogIn];
   } else if (self.businessLogic.selectedAuthentication.isSaml) {
-    [self samlLogIn];
+    [self.businessLogic.samlHelper logIn];
   } else {
     [self barcodeLogIn];
   }
-}
-
-// TODO: SIMPLY-2510 move to NYPLSignInBusinesLogic
-- (void)samlLogIn
-{
-  // for this kind of authentication, we want user to authenticate in a built in webview, as we need to access the cookies later on
-
-  // get the url of IDP that user selected
-  NSURL *idpURL = self.businessLogic.selectedIDP.url;
-
-  NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithURL:idpURL resolvingAgainstBaseURL:true];
-
-  // add redirect uri param
-  NSURLQueryItem *redirect_uri = [[NSURLQueryItem alloc] initWithName:@"redirect_uri" value:NYPLSettings.shared.authenticationUniversalLink.absoluteString];
-  urlComponents.queryItems = [urlComponents.queryItems arrayByAddingObject:redirect_uri];
-  NSURL *url = urlComponents.URL;
-
-  void (^loginCompletionHandler)(NSURL * _Nonnull, NSArray<NSHTTPCookie *> * _Nonnull) = ^(NSURL * _Nonnull url, NSArray<NSHTTPCookie *> * _Nonnull cookies) {
-    // when user login successfully, get cookies
-    self.cookies = cookies;
-
-    // process the last redirection url to get the oauth token
-    [self.businessLogic handleRedirectURL:
-     [NSNotification
-      notificationWithName:NSNotification.NYPLAppDelegateDidReceiveCleverRedirectURL
-      object:url
-      userInfo:nil]];
-
-    // and close the webview
-    [self dismissViewControllerAnimated:YES completion:nil];
-  };
-
-  // create a model for webview authentication process
-  NYPLCookiesWebViewModel *model = [[NYPLCookiesWebViewModel alloc] initWithCookies:@[]
-                                                                            request:[[NSURLRequest alloc] initWithURL:url]
-                                                             loginCompletionHandler:loginCompletionHandler
-                                                                 loginCancelHandler:nil
-                                                                   bookFoundHandler:nil
-                                                                problemFoundHandler:nil
-                                                                autoPresentIfNeeded:NO];
-
-  NYPLCookiesWebViewController *cookiesVC = [[NYPLCookiesWebViewController alloc] initWithModel:model];
-  UINavigationController *navigationWrapper = [[UINavigationController alloc] initWithRootViewController:cookiesVC];
-  [self presentViewController:navigationWrapper animated:YES completion:nil];
 }
 
 - (void)barcodeLogIn

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.m
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.m
@@ -928,53 +928,10 @@ completionHandler:(void (^)(void))handler
   if (self.businessLogic.selectedAuthentication.isOauth) {
     [self.businessLogic oauthLogIn];
   } else if (self.businessLogic.selectedAuthentication.isSaml) {
-    [self samlLogIn];
+    [self.businessLogic.samlHelper logIn];
   } else {
     [self barcodeLogIn];
   }
-}
-
-- (void)samlLogIn
-{
-  // for this kind of authentication, we want user to authenticate in a built in webview, as we need to access the cookies later on
-
-  // get the url of IDP that user selected
-  NSURL *idpURL = self.businessLogic.selectedIDP.url;
-
-  NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithURL:idpURL resolvingAgainstBaseURL:true];
-
-  // add redirect uri param
-  NSURLQueryItem *redirect_uri = [[NSURLQueryItem alloc] initWithName:@"redirect_uri" value:NYPLSettings.shared.authenticationUniversalLink.absoluteString];
-  urlComponents.queryItems = [urlComponents.queryItems arrayByAddingObject:redirect_uri];
-  NSURL *url = urlComponents.URL;
-
-  void (^loginCompletionHandler)(NSURL * _Nonnull, NSArray<NSHTTPCookie *> * _Nonnull) = ^(NSURL * _Nonnull url, NSArray<NSHTTPCookie *> * _Nonnull cookies) {
-    // when user login successfully, get cookies
-    self.cookies = cookies;
-
-    // process the last redirection url to get the oauth token
-    [self.businessLogic handleRedirectURL:
-     [NSNotification
-      notificationWithName:NSNotification.NYPLAppDelegateDidReceiveCleverRedirectURL
-      object:url
-      userInfo:nil]];
-
-    // and close the webview
-    [self dismissViewControllerAnimated:YES completion:nil];
-  };
-
-  // create a model for webview authentication process
-  NYPLCookiesWebViewModel *model = [[NYPLCookiesWebViewModel alloc] initWithCookies:@[]
-                                                                            request:[[NSURLRequest alloc] initWithURL:url]
-                                                             loginCompletionHandler:loginCompletionHandler
-                                                                 loginCancelHandler:nil
-                                                                   bookFoundHandler:nil
-                                                                problemFoundHandler:nil
-                                                                autoPresentIfNeeded:NO];
-
-  NYPLCookiesWebViewController *cookiesVC = [[NYPLCookiesWebViewController alloc] initWithModel:model];
-  UINavigationController *navigationWrapper = [[UINavigationController alloc] initWithRootViewController:cookiesVC];
-  [self presentViewController:navigationWrapper animated:YES completion:nil];
 }
 
 - (void)barcodeLogIn

--- a/Simplified/SignInLogic/NYPLSAMLHelper.h
+++ b/Simplified/SignInLogic/NYPLSAMLHelper.h
@@ -1,0 +1,20 @@
+//
+//  NYPLSAMLHelper.h
+//  Simplified
+//
+//  Created by Ettore Pasquini on 10/21/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class NYPLSignInBusinessLogic;
+
+@interface NYPLSAMLHelper : NSObject
+
+@property (weak) NYPLSignInBusinessLogic *businessLogic;
+
+// Log in via SAML.
+- (void)logIn;
+
+@end

--- a/Simplified/SignInLogic/NYPLSAMLHelper.m
+++ b/Simplified/SignInLogic/NYPLSAMLHelper.m
@@ -1,0 +1,66 @@
+//
+//  NYPLSAMLHelper.m
+//  Simplified
+//
+//  Created by Ettore Pasquini on 10/21/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+#import "SimplyE-Swift.h"
+
+#import "NYPLSAMLHelper.h"
+
+
+@implementation NYPLSAMLHelper
+
+- (void)logIn
+{
+  // for this kind of authentication, we want the user to authenticate in a
+  // built-in webview, as we need to access the cookies later on
+
+  // get the url of IDP that user selected
+  NSURL *idpURL = self.businessLogic.selectedIDP.url;
+
+  NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithURL:idpURL resolvingAgainstBaseURL:true];
+
+  // add redirect uri param
+  NSURLQueryItem *redirect_uri = [[NSURLQueryItem alloc] initWithName:@"redirect_uri" value:NYPLSettings.shared.authenticationUniversalLink.absoluteString];
+  urlComponents.queryItems = [urlComponents.queryItems arrayByAddingObject:redirect_uri];
+  NSURL *url = urlComponents.URL;
+
+  void (^loginCompletionHandler)(NSURL * _Nonnull, NSArray<NSHTTPCookie *> * _Nonnull) = ^(NSURL * _Nonnull url, NSArray<NSHTTPCookie *> * _Nonnull cookies) {
+
+    // when user login successfully, get cookies
+    self.businessLogic.cookies = cookies;
+
+    // process the last redirection url to get the oauth token
+    [self.businessLogic handleRedirectURL:
+     [NSNotification
+      notificationWithName:NSNotification.NYPLAppDelegateDidReceiveCleverRedirectURL
+      object:url
+      userInfo:nil]];
+
+    // and close the webview
+    [self.businessLogic.uiDelegate dismissViewControllerAnimated:YES
+                                                      completion:nil];
+  };
+
+  // create a model for webview authentication process
+  NYPLCookiesWebViewModel *model = [[NYPLCookiesWebViewModel alloc]
+                                    initWithCookies:@[]
+                                    request:[[NSURLRequest alloc] initWithURL:url]
+                                    loginCompletionHandler:loginCompletionHandler
+                                    loginCancelHandler:nil
+                                    bookFoundHandler:nil
+                                    problemFoundHandler:nil
+                                    autoPresentIfNeeded:NO];
+
+  NYPLCookiesWebViewController *cookiesVC = [[NYPLCookiesWebViewController alloc]
+                                             initWithModel:model];
+  UINavigationController *navigationWrapper = [[UINavigationController alloc] initWithRootViewController:cookiesVC];
+  [self.businessLogic.uiDelegate presentViewController:navigationWrapper
+                                              animated:YES
+                                            completion:nil];
+}
+
+@end

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogicUIDelegate.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogicUIDelegate.swift
@@ -27,4 +27,12 @@ import Foundation
   /// The business logic to validate the current credentials.
   /// - TODO: SIMPLY-2510 Do not use, this is here only temporarily.
   func validateCredentials()
+
+  @objc(dismissViewControllerAnimated:completion:)
+  func dismiss(animated flag: Bool, completion: (() -> Void)?)
+
+  @objc(presentViewController:animated:completion:)
+  func present(_ viewControllerToPresent: UIViewController,
+               animated flag: Bool,
+               completion: (() -> Void)?)
 }


### PR DESCRIPTION
**What's this do?**
Refactors the SAML code to remove a method that was duplicated identically in 2 classes. The refactored code was moved to NYPLSAMLHelper as-is. 
Changes in business logic are 99% just documentation + reorg.

**Why are we doing this? (w/ JIRA link if applicable)**
This is part of https://jira.nypl.org/browse/SIMPLY-2510

**How should this be tested? / Do these changes have associated tests?**
Sign in via SAML using Columbia University test library. Ask for credentials if you don't have them.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 