### PR TITLE
SIMPLY-2510 Refactor sign-in finalization logic

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -557,6 +557,9 @@
 		739ECB2E25108EE800691A70 /* NYPLRootTabBarController+SE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739ECB2D25108EE800691A70 /* NYPLRootTabBarController+SE.swift */; };
 		739ECB2F25108EE800691A70 /* NYPLRootTabBarController+SE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739ECB2D25108EE800691A70 /* NYPLRootTabBarController+SE.swift */; };
 		73A3EAED2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 73A3EAEC2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m */; };
+		73A794A625477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A794A525477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift */; };
+		73A794A725477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A794A525477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift */; };
+		73A794A825477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A794A525477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift */; };
 		73AA32D824EF0853000C90B2 /* URLResponse+NYPL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */; };
 		73AA32D924EF0B1F000C90B2 /* NYPLBook+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340DA6724B7F27900361387 /* NYPLBook+Additions.swift */; };
 		73B501C524F48D4C00FBAD7D /* NYPLUserAccountFrontEndValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B501C024F48D4B00FBAD7D /* NYPLUserAccountFrontEndValidation.swift */; };
@@ -1302,6 +1305,7 @@
 		739ECB2D25108EE800691A70 /* NYPLRootTabBarController+SE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLRootTabBarController+SE.swift"; sourceTree = "<group>"; };
 		73A3EAEB2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NYPLSettingsAccountURLSessionChallengeHandler.h; sourceTree = "<group>"; };
 		73A3EAEC2400A9560061A7FB /* NYPLSettingsAccountURLSessionChallengeHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NYPLSettingsAccountURLSessionChallengeHandler.m; sourceTree = "<group>"; };
+		73A794A525477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+UI.swift"; sourceTree = "<group>"; };
 		73B501C024F48D4B00FBAD7D /* NYPLUserAccountFrontEndValidation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLUserAccountFrontEndValidation.swift; sourceTree = "<group>"; };
 		73C3A33F244108F200AFE44D /* carthage-update-simplye.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = "carthage-update-simplye.sh"; path = "scripts/carthage-update-simplye.sh"; sourceTree = SOURCE_ROOT; };
 		73CDA120243EDAD8009CC6A6 /* URLRequest+NYPL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+NYPL.swift"; sourceTree = "<group>"; };
@@ -1966,6 +1970,7 @@
 				089E42C5249A823800310360 /* NYPLCookiesWebViewController.swift */,
 				731A5B1124621F2B00B5E663 /* NYPLSignInBusinessLogic.swift */,
 				733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */,
+				73A794A525477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift */,
 				739062D125358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift */,
 				73422116252FE4950053DA9E /* NYPLSignInViewController+OESelectAuth.swift */,
 				73B501C024F48D4B00FBAD7D /* NYPLUserAccountFrontEndValidation.swift */,
@@ -3094,6 +3099,7 @@
 				21C504792513C9F30016A6C8 /* DPLAAudiobooks.swift in Sources */,
 				7347F062245A4DE200558D7F /* NYPLOPDSCategory.m in Sources */,
 				7347F063245A4DE200558D7F /* NYPLNull.m in Sources */,
+				73A794A725477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift in Sources */,
 				7347F064245A4DE200558D7F /* NYPLLinearView.m in Sources */,
 				7347F065245A4DE200558D7F /* NSDate+NYPLDateAdditions.m in Sources */,
 				7347F066245A4DE200558D7F /* NYPLBook.m in Sources */,
@@ -3281,6 +3287,7 @@
 				73FCA2C325005BA4001B0C5D /* NYPLBookCell.m in Sources */,
 				73FCA2C425005BA4001B0C5D /* NSURL+NYPLURLAdditions.m in Sources */,
 				73FCA2C525005BA4001B0C5D /* NYPLAsync.m in Sources */,
+				73A794A825477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift in Sources */,
 				73FCA2C625005BA4001B0C5D /* NYPLReloadView.m in Sources */,
 				73FCA2C725005BA4001B0C5D /* NYPLReachabilityManager.m in Sources */,
 				73FCA2C825005BA4001B0C5D /* NYPLReadiumViewSyncManager.m in Sources */,
@@ -3491,6 +3498,7 @@
 				119BEBB919902A8800121439 /* NYPLOpenSearchDescription.m in Sources */,
 				11BFDB36199C08E900378691 /* NYPLReaderTOCElement.m in Sources */,
 				2DC8D9DC1D09F797007DD125 /* UpdateCheck.swift in Sources */,
+				73A794A625477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift in Sources */,
 				11BFDB33199C01F700378691 /* NYPLReaderTOCViewController.m in Sources */,
 				B51C1DFA2285FDF9003B49A5 /* OPDS2CatalogsFeed.swift in Sources */,
 				2D62568B1D412BCB0080A81F /* BundledHTMLViewController.swift in Sources */,
