### PR TITLE
SIMPLY-2510 Refactor remaining sign-in business logic out of VCs

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -575,6 +575,9 @@
 		73B72F11254C5A8B008725CA /* NYPLSignInURLSessionChallengeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B72F10254C5A8B008725CA /* NYPLSignInURLSessionChallengeHandler.swift */; };
 		73B72F12254C5A8B008725CA /* NYPLSignInURLSessionChallengeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B72F10254C5A8B008725CA /* NYPLSignInURLSessionChallengeHandler.swift */; };
 		73B72F13254C5A8B008725CA /* NYPLSignInURLSessionChallengeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B72F10254C5A8B008725CA /* NYPLSignInURLSessionChallengeHandler.swift */; };
+		73B80BAB25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B80BAA25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift */; };
+		73B80BAC25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B80BAA25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift */; };
+		73B80BAD25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B80BAA25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift */; };
 		73CDA121243EDAD8009CC6A6 /* URLRequest+NYPL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CDA120243EDAD8009CC6A6 /* URLRequest+NYPL.swift */; };
 		73CEF830252699CA006B2820 /* FirebaseCrashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73CEF82F252699C9006B2820 /* FirebaseCrashlytics.framework */; };
 		73CEF831252699DD006B2820 /* FirebaseCrashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73CEF82F252699C9006B2820 /* FirebaseCrashlytics.framework */; };
@@ -1320,6 +1323,7 @@
 		73A794C925492C9800C59CC1 /* NYPLFakeSamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLFakeSamples.swift; sourceTree = "<group>"; };
 		73B501C024F48D4B00FBAD7D /* NYPLUserAccountFrontEndValidation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLUserAccountFrontEndValidation.swift; sourceTree = "<group>"; };
 		73B72F10254C5A8B008725CA /* NYPLSignInURLSessionChallengeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSignInURLSessionChallengeHandler.swift; sourceTree = "<group>"; };
+		73B80BAA25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+CardCreation.swift"; sourceTree = "<group>"; };
 		73C3A33F244108F200AFE44D /* carthage-update-simplye.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = "carthage-update-simplye.sh"; path = "scripts/carthage-update-simplye.sh"; sourceTree = SOURCE_ROOT; };
 		73CDA120243EDAD8009CC6A6 /* URLRequest+NYPL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+NYPL.swift"; sourceTree = "<group>"; };
 		73CEF82F252699C9006B2820 /* FirebaseCrashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCrashlytics.framework; path = Carthage/Build/iOS/FirebaseCrashlytics.framework; sourceTree = "<group>"; };
@@ -1982,6 +1986,7 @@
 				730263AA2540DE4200A53891 /* NYPLSAMLHelper.h */,
 				730263AB2540DE4200A53891 /* NYPLSAMLHelper.m */,
 				731A5B1124621F2B00B5E663 /* NYPLSignInBusinessLogic.swift */,
+				73B80BAA25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift */,
 				737F4A6A254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift */,
 				733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */,
 				73A794A525477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift */,
@@ -3117,6 +3122,7 @@
 				739ECB2C25102A2B00691A70 /* NYPLCatalogs+SE.swift in Sources */,
 				7347F05C245A4DE200558D7F /* OPDS2CatalogsFeed.swift in Sources */,
 				7347F05D245A4DE200558D7F /* BundledHTMLViewController.swift in Sources */,
+				73B80BAC25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift in Sources */,
 				7347F05E245A4DE200558D7F /* NYPLBookDetailView.m in Sources */,
 				7347F05F245A4DE200558D7F /* UIButton+NYPLAppearanceAdditions.m in Sources */,
 				7347F060245A4DE200558D7F /* NYPLBookCoverRegistry.m in Sources */,
@@ -3457,6 +3463,7 @@
 				73FCA34625005BA4001B0C5D /* NYPLAnnotations.swift in Sources */,
 				73FCA34725005BA4001B0C5D /* RemoteHTMLViewController.swift in Sources */,
 				73FCA34825005BA4001B0C5D /* NYPLBookDetailsProblemDocumentViewController.swift in Sources */,
+				73B80BAD25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift in Sources */,
 				73FCA34925005BA4001B0C5D /* NYPLCatalogGroupedFeed.m in Sources */,
 				73FCA34A25005BA4001B0C5D /* NYPLCatalogFacet.m in Sources */,
 				73FCA34B25005BA4001B0C5D /* NYPLLoginCellTypes.swift in Sources */,
@@ -3529,6 +3536,7 @@
 				B51C1DFA2285FDF9003B49A5 /* OPDS2CatalogsFeed.swift in Sources */,
 				2D62568B1D412BCB0080A81F /* BundledHTMLViewController.swift in Sources */,
 				110AF8961961D94D004887C3 /* NYPLBookDetailView.m in Sources */,
