### PR TITLE
SIMPLY-2804 R2 Bookmark syncing

### DIFF
--- a/Simplified/NYPLAnnotations.swift
+++ b/Simplified/NYPLAnnotations.swift
@@ -626,7 +626,7 @@ import UIKit
         "source": bookID,
         "selector": [
           "type": "oa:FragmentSelector",
-          "value": bookmark.location ?? ""
+          "value": bookmark.location
         ]
       ],
       "body": [

--- a/Simplified/NYPLAnnotations.swift
+++ b/Simplified/NYPLAnnotations.swift
@@ -626,7 +626,7 @@ import UIKit
         "source": bookID,
         "selector": [
           "type": "oa:FragmentSelector",
-          "value": bookmark.location
+          "value": bookmark.location ?? ""
         ]
       ],
       "body": [

--- a/Simplified/NYPLBookRegistry.h
+++ b/Simplified/NYPLBookRegistry.h
@@ -13,7 +13,25 @@ static NSString *const _Nonnull NYPLBookRegistryDidChangeNotification =
 static NSString *const _Nonnull NYPLBookProcessingDidChangeNotification =
   @"NYPLBookProcessingDidChangeNotification";
 
-@interface NYPLBookRegistry : NSObject
+@protocol NYPLBookRegistryProvider <NSObject>
+
+- (nonnull NSArray<NYPLReadiumBookmark *> *)readiumBookmarksForIdentifier:(nonnull NSString *)identifier;
+
+- (nullable NYPLBookLocation *)locationForIdentifier:(nonnull NSString *)identifier;
+
+- (void)addReadiumBookmark:(nonnull NYPLReadiumBookmark *)bookmark
+             forIdentifier:(nonnull NSString *)identifier;
+  
+- (void)deleteReadiumBookmark:(nonnull NYPLReadiumBookmark *)bookmark
+                forIdentifier:(nonnull NSString *)identifier;
+
+- (void)replaceBookmark:(nonnull NYPLReadiumBookmark *)oldBookmark
+                   with:(nonnull NYPLReadiumBookmark *)newBookmark
+          forIdentifier:(nonnull NSString *)identifier;
+
+@end
+
+@interface NYPLBookRegistry : NSObject <NYPLBookRegistryProvider>
 
 // Returns all registered books.
 @property (atomic, readonly, nonnull) NSArray *allBooks;

--- a/Simplified/NYPLReadiumBookmark.swift
+++ b/Simplified/NYPLReadiumBookmark.swift
@@ -47,6 +47,9 @@
     self.idref = idref
     self.chapter = chapter ?? ""
     self.page = page ?? ""
+    // This location structure originally comes from R1 Reader's Javascript
+    // and its not available in R2, we are mimicking the structure
+    // in order to pass the needed information to the server
     self.location = location ?? "{\"idref\":\"\(idref)\",\"contentCFI\":\"\(contentCFI ?? "")\"}"
     self.progressWithinChapter = progressWithinChapter
     self.progressWithinBook = progressWithinBook
@@ -108,11 +111,13 @@
         return self.idref == other.idref
             && self.contentCFI == other.contentCFI
             && self.location == other.location
+            && self.chapter == other.chapter
     } else {
       // R2
       return self.idref == other.idref
         && self.progressWithinBook == other.progressWithinBook
         && self.progressWithinChapter == other.progressWithinChapter
+        && self.chapter == other.chapter
     }
   }
 }

--- a/Simplified/NYPLReadiumBookmark.swift
+++ b/Simplified/NYPLReadiumBookmark.swift
@@ -8,7 +8,7 @@
 
   // location and contentCFI are location information generated from R1 reader
   // which are not available in R2, therefore they are now optionals
-  var location:String?
+  var location:String
   var idref:String
   var contentCFI:String?
   var progressWithinChapter:Float = 0.0
@@ -47,7 +47,7 @@
     self.idref = idref
     self.chapter = chapter ?? ""
     self.page = page ?? ""
-    self.location = location
+    self.location = location ?? "{\"idref\":\"\(idref)\",\"contentCFI\":\"\(contentCFI ?? "")\"}"
     self.progressWithinChapter = progressWithinChapter
     self.progressWithinBook = progressWithinBook
     self.time = time ?? NSDate().rfc3339String()
