### PR TITLE
SIMPLY-3211 Don't add constraints for "Signing Out" view if already present

### DIFF
--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -1601,6 +1601,11 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
 - (void)updateLoginLogoutCellAppearance
 {
   if([self.selectedUserAccount hasCredentials]) {
+    // check if we have added the activity view for signing out
+    if ([self.logInSignOutCell.contentView viewWithTag:sLinearViewTag] != nil) {
+      return;
+    }
+
     self.logInSignOutCell.textLabel.text = NSLocalizedString(@"SignOut", @"Title for sign out action");
     self.logInSignOutCell.textLabel.textAlignment = NSTextAlignmentCenter;
     self.logInSignOutCell.textLabel.textColor = [NYPLConfiguration mainColor];
@@ -1636,6 +1641,11 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
     return;
   }
 
+  // check if we already added the activity view
+  if ([self.logInSignOutCell.contentView viewWithTag:sLinearViewTag] != nil) {
+    return;
+  }
+
   UIActivityIndicatorView *aiv;
   if (@available(iOS 13.0, *)) {
     aiv = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
@@ -1665,9 +1675,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
   [linearView autoSetDimensionsToSize:CGSizeMake(linearView.frame.size.width, linearView.frame.size.height)];
   
   self.logInSignOutCell.textLabel.text = nil;
-  if (![self.logInSignOutCell.contentView viewWithTag:sLinearViewTag]) {
-    [self.logInSignOutCell.contentView addSubview:linearView];
-  }
+  [self.logInSignOutCell.contentView addSubview:linearView];
   [linearView autoCenterInSuperview];
 }
 

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.m
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.m
@@ -956,6 +956,11 @@ completionHandler:(void (^)(void))handler
   if (self.logInSignOutCell.contentView == nil) {
     return;
   }
+
+  // check if we already added the activity view
+  if ([self.logInSignOutCell.contentView viewWithTag:sLinearViewTag] != nil) {
+    return;
+  }
   
   UIActivityIndicatorView *const activityIndicatorView =
   [[UIActivityIndicatorView alloc]
@@ -982,13 +987,8 @@ completionHandler:(void (^)(void))handler
   [linearView autoSetDimensionsToSize:CGSizeMake(linearView.frame.size.width, linearView.frame.size.height)];
   
   self.logInSignOutCell.textLabel.text = nil;
-  if (![self.logInSignOutCell.contentView viewWithTag:sLinearViewTag]) {
-    [self.logInSignOutCell.contentView addSubview:linearView];
-  }
-
-  if (linearView.superview) {
-    [linearView autoCenterInSuperview];
-  }
+  [self.logInSignOutCell.contentView addSubview:linearView];
+  [linearView autoCenterInSuperview];
 }
 
 - (void)removeActivityTitle {


### PR DESCRIPTION
**What's this do?**
If we already added the "Signing Out" "linear view", we were skipping adding the view to the superview but at the same time we were still adding constraints to the newly created view in relation to the superview, which was nil, causing the crash.

This change makes the `setActivityTitleWithText` idempotent.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3211

**How should this be tested? / Do these changes have associated tests?**
Steps are in the ticket description.

**Dependencies for merging? Releasing to production?**
n/a/

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 