### PR TITLE
SIMPLY-2510 Refactor sign-in logic handling DRM authorization

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -525,6 +525,9 @@
 		7375AE5B25382AC900C85211 /* NYPLUserAccountMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7375AE5925382AC900C85211 /* NYPLUserAccountMock.swift */; };
 		737F4A532549D78100A3C34B /* NYPLBookCreationTestsObjc.m in Sources */ = {isa = PBXBuildFile; fileRef = 737F4A522549D78100A3C34B /* NYPLBookCreationTestsObjc.m */; };
 		737F4A542549D78100A3C34B /* NYPLBookCreationTestsObjc.m in Sources */ = {isa = PBXBuildFile; fileRef = 737F4A522549D78100A3C34B /* NYPLBookCreationTestsObjc.m */; };
+		737F4A6B254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737F4A6A254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift */; };
+		737F4A6C254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737F4A6A254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift */; };
+		737F4A6D254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737F4A6A254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift */; };
 		738170152526504800BA2C44 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 738170142526504800BA2C44 /* GoogleService-Info.plist */; };
 		7384C757252D20AA0012C2DD /* NYPLBook+DistributorChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7384C756252D20AA0012C2DD /* NYPLBook+DistributorChecks.swift */; };
 		7384C758252D20AA0012C2DD /* NYPLBook+DistributorChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7384C756252D20AA0012C2DD /* NYPLBook+DistributorChecks.swift */; };
@@ -1286,6 +1289,7 @@
 		7360D0D424BFCB9700C8AD16 /* NYPLUserFriendlyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserFriendlyError.swift; sourceTree = "<group>"; };
 		7375AE5925382AC900C85211 /* NYPLUserAccountMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserAccountMock.swift; sourceTree = "<group>"; };
 		737F4A522549D78100A3C34B /* NYPLBookCreationTestsObjc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NYPLBookCreationTestsObjc.m; sourceTree = "<group>"; };
+		737F4A6A254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+DRM.swift"; sourceTree = "<group>"; };
 		738170142526504800BA2C44 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		7384C756252D20AA0012C2DD /* NYPLBook+DistributorChecks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLBook+DistributorChecks.swift"; sourceTree = "<group>"; };
 		7384C7FF242BB43300D5F960 /* NYPLCachingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLCachingTests.swift; sourceTree = "<group>"; };
@@ -1978,14 +1982,15 @@
 				1158812D1A894F4E008672C3 /* NYPLAccountSignInViewController.m */,
 				086C45D524AE77CA00F5108E /* NYPLBasicAuth.swift */,
 				089E42C5249A823800310360 /* NYPLCookiesWebViewController.swift */,
+				730263AA2540DE4200A53891 /* NYPLSAMLHelper.h */,
+				730263AB2540DE4200A53891 /* NYPLSAMLHelper.m */,
 				731A5B1124621F2B00B5E663 /* NYPLSignInBusinessLogic.swift */,
+				737F4A6A254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift */,
 				733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */,
 				73A794A525477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift */,
 				739062D125358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift */,
 				73422116252FE4950053DA9E /* NYPLSignInViewController+OESelectAuth.swift */,
 				73B501C024F48D4B00FBAD7D /* NYPLUserAccountFrontEndValidation.swift */,
-				730263AA2540DE4200A53891 /* NYPLSAMLHelper.h */,
-				730263AB2540DE4200A53891 /* NYPLSAMLHelper.m */,
 			);
 			path = SignInLogic;
 			sourceTree = "<group>";
@@ -3147,6 +3152,7 @@
 				7347F078245A4DE200558D7F /* NYPLAppTheme.swift in Sources */,
 				7347F079245A4DE200558D7F /* UIColor+NYPLColorAdditions.m in Sources */,
 				7347F07A245A4DE200558D7F /* URLRequest+NYPL.swift in Sources */,
+				737F4A6C254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift in Sources */,
 				730EDFF42515386B0038DD9F /* NYPLLibraryDescriptionCell.swift in Sources */,
 				7347F07B245A4DE200558D7F /* NYPLCatalogFeedViewController.m in Sources */,
 				7347F07C245A4DE200558D7F /* NYPLBookDownloadingCell.m in Sources */,
@@ -3359,6 +3365,7 @@
 				73FCA2F125005BA4001B0C5D /* URLRequest+NYPL.swift in Sources */,
 				21C504772513C9F00016A6C8 /* JWKResponse.swift in Sources */,
 				73FCA2F225005BA4001B0C5D /* NYPLCredentials.swift in Sources */,
+				737F4A6D254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift in Sources */,
 				73FCA2F325005BA4001B0C5D /* NYPLCatalogFeedViewController.m in Sources */,
 				73FCA2F425005BA4001B0C5D /* NYPLBookDownloadingCell.m in Sources */,
 				73FCA2F525005BA4001B0C5D /* NYPLTenPrintCoverView+NYPLImageAdditions.m in Sources */,