+				73B80BAB25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift in Sources */,
 				0813875A1BC5767F003DEA6A /* UIButton+NYPLAppearanceAdditions.m in Sources */,
 				1139DA6519C7755D00A07810 /* NYPLBookCoverRegistry.m in Sources */,
 				73085E3525030D27008F6244 /* SEMigrations.swift in Sources */,

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.m
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.m
@@ -761,57 +761,6 @@ completionHandler:(void (^)(void))handler
   [self dismissViewControllerAnimated:YES completion:nil];
 }
 
-- (void)verifyLocationServicesWithHandler:(void(^)(void))handler
-{
-  CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
-
-  switch (status) {
-    case kCLAuthorizationStatusAuthorizedAlways:
-      if (handler) handler();
-      break;
-    case kCLAuthorizationStatusAuthorizedWhenInUse:
-      if (handler) handler();
-      break;
-    case kCLAuthorizationStatusDenied:
-    {
-      UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Location", nil)
-                                                                               message:NSLocalizedString(@"LocationRequiredMessage", nil)
-                                                                        preferredStyle:UIAlertControllerStyleAlert];
-
-      UIAlertAction *settingsAction = [UIAlertAction
-                                       actionWithTitle:NSLocalizedString(@"Settings", nil)
-                                       style:UIAlertActionStyleDefault
-                                       handler:^(UIAlertAction *action) {
-        if (action) {
-          [UIApplication.sharedApplication
-           openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
-           options:@{}
-           completionHandler:nil];
-        }
-      }];
-
-      UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil)
-                                                             style:UIAlertActionStyleDestructive
-                                                           handler:nil];
-
-      [alertController addAction:settingsAction];
-      [alertController addAction:cancelAction];
-
-      [self presentViewController:alertController
-                         animated:NO
-                       completion:nil];
-
-      break;
-    }
-    case kCLAuthorizationStatusRestricted:
-      if (handler) handler();
-      break;
-    case kCLAuthorizationStatusNotDetermined:
-      if (handler) handler();
-      break;
-  }
-}
-
 - (void)didSelectReveal
 {
   self.hiddenPIN = NO;

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.m
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.m
@@ -13,7 +13,6 @@
 #import "NYPLBookRegistry.h"
 #import "NYPLConfiguration.h"
 #import "NYPLLinearView.h"
-#import "NYPLMyBooksDownloadCenter.h"
 #import "NYPLOPDSFeed.h"
 #import "NYPLReachability.h"
 #import "NYPLRootTabBarController.h"
@@ -323,17 +322,7 @@ CGFloat const marginPadding = 2.0;
 - (void)viewDidAppear:(BOOL)animated
 {
   [super viewDidAppear:animated];
-
-  NYPLUserAccount *userAccount = self.businessLogic.userAccount;
-
-  if (![[NYPLADEPT sharedInstance] isUserAuthorized:[userAccount userID]
-                                         withDevice:[userAccount deviceID]]) {
-    if ([userAccount hasBarcodeAndPIN] && !self.businessLogic.isCurrentlySigningIn) {
-      self.usernameTextField.text = userAccount.barcode;
-      self.PINTextField.text = userAccount.PIN;
-      [self.businessLogic logIn];
-    }
-  }
+  [self.businessLogic logInIfUserAuthorized];
 }
 #endif
 

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+CardCreation.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+CardCreation.swift
@@ -1,0 +1,61 @@
+//
+//  NYPLSignInBusinessLogic+CardCreation.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 11/2/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+import NYPLCardCreator
+
+extension NYPLSignInBusinessLogic {
+  @objc func makeCardCreatorIfPossible() -> UINavigationController? {
+
+    // if the library does not have a sign-up url, there's nothing we can do
+    guard let signUpURL = libraryAccount?.details?.signUpUrl else {
+      NYPLErrorLogger.logError(withCode: .nilSignUpURL,
+                               summary: "SignUp Error in Settings: nil signUp URL",
+                               message: nil,
+                               metadata: [
+                                "libraryAccountUUID": libraryAccountID,
+                                "libraryAccountName": libraryAccount?.name ?? "N/A",
+      ])
+      return nil
+    }
+
+    // verify if the native card creator is supported for this library,
+    // otherwise default to web
+    guard libraryAccount?.details?.supportsCardCreator ?? false else {
+      let title = NSLocalizedString("eCard",
+                                    comment: "Title for web-based card creator page")
+      let msg = NSLocalizedString("SettingsConnectionFailureMessage",
+                                  comment: "Message for errors loading a HTML page")
+      let webVC = RemoteHTMLViewController(URL: signUpURL,
+                                           title: title,
+                                           failureMessage: msg)
+      return UINavigationController(rootViewController: webVC)
+    }
+
+    let config = makeRegularCardCreationConfiguration()
+    config.completionHandler = { [weak self] username, pin, isUserInitiated in
+      guard let self = self else {
+        return
+      }
+
+      if isUserInitiated {
+        // Dismiss CardCreator when user finishes Credential Review
+        self.uiDelegate?.dismiss(animated: true, completion: nil)
+      } else {
+        if let usernameTextField = self.uiDelegate?.usernameTextField, let PINTextField = self.uiDelegate?.PINTextField {
+          usernameTextField.text = username
+          PINTextField.text = pin
+        }
+        self.isLoggingInAfterSignUp = true
+        self.logIn()
+      }
+    }
+
+    return CardCreator.initialNavigationControllerWithConfiguration(config)
+  }
+}

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+DRM.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+DRM.swift
@@ -156,6 +156,24 @@ extension NYPLSignInBusinessLogic {
                                                     completion: nil)
     }
   }