@@ -3848,7 +3856,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PRODUCT_NAME = SimplyECardCreator;
@@ -3904,7 +3912,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.0;
+				MARKETING_VERSION = 3.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PRODUCT_NAME = SimplyECardCreator;
@@ -4168,7 +4176,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4185,7 +4193,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
@@ -4219,7 +4227,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4240,7 +4248,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";

--- a/Simplified/ErrorHandling/NYPLAlertUtils.swift
+++ b/Simplified/ErrorHandling/NYPLAlertUtils.swift
@@ -3,6 +3,24 @@ import UIKit
 
 @objcMembers class NYPLAlertUtils : NSObject {
   /**
+   Generates an alert view controller. If the `message` is non-nil, it will be
+   used instead of deriving the error message from the `error`.
+
+   - Parameter title: The alert title; can be a localization key.
+   - Parameter error: An error. If the error contains a localizedDescription, that will be used for the alert message.
+   - Returns: The alert controller to be presented.
+   */
+  class func alert(title: String?,
+                   message: String?,
+                   error: NSError?) -> UIAlertController {
+    if let message = message {
+      return alert(title: title, message: message)
+    } else {
+      return alert(title: title, error: error)
+    }
+  }
+
+  /**
     Generates an alert view from errors of domains: NSURLErrorDomain, NYPLADEPTErrorDomain
 
    - Parameter title: The alert title; can be a localization key.

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.h
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.h
@@ -4,23 +4,11 @@
 /// places in the app when necessary. Managing account sign in with settings is
 /// NYPLSettingsAccountDetailViewController.
 @interface NYPLAccountSignInViewController : UITableViewController
-@property (nonatomic, copy) void (^completionHandler)(void);
 
 - (id)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 
 @property(readonly) NYPLSignInBusinessLogic *businessLogic;
-
-/**
- * Presents itself to begin the login process.
- *
- * @param useExistingBarcode Should the screen be filled with the barcode when available?
- * @param authorizeImmediately Should the authentication process begin automatically after presenting? For Oauth2 and SAML it would mean opening a webview.
- * @param completionHandler Called upon successful authentication
- */
-- (void)presentUsingExistingBarcode:(BOOL const)useExistingBarcode
-               authorizeImmediately:(BOOL)authorizeImmediately
-                  completionHandler:(void (^)(void))handler;
 
 /**
  * Present sign in view controller to begin a login process.

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+UI.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+UI.swift
@@ -1,0 +1,106 @@
+//
+//  NYPLSignInBusinessLogic+UI.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 10/26/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import UIKit
+
+extension NYPLSignInBusinessLogic {
+
+  /// Finalizes the sign in process by updating the user account for the
+  /// library we are signing in to and calling the completion handler in
+  /// case that was set, as well as dismissing the presented view controller
+  /// in case the `uiDelegate` was a modal.
+  /// - Important: This must be called on the main thread.
+  /// - Parameters:
+  ///   - drmSuccess: whether the DRM authorization was successful or not.
+  ///   Ignored if the app is built without DRM support.
+  ///   - error: The error encountered during sign-in, if any.
+  ///   - errorMessage: Error message to display, taking priority over `error`.
+  ///   - barcode: The new barcode, if available.
+  ///   - pin: The new PIN, if barcode is provided.
+  ///   - authToken: the token if `selectedAuthentication` is OAuth or SAML.
+  ///   - patron: The patron info for OAuth / SAML authentication.
+  ///   - cookies: Cookies for SAML authentication.
+  @objc func finalizeSignIn(forDRMAuthorization drmSuccess: Bool,
+                            error: Error?,
+                            errorMessage: String?,
+                            withBarcode barcode: String?,
+                            pin: String?,
+                            authToken: String?,
+                            patron: [String:Any]?,
+                            cookies: [HTTPCookie]?) {
+
+    updateUserAccount(forDRMAuthorization: drmSuccess,
+                      withBarcode: barcode,
+                      pin: pin,
+                      authToken: authToken,
+                      patron: patron,
+                      cookies: cookies)
+
+    #if FEATURE_DRM_CONNECTOR
+    guard drmSuccess else {
+      NotificationCenter.default.post(name: .NYPLSyncEnded, object: nil)
+
+      let alert = NYPLAlertUtils.alert(title: "SettingsAccountViewControllerLoginFailed",
+                                       message: errorMessage,
+                                       error: error as NSError?)
+      NYPLRootTabBarController.shared()?
+        .safelyPresentViewController(alert, animated: true, completion: nil)
+      return
+    }
+    #endif
+
+    // no need to force a login, as we just logged in successfully
+    ignoreSignedInState = false
+
+    if let completionHandler = completionHandler {
+      self.completionHandler = nil
+      if isLoggingInAfterSignUp {
+        completionHandler()
+      } else {
+        uiDelegate?.dismiss(animated: true, completion: completionHandler)
+      }
+    }
+  }
+
+  /// Performs log out using the given executor verifying no book registry
+  /// syncing or book downloads/returns authorizations are in progress.
+  /// - Parameter logOutExecutor: The object actually performing the log out.
+  /// - Returns: An alert the caller needs to present.
+  @objc func logOutOrWarn(using logOutExecutor: NYPLLogOutExecutor) -> UIAlertController? {
+
+    let title = NSLocalizedString("SignOut",
+                                  comment: "Title for sign out action")
+    let msg: String
+    if bookRegistry.syncing {
+      msg = NSLocalizedString("Your bookmarks and reading positions are in the process of being saved to the server. Would you like to stop that and continue logging out?",
+                              comment: "Warning message offering the user the choice of interrupting book registry syncing to log out immediately, or waiting until that finishes.")
+    } else if let drm = drmAuthorizer, drm.workflowsInProgress {
+      msg = NSLocalizedString("It looks like you may have a book download or return in progress. Would you like to stop that and continue logging out?",
+                              comment: "Warning message offering the user the choice of interrupting the download or return of a book to log out immediately, or waiting until that finishes.")
+    } else {
+      logOutExecutor.performLogOut()
+      return nil
+    }
+
+    let alert = UIAlertController(title: title,
+                                  message: msg,
+                                  preferredStyle: .alert)
+    alert.addAction(
+      UIAlertAction(title: title,
+                    style: .destructive,
+                    handler: { _ in
+                      logOutExecutor.performLogOut()
+      }))
+    alert.addAction(
+      UIAlertAction(title: NSLocalizedString("Wait", comment: "button title"),
+                    style: .cancel,
+                    handler: nil))
+
+    return alert
+  }
+}

--- a/SimplifiedTests/NYPLSignInBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLSignInBusinessLogicTests.swift
@@ -40,7 +40,8 @@ class NYPLSignInBusinessLogicTests: XCTestCase {
     XCTAssertNotEqual(user.PIN, "newPIN")
 
     // test
-    businessLogic.updateUserAccount(withBarcode: "newBarcode",
+    businessLogic.updateUserAccount(forDRMAuthorization: true,
+                                    withBarcode: "newBarcode",
                                     pin: "newPIN",
                                     authToken: nil,
                                     patron: nil,
@@ -59,7 +60,8 @@ class NYPLSignInBusinessLogicTests: XCTestCase {
     businessLogic.selectedAuthentication = libraryAccountMock.barcodeAuthentication
 
     // test
-    businessLogic.updateUserAccount(withBarcode: "newBarcode",
+    businessLogic.updateUserAccount(forDRMAuthorization: true,
+                                    withBarcode: "newBarcode",
                                     pin: "newPIN",
                                     authToken: nil,
                                     patron: nil,
@@ -80,7 +82,8 @@ class NYPLSignInBusinessLogicTests: XCTestCase {
     let patron = ["name": "ciccio"]
 
     // test
-    businessLogic.updateUserAccount(withBarcode: nil,
+    businessLogic.updateUserAccount(forDRMAuthorization: true,
+                                    withBarcode: nil,
                                     pin: nil,
                                     authToken: "some-great-token",
                                     patron: patron,
@@ -108,7 +111,8 @@ class NYPLSignInBusinessLogicTests: XCTestCase {
     ])!]
 
     // test
-    businessLogic.updateUserAccount(withBarcode: nil,
+    businessLogic.updateUserAccount(forDRMAuthorization: true,
+                                    withBarcode: nil,
                                     pin: nil,
                                     authToken: "some-great-token",
                                     patron: patron,


### PR DESCRIPTION
**What's this do?**
Move logic that was in `authorizationAttemptDidFinish:error:errorMessage` (now renamed to `finalizeSignInForDRMAuthorization:error:errorMessage` to the business logic class since it is and should be identical between the 2 VCs. While doind this 2 changes were done:
1. the sign-in modal had 2 additional calls to `updateLoginLogoutCellAppearance` and `accountDidChange` that were actually redundant (i.e. already called)
2. the settings account VC did not have a call to `NYPLUserAccount::removeAll` in case of DRM failure, so this was added (it can't hurt, and there's no reason why one VC should have and the other not)

Also, `NYPLSignInBusinessLogic::logOutOrWarn(using:)` was moved as-is to the UI extension.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2510

**How should this be tested? / Do these changes have associated tests?**
Work for this ticket is not completed. This code changes should not introduce any changes in sign-in functionality for both the modal sign-in and the settings sign-in.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 