### PR TITLE
SIMPLY-2510 Break up validation logic to highlight similarities between sign-in modal and account settings tab

### DIFF
--- a/Simplified/ErrorHandling/NYPLAlertUtils.swift
+++ b/Simplified/ErrorHandling/NYPLAlertUtils.swift
@@ -143,7 +143,7 @@ import UIKit
 
     let docDetail = detailWasAdded ? "" : (document.detail ?? "")
 
-    if !titleWasAdded, let docTitle = document.title, !docTitle.isEmpty {
+    if !titleWasAdded, let docTitle = document.title, !docTitle.isEmpty, docTitle != alert.title {
       alert.message = "\(existingMsg)\(docTitle)\n\(docDetail)"
     } else {
       alert.message = "\(existingMsg)\(docDetail)"

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -201,10 +201,9 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
       [NYPLErrorLogger
        logProblemDocumentParseError:problemDocumentParseError
        problemDocumentData:problemDocData
-       barcode:NYPLUserAccount.sharedAccount.barcode
        url:tmpSavedFileURL
        summary:[NSString stringWithFormat:@"Error parsing problem doc downloading %@ book", book.distributor]
-       message:[book loggableShortString]];
+       metadata:@{ @"book": [book loggableShortString] }];
     }
     [self logBookDownloadFailure:book
                           reason:@"Got problem document"

--- a/Simplified/NYPLOPDSFeed.m
+++ b/Simplified/NYPLOPDSFeed.m
@@ -99,7 +99,7 @@ completionHandler:(void (^)(NYPLOPDSFeed *feed, NSDictionary *error))handler
                                 message:nil
                                metadata:@{
                                  @"Request": [request loggableString],
-                                 @"Response": response,
+                                 @"Response": response ?: @"N/A",
                                }];
       NYPLAsyncDispatch(^{handler(nil, nil);});
       return;

--- a/Simplified/Network/NYPLRemoteViewController.m
+++ b/Simplified/Network/NYPLRemoteViewController.m
@@ -296,12 +296,14 @@
     UIAlertController *alert;
 
     if (problemDocumentParseError) {
-      [NYPLErrorLogger logProblemDocumentParseError:problemDocumentParseError
-                                problemDocumentData:data
-                                            barcode:nil
-                                                url:httpResponse.URL
-                                            summary:@"Catalog api fail: Problem Doc parse error"
-                                            message:@"Server-side api call (likely related to Catalog loading) failed and couldn't parse the problem doc either"];
+      [NYPLErrorLogger
+       logProblemDocumentParseError:problemDocumentParseError
+       problemDocumentData:data
+       url:httpResponse.URL
+       summary:@"Catalog api fail: Problem Doc parse error"
+       metadata:@{
+         @"message": @"Server-side api call (likely related to Catalog loading) failed and couldn't parse the problem doc either"
+       }];
       alert = [NYPLAlertUtils
                alertWithTitle:NSLocalizedString(@"Error", @"Title for a generic error")
                message:NSLocalizedString(@"Unknown error parsing problem document",


### PR DESCRIPTION
**What's this do?**
This does some preparation work for refactoring the duplicated logic present in NYPLAccountSignInViewController and NYPLSettingsAccountDetailViewController, by making it obvious which parts of the sign-in validation are indeed identical between the 2 classes. It is now simple to see that the following methods are almost identical:

- validateCredentials
- drmAuthorizeUserData:loggingContext:
- drmAuthorizeWithUsername:password:loggingContext:
- alertUserOfValidationError:problemDocData:response:loggingContext:
- authorizationAttemptDidFinish:error:errorMessage:

This enables a subsequent refactor to actually remove the duplication.

Unfortunately because the code was / is so messy, it might be difficult to see what changed in the Sign-in modal. I could not find another way to do this. I can do a code walkthrough if needed. Changes there consist in basically breaking the gigantic `validateCredentials` method into 4 different methods. There are no functionality changes to report, but things like retain cycles, main thread issues, and other implementation details  (for example) could have snuck in.

The `authorizationAttemptDidFinish...` method existed but was slightly different from what we have in the settings tab. The differences were irrelevant, so I changed it match the settings tab.

A few things were removed for simplicity, such as logging of the barcode, because the benefit of doing this refactor far outweighs the benefit of logging a likely user typing error.

**Why are we doing this? (w/ JIRA link if applicable)**
This is part of https://jira.nypl.org/browse/SIMPLY-2510

**How should this be tested? / Do these changes have associated tests?**
Signing in and out using the sign-in modal or the settings tab should behave identical as before.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 
I explored sign-in success and fail cases in both the modal and the settings tab.