+
+  @objc func logInIfUserAuthorized() {
+    if let drmAuthorizer = drmAuthorizer,
+      !drmAuthorizer.isUserAuthorized(userAccount.userID,
+                                      withDevice: userAccount.deviceID) {
+
+      if userAccount.hasBarcodeAndPIN() && !isCurrentlySigningIn {
+        if let usernameTextField = uiDelegate?.usernameTextField,
+          let PINTextField = uiDelegate?.PINTextField
+        {
+          usernameTextField.text = userAccount.barcode
+          PINTextField.text = userAccount.PIN
+        }
+
+        logIn()
+      }
+    }
+  }
 }
 
 #endif

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
@@ -427,8 +427,16 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider {
     return userAccount.hasCredentials()
   }
 
+  /// - Returns: Whether it is possible to sign up for a new account or not.
   func registrationIsPossible() -> Bool {
     return !isSignedIn() && NYPLConfiguration.cardCreationEnabled() && libraryAccount?.details?.signUpUrl != nil
+  }
+
+  /// - Returns: Whether it is possible to sign up using the native card
+  /// creator.
+  func registrationViaCardCreatorIsPossible() -> Bool {
+    return registrationIsPossible() &&
+      (libraryAccount?.details?.supportsCardCreator ?? false)
   }
 
   func isSamlPossible() -> Bool {

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
@@ -23,6 +23,7 @@ import NYPLCardCreator
 
 @objc protocol NYPLDRMAuthorizing: NSObjectProtocol {
   var workflowsInProgress: Bool {get}
+  func isUserAuthorized(_ userID: String!, withDevice device: String!) -> Bool
 }
 
 @objc protocol NYPLLogOutExecutor: NSObjectProtocol {

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
@@ -342,6 +342,26 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider {
     }
   }
 
+  @objc var isAuthenticationDocumentLoading: Bool = false
+
+  /// Makes sure we have the `libraryAccount` `details` loading the
+  /// authentication document if needed.
+  /// - Note: if an error occurs while loading the authentication document,
+  /// an error is reported via `NYPLErrorLogger`.
+  /// - Parameter completion: Always called once we have the library details.
+  @objc func ensureAuthenticationDocumentIsLoaded(_ completion: @escaping (Bool) -> Void) {
+    if libraryAccount?.details != nil {
+      completion(true)
+      return
+    }
+
+    isAuthenticationDocumentLoading = true
+    libraryAccount?.loadAuthenticationDocument(using: self) { success in
+      self.isAuthenticationDocumentLoading = false
+      completion(success)
+    }
+  }
+
   // MARK:- User Account Management
 
   /// The user account for the library we are signing in to.

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogicUIDelegate.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogicUIDelegate.swift
@@ -16,7 +16,7 @@ import Foundation
 }
 
 /// The functionalities on the UI that the sign-in business logic requires.
-@objc protocol NYPLSignInBusinessLogicUIDelegate: NYPLSignInUserProvidedCredentials {
+@objc protocol NYPLSignInBusinessLogicUIDelegate: NYPLSignInUserProvidedCredentials, NYPLUserAccountInputProvider {
   /// The context in which the UI delegate is operating in, such as in a modal
   /// sheet or a tab.
   /// - Note: This should not be derived from a computation involving views,

--- a/Simplified/SignInLogic/NYPLUserAccountFrontEndValidation.swift
+++ b/Simplified/SignInLogic/NYPLUserAccountFrontEndValidation.swift
@@ -14,8 +14,8 @@ import UIKit
  */
 @objc
 protocol NYPLUserAccountInputProvider {
-  var usernameTextField: UITextField! { get set }
-  var PINTextField: UITextField! { get set }
+  var usernameTextField: UITextField? { get set }
+  var PINTextField: UITextField? { get set }
 }
 
 @objcMembers class NYPLUserAccountFrontEndValidation: NSObject {


### PR DESCRIPTION
**What's this do?**
Removes the last part of sign-in business logic from the VCs:
- card creation logic
- DRM check in modal VC that automatically sign you in 
- implicit load of authentication document in settings account VC

 Note that sign-out business logic is still in NYPLSettingsAccountDetailViewController.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2510

**How should this be tested? / Do these changes have associated tests?**
test all ways of signing in and signing up in both the modal sign in page and the settings tab.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
y

**Did someone actually run this code to verify it works?**
@ettore 