@@ -3557,6 +3564,7 @@
 				E683953B217663B100371072 /* NYPLFacetViewDefaultDataSource.swift in Sources */,
 				E6207B652118973800864143 /* NYPLAppTheme.swift in Sources */,
 				11A14DF41A1BF94F00D6C510 /* UIColor+NYPLColorAdditions.m in Sources */,
+				737F4A6B254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift in Sources */,
 				73CDA121243EDAD8009CC6A6 /* URLRequest+NYPL.swift in Sources */,
 				0857A0F72478337D00C7984E /* NYPLCredentials.swift in Sources */,
 				A42E0DF41B40F4E00095EBAE /* NYPLCatalogFeedViewController.m in Sources */,

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+DRM.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+DRM.swift
@@ -1,0 +1,160 @@
+//
+//  NYPLSignInBusinessLogic+DRM.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 10/28/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+#if FEATURE_DRM_CONNECTOR
+
+extension NYPLSignInBusinessLogic {
+
+  /// Extract authorization credentials from binary data and perform DRM
+  /// authorization request.
+  ///
+  /// - Parameters:
+  ///   - data: The binary data containing the DRM authorization info.
+  ///   - loggingContext: Information to report when logging errors.
+  func drmAuthorizeUserData(_ data: Data, loggingContext: [String: Any]) {
+    let profileDoc: UserProfileDocument
+    do {
+      profileDoc = try UserProfileDocument.fromData(data)
+    } catch {
+      NYPLErrorLogger.logUserProfileDocumentAuthError(error as NSError,
+                                                      summary:"SignIn: unable to parse user profile doc",
+                                                      barcode:nil,
+                                                      metadata:loggingContext)
+      uiDelegate?.finalizeSignIn(forDRMAuthorization: false,
+                                 error: nil,
+                                 errorMessage: "Error parsing user profile document")
+      return
+    }
+
+    if let authID = profileDoc.authorizationIdentifier {
+      userAccount.setAuthorizationIdentifier(authID)
+    } else {
+      NYPLErrorLogger.logError(withCode: .noAuthorizationIdentifier,
+                               summary: "SignIn: no authorization ID in user profile doc",
+                               metadata: loggingContext)
+    }
+
+    guard
+      let drm = profileDoc.drm?.first,
+      drm.vendor != nil,
+      let clientToken = drm.clientToken else {
+
+        let drm = profileDoc.drm?.first
+        Log.info(#file, "\nLicensor: \(drm?.licensor ?? ["N/A": "N/A"])")
+
+        NYPLErrorLogger.logError(withCode: .noLicensorToken,
+                                 summary: "SignIn: no licensor token in user profile doc",
+                                 metadata: loggingContext)
+
+        uiDelegate?.finalizeSignIn(forDRMAuthorization: false,
+                                   error: nil,
+                                   errorMessage: "No credentials were received to authorize access to books with DRM.")
+        return
+    }
+
+
+    Log.info(#file, "\nLicensor: \(drm.licensor)")
+    userAccount.setLicensor(drm.licensor)
+
+    var licensorItems = clientToken.replacingOccurrences(of: "\n", with: "").components(separatedBy: "|")
+    let tokenPassword = licensorItems.last
+    licensorItems.removeLast()
+    let tokenUsername = (licensorItems as NSArray).componentsJoined(by: "|")
+
+    drmAuthorize(username: tokenUsername,
+                 password: tokenPassword,
+                 loggingContext: loggingContext)
+  }
+
+  /// Perform the DRM authorization request with the given credentials
+  ///
+  /// - Parameters:
+  ///   - username: Adobe DRM token username.
+  ///   - password: Adobe DRM token password. The only reason why this is
+  ///   optional is because ADEPT already handles `nil` values, so we don't
+  ///   have to do the same here.
+  ///   - loggingContext: Information to report when logging errors.
+  private func drmAuthorize(username: String,
+                            password: String?,
+                            loggingContext: [String: Any]) {
+
+    let vendor = userAccount.licensor?["vendor"] as? String
+
+    Log.info(#file, """
+      ***DRM Auth/Activation Attempt***
+      Token username: \(username)
+      Token password: \(password ?? "N/A")
+      VendorID: \(vendor ?? "N/A")
+      """)
+
+    NYPLADEPT.sharedInstance()?
+      .authorize(withVendorID: vendor,
+                 username: username,
+                 password: password) { success, error, deviceID, userID in
+
+                  OperationQueue.main.addOperation { [weak self] in
+                    if let self = self {
+                      NSObject.cancelPreviousPerformRequests(withTarget: self)
+                    }
+                  }
+
+                  Log.info(#file, """
+                    Activation success: \(success)
+                    Error: \(error?.localizedDescription ?? "N/A")
+                    DeviceID: \(deviceID ?? "N/A")
+                    UserID: \(userID ?? "N/A")
+                    ***DRM Auth/Activation completion***
+                    """)
+
+                  var success = success
+
+                  if success, let userID = userID, let deviceID = deviceID {
+                    OperationQueue.main.addOperation {
+                      self.userAccount.setUserID(userID)
+                      self.userAccount.setDeviceID(deviceID)
+                    }
+                  } else {
+                    success = false
+                    NYPLErrorLogger.logLocalAuthFailed(error: error as NSError?,
+                                                       library: self.libraryAccount,
+                                                       metadata: loggingContext)
+                  }
+
+                  self.uiDelegate?.finalizeSignIn(forDRMAuthorization: success,
+                                                  error: error as NSError?,
+                                                  errorMessage: nil)
+    }
+
+    perform(#selector(dismissAfterUnexpectedDRMDelay), with: self, afterDelay: 25)
+  }
+
+  @objc func dismissAfterUnexpectedDRMDelay(_ arg: Any) {
+
+    let title = NSLocalizedString("Sign In Error",
+                                  comment: "Title for sign in error alert")
+    let message = NSLocalizedString("The DRM Library is taking longer than expected. Please wait and try again later.\n\nIf the problem persists, try to sign out and back in again from the Library Settings menu.",
+                                    comment: "Message for sign-in error alert caused by failed DRM authorization")
+
+    let alert = UIAlertController(title: title, message: message,
+                                  preferredStyle: .alert)
+    alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "OK"),
+                                  style: .default) { [weak self] action in
+                                    self?.uiDelegate?.dismiss(animated: true,
+                                                              completion: nil)
+    })
+
+    NYPLAlertUtils.presentFromViewControllerOrNil(alertController: alert,
+                                                  viewController: nil,
+                                                  animated: true,
+                                                  completion: nil)
+  }
+}
+
+#endif

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+UI.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+UI.swift
@@ -14,12 +14,14 @@ extension NYPLSignInBusinessLogic {
   /// library we are signing in to and calling the completion handler in
   /// case that was set, as well as dismissing the presented view controller
   /// in case the `uiDelegate` was a modal.
+  /// - Note: This does not log the error/message to Crashlytics.
   /// - Important: This must be called on the main thread.
   /// - Parameters:
   ///   - drmSuccess: whether the DRM authorization was successful or not.
   ///   Ignored if the app is built without DRM support.
   ///   - error: The error encountered during sign-in, if any.
   ///   - errorMessage: Error message to display, taking priority over `error`.
+  ///   This can be a localization key.
   ///   - barcode: The new barcode, if available.
   ///   - pin: The new PIN, if barcode is provided.
   ///   - authToken: the token if `selectedAuthentication` is OAuth or SAML.

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
@@ -93,6 +93,9 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider {
   /// the session expired (e.g. SAML flow).
   var ignoreSignedInState: Bool = false
 
+  /// This is `true` during the process of signing in / validating credentials.
+  var isCurrentlySigningIn = false
+
   // MARK:- Juvenile Card Creation Info
 
   private let juvenileAuthLock = NSLock()

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogicUIDelegate.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogicUIDelegate.swift
@@ -28,6 +28,17 @@ import Foundation
   /// - TODO: SIMPLY-2510 Do not use, this is here only temporarily.
   func validateCredentials()
 
+  /// After signing in and authorizing for DRM successfully or not, the
+  /// business logic will let the UI know the result by calling this method.
+  /// - Parameters:
+  ///   - success: Whether DRM authorization succeeded or not.
+  ///   - error: The error that occurred, if any.
+  ///   - errorMessage: A specific error message in case an `error` object is
+  ///   missing.
+  func finalizeSignIn(forDRMAuthorization success: Bool,
+                      error: NSError?,
+                      errorMessage: String?)
+
   @objc(dismissViewControllerAnimated:completion:)
   func dismiss(animated flag: Bool, completion: (() -> Void)?)
 
@@ -35,4 +46,5 @@ import Foundation
   func present(_ viewControllerToPresent: UIViewController,
                animated flag: Bool,
                completion: (() -> Void)?)
+
 }


### PR DESCRIPTION
**What's this do?**
Note that the 2 objc implementations of `drmAuthorizeWithUsername:password:loggingContext:` where slightly different in the 2 VCs, with the modal implementation performing an additional check to warn the user if the DRM authorization takes too long. Since this seems like a good idea, this is now added to both (the VC dismissal will result in nothing for a non-modal VC in the stack).

The implementations of `drmAuthorizeUserData:loggingContext` were instead identical in the 2 VCs.

Both are now rewritten in swift and added to NYPLSignInBusinessLogic as an extension.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2510

**How should this be tested? / Do these changes have associated tests?**
As other PRs for this ticket, no changes in functionality should be observed from what we currently have.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
Yes, added docs for all the new methods.

**Did someone actually run this code to verify it works?**
@ettore 