@@ -90,7 +90,7 @@
             "idref":self.idref,
             "chapter":self.chapter ?? "",
             "page":self.page ?? "",
-            "location":self.location ?? "",
+            "location":self.location,
             "time":self.time,
             "device":self.device ?? "",
             "progressWithinChapter":self.progressWithinChapter,
@@ -101,14 +101,19 @@
   override func isEqual(_ object: Any?) -> Bool {
     let other = object as! NYPLReadiumBookmark
 
-    if (self.contentCFI == other.contentCFI &&
-      self.idref == other.idref &&
-      self.chapter == other.chapter &&
-      self.location == other.location)
-    {
-      return true
+    if let contentCFI = self.contentCFI,
+      let otherContentCFI = other.contentCFI,
+      contentCFI.count > 0 && otherContentCFI.count > 0 {
+        // R1
+        return self.idref == other.idref
+            && self.contentCFI == other.contentCFI
+            && self.location == other.location
+    } else {
+      // R2
+      return self.idref == other.idref
+        && self.progressWithinBook == other.progressWithinBook
+        && self.progressWithinChapter == other.progressWithinChapter
     }
-    return false
   }
 }
 

--- a/Simplified/Reader2/NYPLReaderBookmarksBusinessLogic.swift
+++ b/Simplified/Reader2/NYPLReaderBookmarksBusinessLogic.swift
@@ -225,7 +225,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject, NYPLReadiumViewSyncManagerDele
       NYPLMainThreadRun.asyncIfNeeded { [weak self] in
         self?.bookmarks = bookmarks
         vc.tableView.reloadData()
-//        vc.bookmarksRefreshControl.endRefreshing()
+        vc.bookmarksRefreshControl?.endRefreshing()
         if !success {
           let alert = NYPLAlertUtils.alert(title: "Error Syncing Bookmarks",
                                            message: "There was an error syncing bookmarks to the server. Ensure your device is connected to the internet or try again later.")
@@ -291,7 +291,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject, NYPLReadiumViewSyncManagerDele
     var localBookmarksToDelete = [NYPLReadiumBookmark]()
     // Bookmarks that are present on the server, but not the client, should be added to this
     // client as long as they were not created on this device originally.
-    var serverBookmarksToKeep = [NYPLReadiumBookmark]()
+    var serverBookmarksToKeep = serverBookmarks
     // Bookmarks present on the server, that were originally created on this device,
     // and are no longer present on the client, should be deleted on the server.
     var serverBookmarksToDelete = [NYPLReadiumBookmark]()
@@ -301,9 +301,9 @@ class NYPLReaderBookmarksBusinessLogic: NSObject, NYPLReadiumViewSyncManagerDele
         
       localBookmarksToKeep.append(contentsOf: matchingBookmarks)
         
-      if (matchingBookmarks.count == 0 &&
-          serverBookmark.device != nil &&
-          serverBookmark.device == NYPLUserAccount.sharedAccount().deviceID)
+      if let deviceID = serverBookmark.device,
+        deviceID == NYPLUserAccount.sharedAccount().deviceID
+        && matchingBookmarks.count == 0
       {
         serverBookmarksToDelete.append(serverBookmark)
         if let indexToRemove = serverBookmarksToKeep.index(of: serverBookmark) {

--- a/Simplified/Reader2/NYPLReaderBookmarksBusinessLogic.swift
+++ b/Simplified/Reader2/NYPLReaderBookmarksBusinessLogic.swift
@@ -201,7 +201,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject, NYPLReadiumViewSyncManagerDele
     guard let currentAccount = AccountsManager.shared.currentAccount,
         let details = currentAccount.details,
         let annotationId = bookmark.annotationId else {
-      Log.debug(#file, "Delete on Server skipped: Sync is not enabled or Annotation ID did not exist for bookmark.")
+      Log.debug(#file, "Delete on Server skipped: Annotation ID did not exist for bookmark.")
       return
     }
     
@@ -233,7 +233,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject, NYPLReadiumViewSyncManagerDele
                                             timeoutInternal: 8.0,
                                             handler: { (reachable) in
       if (!reachable) {
-        Log.debug(#file, "Error: host was not reachable for bookmark sync attempt.")
+        Log.warn(#file, "Error: host was not reachable for bookmark sync attempt.")
         self.bookmarks = self.bookRegistry.readiumBookmarks(forIdentifier: self.book.identifier)
         completion(false, self.bookmarks)
         return
@@ -265,7 +265,11 @@ class NYPLReaderBookmarksBusinessLogic: NSObject, NYPLReadiumViewSyncManagerDele
           self.updateLocalBookmarks(serverBookmarks: serverBookmarks,
                                      localBookmarks: localBookmarks,
                                      bookmarksFailedToUpload: bookmarksFailedToUpload)
-          {
+          { [weak self] in
+            guard let self = self else {
+              completion(false, localBookmarks)
+              return
+            }
             self.bookmarks = self.bookRegistry.readiumBookmarks(forIdentifier: self.book.identifier)
             completion(true, self.bookmarks)
           }

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -64,9 +64,6 @@ class NYPLBaseReaderViewController: UIViewController, NYPLBackgroundWorkOwner, L
       bookRegistry: NYPLBookRegistry.shared())
 
     bookmarksBusinessLogic.syncBookmarks { (_, _) in }
-    
-    // TODO: SIMPLY-2804
-    //backgroundHelper = NYPLBackgroundExecutor(owner: self, taskName: "R2init")
 
     super.init(nibName: nil, bundle: nil)
 
@@ -442,7 +439,9 @@ extension NYPLBaseReaderViewController: NYPLReaderPositionsDelegate {
   }
 
   func positionsVC(_ positionsVC: NYPLReaderPositionsVC,
-                   didRequestSyncBookmarksWithCompletion completion: (_ success: Bool, _ bookmarks: [NYPLReadiumBookmark]) -> Void) {
-    // TODO: SIMPLY-2804
+                   didRequestSyncBookmarksWithCompletion completion: @escaping (_ success: Bool, _ bookmarks: [NYPLReadiumBookmark]) -> Void) {
+    bookmarksBusinessLogic.syncBookmarks { (success, bookmarks) in
+      completion(success, bookmarks)
+    }
   }
 }

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -61,7 +61,8 @@ class NYPLBaseReaderViewController: UIViewController, NYPLBackgroundWorkOwner, L
       book: book,
       r2Publication: publication,
       drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
-      bookRegistry: NYPLBookRegistry.shared())
+      bookRegistryProvider: NYPLBookRegistry.shared(),
+      currentLibraryAccountProvider: AccountsManager.shared)
 
     bookmarksBusinessLogic.syncBookmarks { (_, _) in }
 

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -60,8 +60,11 @@ class NYPLBaseReaderViewController: UIViewController, NYPLBackgroundWorkOwner, L
     bookmarksBusinessLogic = NYPLReaderBookmarksBusinessLogic(
       book: book,
       r2Publication: publication,
-      drmDeviceID: NYPLUserAccount.sharedAccount().deviceID)
+      drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
+      bookRegistry: NYPLBookRegistry.shared())
 
+    bookmarksBusinessLogic.syncBookmarks { (_, _) in }
+    
     // TODO: SIMPLY-2804
     //backgroundHelper = NYPLBackgroundExecutor(owner: self, taskName: "R2init")
 

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -440,8 +440,6 @@ extension NYPLBaseReaderViewController: NYPLReaderPositionsDelegate {
 
   func positionsVC(_ positionsVC: NYPLReaderPositionsVC,
                    didRequestSyncBookmarksWithCompletion completion: @escaping (_ success: Bool, _ bookmarks: [NYPLReadiumBookmark]) -> Void) {
-    bookmarksBusinessLogic.syncBookmarks { (success, bookmarks) in
-      completion(success, bookmarks)
-    }
+    bookmarksBusinessLogic.syncBookmarks(completion: completion)
   }
 }

--- a/Simplified/Reader2/UI/NYPLReaderPositionsVC.swift
+++ b/Simplified/Reader2/UI/NYPLReaderPositionsVC.swift
@@ -16,7 +16,7 @@ protocol NYPLReaderPositionsDelegate: class {
   func positionsVC(_ positionsVC: NYPLReaderPositionsVC, didSelectTOCLocation loc: Any)
   func positionsVC(_ positionsVC: NYPLReaderPositionsVC, didSelectBookmark bookmark: NYPLReadiumBookmark)
   func positionsVC(_ positionsVC: NYPLReaderPositionsVC, didDeleteBookmark bookmark: NYPLReadiumBookmark)
-  func positionsVC(_ positionsVC: NYPLReaderPositionsVC, didRequestSyncBookmarksWithCompletion completion: (_ success: Bool, _ bookmarks: [NYPLReadiumBookmark]) -> Void)
+  func positionsVC(_ positionsVC: NYPLReaderPositionsVC, didRequestSyncBookmarksWithCompletion completion: @escaping (_ success: Bool, _ bookmarks: [NYPLReadiumBookmark]) -> Void)
 }
 
 // MARK: -
@@ -31,7 +31,7 @@ class NYPLReaderPositionsVC: UIViewController, UITableViewDataSource, UITableVie
   @IBOutlet weak var tableView: UITableView!
   @IBOutlet weak var segmentedControl: UISegmentedControl!
   @IBOutlet weak var noBookmarksLabel: UILabel!
-  private(set) var bookmarksRefreshControl: UIRefreshControl?
+  private var bookmarksRefreshControl: UIRefreshControl?
 
   private let reuseIdentifierTOC = "contentCell"
   private let reuseIdentifierBookmark = "bookmarkCell"
@@ -247,7 +247,17 @@ class NYPLReaderPositionsVC: UIViewController, UITableViewDataSource, UITableVie
 
   @objc(userDidRefreshBookmarksWith:)
   private func userDidRefreshBookmarks(with refreshControl: UIRefreshControl) {
-    bookmarksBusinessLogic?.refreshBookmarks(inVC: self)
+    delegate?.positionsVC(self, didRequestSyncBookmarksWithCompletion: { (success, bookmarks) in
+      NYPLMainThreadRun.asyncIfNeeded { [weak self] in
+        self?.tableView.reloadData()
+        self?.bookmarksRefreshControl?.endRefreshing()
+        if !success {
+          let alert = NYPLAlertUtils.alert(title: "Error Syncing Bookmarks",
+                                           message: "There was an error syncing bookmarks to the server. Ensure your device is connected to the internet or try again later.")
+          self?.present(alert, animated: true)
+        }
+      }
+    })
   }
 
   private func configRefreshControl() {

--- a/Simplified/Reader2/UI/NYPLReaderPositionsVC.swift
+++ b/Simplified/Reader2/UI/NYPLReaderPositionsVC.swift
@@ -31,7 +31,7 @@ class NYPLReaderPositionsVC: UIViewController, UITableViewDataSource, UITableVie
   @IBOutlet weak var tableView: UITableView!
   @IBOutlet weak var segmentedControl: UISegmentedControl!
   @IBOutlet weak var noBookmarksLabel: UILabel!
-  private var bookmarksRefreshControl: UIRefreshControl?
+  private(set) var bookmarksRefreshControl: UIRefreshControl?
 
   private let reuseIdentifierTOC = "contentCell"
   private let reuseIdentifierBookmark = "bookmarkCell"


### PR DESCRIPTION
**What's this do?**
Add, delete and sync bookmarks from server for R2
Probably easier to review by single commit

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-2804](https://jira.nypl.org/projects/SIMPLY/issues/SIMPLY-2804)

**How should this be tested? / Do these changes have associated tests?**
Make sure `bookmark syncing` is turned on in account detail
Open any epub book and create a bookmark
Go to bookmark list, the bookmark should be shown
Pull down to refresh and look for `server bookmark count` in debug area, which should be the same as the number of bookmarks in the list
*Since the bookmarks in the list could be local cache, this is the way to test the syncing without clearing the cache*
Delete a bookmark and repeat the step above to make sure bookmark on server is removed
For QA, I will have to talk to Joe to figure out what's their method on testing server bookmark

**Dependencies for merging? Releasing to production?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 