### PR TITLE
SIMPLY-2804 Add unit tests for R2 bookmark business logic

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -128,6 +128,8 @@
 		175E480E24EF46EA0066A6CF /* NYPLAnnouncementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175E480D24EF46EA0066A6CF /* NYPLAnnouncementViewController.swift */; };
 		1763C0D624F460FE00A4D0E2 /* NYPLAnnouncementManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1763C0D524F460FE00A4D0E2 /* NYPLAnnouncementManagerTests.swift */; };
 		179699D124131BA500EC309F /* UIColor+LabelColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179699D024131BA500EC309F /* UIColor+LabelColor.swift */; };
+		17ADCF4F254BB84800D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17ADCF4E254BB84800D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift */; };
+		17ADCF54254BBA4E00D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17ADCF4E254BB84800D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift */; };
 		17CE5305243C020800315E63 /* NYPLUserAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE5304243C020800315E63 /* NYPLUserAccount.swift */; };
 		17D08381248E938000092AA9 /* OverdriveProcessor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17D08378248E8EEB00092AA9 /* OverdriveProcessor.framework */; };
 		17DFC5ED251E7FBC003A19CC /* AudioEngine.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; settings = {ATTRIBUTES = (Required, ); }; };
@@ -1568,6 +1570,7 @@
 		1763C0D524F460FE00A4D0E2 /* NYPLAnnouncementManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAnnouncementManagerTests.swift; sourceTree = "<group>"; };
 		176F8A802519684D00CE5BFB /* AudioEngine.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AudioEngine.xcframework; path = Carthage/Build/iOS/AudioEngine.xcframework; sourceTree = "<group>"; };
 		179699D024131BA500EC309F /* UIColor+LabelColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+LabelColor.swift"; sourceTree = "<group>"; };
+		17ADCF4E254BB84800D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLReaderBookmarksBusinessLogicTests.swift; sourceTree = "<group>"; };
 		17CE5304243C020800315E63 /* NYPLUserAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserAccount.swift; sourceTree = "<group>"; };
 		17D08378248E8EEB00092AA9 /* OverdriveProcessor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OverdriveProcessor.framework; path = Carthage/Build/iOS/OverdriveProcessor.framework; sourceTree = "<group>"; };
 		2198F90F250A90EE000D9DAB /* AudioBookVendorsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioBookVendorsHelper.swift; sourceTree = "<group>"; };
@@ -2979,6 +2982,7 @@
 				2D2B47631D08F1ED007F7764 /* UpdateCheckTests.swift */,
 				5D3A28D322D3FBB90042B3BD /* UserProfileDocumentTests.swift */,
 				735350B624918432006021BD /* URLRequest+NYPLTests.swift */,
+				17ADCF4E254BB84800D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift */,
 			);
 			path = SimplifiedTests;
 			sourceTree = "<group>";
@@ -3730,6 +3734,7 @@
 				735F41A3243E381D00046182 /* String+NYPLAdditionsTests.swift in Sources */,
 				173F0823241AAA4E00A64658 /* NYPLBookStateTests.swift in Sources */,
 				2199020624FD3334001BC727 /* NYPLJWKConversionTest.swift in Sources */,
+				17ADCF4F254BB84800D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift in Sources */,
 				735771AB2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift in Sources */,
 				1763C0D624F460FE00A4D0E2 /* NYPLAnnouncementManagerTests.swift in Sources */,
 				2D2B477C1D08F821007F7764 /* UpdateCheckTests.swift in Sources */,
@@ -3765,6 +3770,7 @@
 				735DD0D12522A0730096D1F9 /* URLRequest+NYPLTests.swift in Sources */,
 				735771AC2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift in Sources */,
 				7320AB2B251EBC9900E3F04D /* JWKResponse.swift in Sources */,
+				17ADCF54254BBA4E00D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift in Sources */,
 				735DD0AE2522935B0096D1F9 /* NYPLCachingTests.swift in Sources */,
 				7320AB30251EBC9900E3F04D /* NYPLJWKConversionTest.swift in Sources */,
 				735DD0CC2522A06C0096D1F9 /* OPDS2CatalogsFeedTests.swift in Sources */,

--- a/Simplified/Reader2/NYPLReaderBookmarksBusinessLogic.swift
+++ b/Simplified/Reader2/NYPLReaderBookmarksBusinessLogic.swift
@@ -282,7 +282,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject, NYPLReadiumViewSyncManagerDele
     })
   }
     
-  private func updateLocalBookmarks(serverBookmarks: [NYPLReadiumBookmark],
+  internal func updateLocalBookmarks(serverBookmarks: [NYPLReadiumBookmark],
                                      localBookmarks: [NYPLReadiumBookmark],
                                      bookmarksFailedToUpload: [NYPLReadiumBookmark],
                                      completion: @escaping () -> ())
@@ -300,7 +300,9 @@ class NYPLReaderBookmarksBusinessLogic: NSObject, NYPLReadiumViewSyncManagerDele
     for serverBookmark in serverBookmarks {
       let matched = localBookmarks.contains{ $0.annotationId == serverBookmark.annotationId }
         
-      localBookmarksToKeep.append(serverBookmark)
+      if matched {
+        localBookmarksToKeep.append(serverBookmark)
+      }
         
       if let deviceID = serverBookmark.device,
         let drmDeviceID = drmDeviceID,

--- a/Simplified/Reader2/NYPLReaderBookmarksBusinessLogic.swift
+++ b/Simplified/Reader2/NYPLReaderBookmarksBusinessLogic.swift
@@ -282,7 +282,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject, NYPLReadiumViewSyncManagerDele
     })
   }
     
-  internal func updateLocalBookmarks(serverBookmarks: [NYPLReadiumBookmark],
+  func updateLocalBookmarks(serverBookmarks: [NYPLReadiumBookmark],
                                      localBookmarks: [NYPLReadiumBookmark],
                                      bookmarksFailedToUpload: [NYPLReadiumBookmark],
                                      completion: @escaping () -> ())

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -17,7 +17,7 @@ import R2Shared
 
 
 /// This class is meant to be subclassed by each publication format view controller. It contains the shared behavior, eg. navigation bar toggling.
-class NYPLBaseReaderViewController: UIViewController, NYPLBackgroundWorkOwner, Loggable {
+class NYPLBaseReaderViewController: UIViewController, Loggable {
 
   private static let bookmarkOnImageName = "BookmarkOn"
   private static let bookmarkOffImageName = "BookmarkOff"
@@ -30,10 +30,6 @@ class NYPLBaseReaderViewController: UIViewController, NYPLBackgroundWorkOwner, L
   private let book: NYPLBook
   private let drm: DRM?
   private var bookmarksBusinessLogic: NYPLReaderBookmarksBusinessLogic
-
-  // TODO: SIMPLY-2804
-//  let backgroundHelper: NYPLBackgroundExecutor
-//  let syncManager: NYPLReadiumViewSyncManager?
 
   // UI
   let navigator: UIViewController & Navigator
@@ -193,22 +189,6 @@ class NYPLBaseReaderViewController: UIViewController, NYPLBackgroundWorkOwner, L
   }
 
   //----------------------------------------------------------------------------
-  // MARK: - NYPLBackgroundWorkOwner
-  // TODO: SIMPLY-2804
-
-  func setUpWorkItem(wrapping backgroundWork: @escaping () -> Void) -> (() -> Void)? {
-    return { }
-  }
-
-  func performBackgroundWork() {
-//    let bookMapDict: [AnyHashable : Any] = [:]//NYPLReaderReadiumView.generateBookDictionary
-//    self.syncManager = NYPLReadiumViewSyncManager(bookID: book.identifier,
-//                                                  annotationsURL: book.annotationsURL,
-//                                                  bookMap: bookMapDict,
-//                                                  delegate: bookmarksBusinessLogic)
-  }
-
-  //----------------------------------------------------------------------------
   // MARK: - TOC / Bookmarks
 
   private func shouldPresentAsPopover() -> Bool {
@@ -364,6 +344,13 @@ extension NYPLBaseReaderViewController: NavigatorDelegate {
         return nil
       }
     }()
+    
+    if let resourceIndex = publication.resourceIndex(forLocator: locator),
+      let _ = bookmarksBusinessLogic.isBookmarkExisting(at: NYPLBookmarkR2Location(resourceIndex: resourceIndex, locator: locator)) {
+      updateBookmarkButton(withState: true)
+    } else {
+      updateBookmarkButton(withState: false)
+    }
   }
 
   func navigator(_ navigator: Navigator, presentExternalURL url: URL) {

--- a/SimplifiedTests/Date+NYPLAdditionsTests.swift
+++ b/SimplifiedTests/Date+NYPLAdditionsTests.swift
@@ -33,9 +33,9 @@ class Date_NYPLAdditionsTests: XCTestCase {
     let dateString = "2020-06-02"
     let iOS10Date = NSDate(iso8601DateString: dateString)
     XCTAssertNotNil(iOS10Date)
-    XCTAssertEqual(iOS10Date?.utcComponents()?.year, 2020)
-    XCTAssertEqual(iOS10Date?.utcComponents()?.month, 6)
-    XCTAssertEqual(iOS10Date?.utcComponents()?.day, 2)
+    XCTAssertEqual(iOS10Date?.utcComponents().year, 2020)
+    XCTAssertEqual(iOS10Date?.utcComponents().month, 6)
+    XCTAssertEqual(iOS10Date?.utcComponents().day, 2)
   }
 
   func testInvalidRFC3339Date() {

--- a/SimplifiedTests/Mocks/NYPLBookRegistryMock.swift
+++ b/SimplifiedTests/Mocks/NYPLBookRegistryMock.swift
@@ -9,8 +9,9 @@
 import Foundation
 @testable import SimplyE
 
-class NYPLBookRegistryMock: NSObject, NYPLBookRegistrySyncing {
+class NYPLBookRegistryMock: NSObject, NYPLBookRegistrySyncing, NYPLBookRegistryProvider {
   var syncing = false
+  var identifiersToRecords = [String: NYPLBookRegistryRecord]()
 
   func reset(_ libraryAccountUUID: String) {
     syncing = false
@@ -25,5 +26,36 @@ class NYPLBookRegistryMock: NSObject, NYPLBookRegistrySyncing {
   }
 
   func save() {
+  }
+    
+  func readiumBookmarks(forIdentifier identifier: String) -> [NYPLReadiumBookmark] {
+    guard let record = identifiersToRecords[identifier] else { return [NYPLReadiumBookmark]() }
+    return record.readiumBookmarks.sorted{ $0.progressWithinBook > $1.progressWithinBook }
+  }
+  
+  func location(forIdentifier identifier: String) -> NYPLBookLocation? {
+    guard let record = identifiersToRecords[identifier] else { return nil }
+    return record.location
+  }
+    
+  func add(_ bookmark: NYPLReadiumBookmark, forIdentifier identifier: String) {
+    guard let record = identifiersToRecords[identifier] else { return }
+    var bookmarks = [NYPLReadiumBookmark]()
+    bookmarks.append(contentsOf: record.readiumBookmarks)
+    bookmarks.append(bookmark)
+    identifiersToRecords[identifier] = record.withReadiumBookmarks(bookmarks)
+  }
+
+  func delete(_ bookmark: NYPLReadiumBookmark, forIdentifier identifier: String) {
+    guard let record = identifiersToRecords[identifier] else { return }
+    let bookmarks = record.readiumBookmarks.filter { $0 != bookmark }
+    identifiersToRecords[identifier] = record.withReadiumBookmarks(bookmarks)
+  }
+  
+  func replace(_ oldBookmark: NYPLReadiumBookmark, with newBookmark: NYPLReadiumBookmark, forIdentifier identifier: String) {
+    guard let record = identifiersToRecords[identifier] else { return }
+    var bookmarks = record.readiumBookmarks.filter { $0 != oldBookmark }
+    bookmarks.append(newBookmark)
+    identifiersToRecords[identifier] = record.withReadiumBookmarks(bookmarks)
   }
 }

--- a/SimplifiedTests/Mocks/NYPLBookRegistryMock.swift
+++ b/SimplifiedTests/Mocks/NYPLBookRegistryMock.swift
@@ -28,6 +28,12 @@ class NYPLBookRegistryMock: NSObject, NYPLBookRegistrySyncing, NYPLBookRegistryP
   func save() {
   }
     
+  func addBook(book: NYPLBook,
+               state: NYPLBookState) {
+    let dict = ["metadata": book.dictionaryRepresentation(), "state": state.stringValue()] as [String : AnyObject]
+    self.identifiersToRecords[book.identifier] = NYPLBookRegistryRecord(dictionary: dict)
+  }
+    
   func readiumBookmarks(forIdentifier identifier: String) -> [NYPLReadiumBookmark] {
     guard let record = identifiersToRecords[identifier] else { return [NYPLReadiumBookmark]() }
     return record.readiumBookmarks.sorted{ $0.progressWithinBook > $1.progressWithinBook }

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -75,7 +75,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
 
     // MARK: - Test updateLocalBookmarks
     
-    func testSyncServerBookmarksWithNoLocalBookmarks() throws {
+    func testUpdateLocalBookmarksWithNoLocalBookmarks() throws {
       var serverBookmarks = [NYPLReadiumBookmark]()
         
       // Make sure BookRegistry contains no bookmark
@@ -97,7 +97,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       }
     }
     
-    func testSyncServerBookmarksWithDuplicatedLocalBookmarks() throws {
+    func testUpdateLocalBookmarksWithDuplicatedLocalBookmarks() throws {
       var serverBookmarks = [NYPLReadiumBookmark]()
 
       // Make sure BookRegistry contains no bookmark
@@ -128,7 +128,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       }
     }
     
-    func testSyncServerBookmarksWithExtraLocalBookmarks() throws {
+    func testUpdateLocalBookmarksWithExtraLocalBookmarks() throws {
       var serverBookmarks = [NYPLReadiumBookmark]()
 
       // Make sure BookRegistry contains no bookmark
@@ -160,7 +160,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       }
     }
     
-    func testSyncServerBookmarksWithFailedUploadBookmarks() throws {
+    func testUpdateLocalBookmarksWithFailedUploadBookmarks() throws {
       var serverBookmarks = [NYPLReadiumBookmark]()
 
       // Make sure BookRegistry contains no bookmark

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -1,0 +1,75 @@
+//
+//  NYPLReaderBookmarkBusinessLogicTests.swift
+//  SimplyETests
+//
+//  Created by Ernest Fan on 2020-10-29.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import XCTest
+import R2Shared
+@testable import SimplyE
+
+class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
+    var businessLogic: NYPLReaderBookmarksBusinessLogic!
+    var bookRegistryMock: NYPLBookRegistryMock!
+    var libraryAccountMock: NYPLLibraryAccountMock!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        let emptyUrl = URL.init(fileURLWithPath: "")
+        let fakeAcquisition = NYPLOPDSAcquisition.init(
+          relation: .generic,
+          type: "application/epub+zip",
+          hrefURL: emptyUrl,
+          indirectAcquisitions: [NYPLOPDSIndirectAcquisition](),
+          availability: NYPLOPDSAcquisitionAvailabilityUnlimited.init()
+        )
+        let fakeBook = NYPLBook.init(
+          acquisitions: [fakeAcquisition],
+          bookAuthors: [NYPLBookAuthor](),
+          categoryStrings: [String](),
+          distributor: "",
+          identifier: "fakeEpub",
+          imageURL: emptyUrl,
+          imageThumbnailURL: emptyUrl,
+          published: Date.init(),
+          publisher: "",
+          subtitle: "",
+          summary: "",
+          title: "",
+          updated: Date.init(),
+          annotationsURL: emptyUrl,
+          analyticsURL: emptyUrl,
+          alternateURL: emptyUrl,
+          relatedWorksURL: emptyUrl,
+          seriesURL: emptyUrl,
+          revokeURL: emptyUrl,
+          report: emptyUrl
+        )!
+        
+        bookRegistryMock = NYPLBookRegistryMock()
+        libraryAccountMock = NYPLLibraryAccountMock()
+        
+        businessLogic = NYPLReaderBookmarksBusinessLogic(
+            book: fakeBook,
+            r2Publication: Publication(metadata: Metadata(title: "FakeMetadata")),
+            drmDeviceID: "fakeDeviceID",
+            bookRegistryProvider: bookRegistryMock,
+            currentLibraryAccountProvider: libraryAccountMock)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        businessLogic = nil
+        libraryAccountMock = nil
+        bookRegistryMock = nil
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+}

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -49,7 +49,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
         seriesURL: emptyUrl,
         revokeURL: emptyUrl,
         report: emptyUrl
-      )!
+      )
       
       bookRegistryMock = NYPLBookRegistryMock()
       bookRegistryMock.addBook(book: fakeBook, state: .DownloadSuccessful)

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -11,65 +11,204 @@ import R2Shared
 @testable import SimplyE
 
 class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
-    var businessLogic: NYPLReaderBookmarksBusinessLogic!
+    var bookmarkBusinessLogic: NYPLReaderBookmarksBusinessLogic!
     var bookRegistryMock: NYPLBookRegistryMock!
     var libraryAccountMock: NYPLLibraryAccountMock!
+    var bookmarkCounter: Int = 0
+    let bookIdentifier = "fakeEpub"
     
     override func setUpWithError() throws {
-        try super.setUpWithError()
-        
-        let emptyUrl = URL.init(fileURLWithPath: "")
-        let fakeAcquisition = NYPLOPDSAcquisition.init(
-          relation: .generic,
-          type: "application/epub+zip",
-          hrefURL: emptyUrl,
-          indirectAcquisitions: [NYPLOPDSIndirectAcquisition](),
-          availability: NYPLOPDSAcquisitionAvailabilityUnlimited.init()
-        )
-        let fakeBook = NYPLBook.init(
-          acquisitions: [fakeAcquisition],
-          bookAuthors: [NYPLBookAuthor](),
-          categoryStrings: [String](),
-          distributor: "",
-          identifier: "fakeEpub",
-          imageURL: emptyUrl,
-          imageThumbnailURL: emptyUrl,
-          published: Date.init(),
-          publisher: "",
-          subtitle: "",
-          summary: "",
-          title: "",
-          updated: Date.init(),
-          annotationsURL: emptyUrl,
-          analyticsURL: emptyUrl,
-          alternateURL: emptyUrl,
-          relatedWorksURL: emptyUrl,
-          seriesURL: emptyUrl,
-          revokeURL: emptyUrl,
-          report: emptyUrl
-        )!
-        
-        bookRegistryMock = NYPLBookRegistryMock()
-        libraryAccountMock = NYPLLibraryAccountMock()
-        
-        businessLogic = NYPLReaderBookmarksBusinessLogic(
-            book: fakeBook,
-            r2Publication: Publication(metadata: Metadata(title: "FakeMetadata")),
-            drmDeviceID: "fakeDeviceID",
-            bookRegistryProvider: bookRegistryMock,
-            currentLibraryAccountProvider: libraryAccountMock)
+      try super.setUpWithError()
+      
+      let emptyUrl = URL.init(fileURLWithPath: "")
+      let fakeAcquisition = NYPLOPDSAcquisition.init(
+        relation: .generic,
+        type: "application/epub+zip",
+        hrefURL: emptyUrl,
+        indirectAcquisitions: [NYPLOPDSIndirectAcquisition](),
+        availability: NYPLOPDSAcquisitionAvailabilityUnlimited.init()
+      )
+      let fakeBook = NYPLBook.init(
+        acquisitions: [fakeAcquisition],
+        bookAuthors: [NYPLBookAuthor](),
+        categoryStrings: [String](),
+        distributor: "",
+        identifier: bookIdentifier,
+        imageURL: emptyUrl,
+        imageThumbnailURL: emptyUrl,
+        published: Date.init(),
+        publisher: "",
+        subtitle: "",
+        summary: "",
+        title: "",
+        updated: Date.init(),
+        annotationsURL: emptyUrl,
+        analyticsURL: emptyUrl,
+        alternateURL: emptyUrl,
+        relatedWorksURL: emptyUrl,
+        seriesURL: emptyUrl,
+        revokeURL: emptyUrl,
+        report: emptyUrl
+      )!
+      
+      bookRegistryMock = NYPLBookRegistryMock()
+      bookRegistryMock.addBook(book: fakeBook, state: .DownloadSuccessful)
+      libraryAccountMock = NYPLLibraryAccountMock()
+      
+      bookmarkBusinessLogic = NYPLReaderBookmarksBusinessLogic(
+        book: fakeBook,
+        r2Publication: Publication(metadata: Metadata(title: "fakeMetadata")),
+        drmDeviceID: "fakeDeviceID",
+        bookRegistryProvider: bookRegistryMock,
+        currentLibraryAccountProvider: libraryAccountMock)
+      bookmarkCounter = 0
     }
 
     override func tearDownWithError() throws {
-        try super.tearDownWithError()
-        businessLogic = nil
-        libraryAccountMock = nil
-        bookRegistryMock = nil
+      try super.tearDownWithError()
+      bookmarkBusinessLogic = nil
+      libraryAccountMock = nil
+      bookRegistryMock.identifiersToRecords.removeAll()
+      bookRegistryMock = nil
+      bookmarkCounter = 0
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    // MARK: - Test updateLocalBookmarks
+    
+    func testSyncServerBookmarksWithNoLocalBookmarks() throws {
+      var serverBookmarks = [NYPLReadiumBookmark]()
+        
+      // Make sure BookRegistry contains no bookmark
+      XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
+      
+      guard let firstBookmark = newBookmark(idref: "Intro",
+                                          chapter: "1",
+                                          progressWithinChapter: 0.1,
+                                          progressWithinBook: 0.1) else {
+        XCTFail("Failed to create new bookmark")
+        return
+      }
+      serverBookmarks.append(firstBookmark)
+
+      bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
+                                                 localBookmarks: bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier),
+                                                 bookmarksFailedToUpload: [NYPLReadiumBookmark]()) {
+        XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
+      }
+    }
+    
+    func testSyncServerBookmarksWithDuplicatedLocalBookmarks() throws {
+      var serverBookmarks = [NYPLReadiumBookmark]()
+
+      // Make sure BookRegistry contains no bookmark
+      XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
+      
+      guard let firstBookmark = newBookmark(idref: "Intro",
+                                          chapter: "1",
+                                          progressWithinChapter: 0.1,
+                                          progressWithinBook: 0.1),
+        let secondBookmark = newBookmark(idref: "Intro",
+                                         chapter: "1",
+                                         progressWithinChapter: 0.2,
+                                         progressWithinBook: 0.1) else {
+        XCTFail("Failed to create new bookmark")
+        return
+      }
+        
+      serverBookmarks.append(firstBookmark)
+      serverBookmarks.append(secondBookmark)
+      bookRegistryMock.add(firstBookmark, forIdentifier: bookIdentifier)
+      XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
+
+      // There are one duplicated bookmark and one non-synced (server) bookmark
+      bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
+                                                 localBookmarks: bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier),
+                                                 bookmarksFailedToUpload: [NYPLReadiumBookmark]()) {
+        XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
+      }
+    }
+    
+    func testSyncServerBookmarksWithExtraLocalBookmarks() throws {
+      var serverBookmarks = [NYPLReadiumBookmark]()
+
+      // Make sure BookRegistry contains no bookmark
+      XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
+      
+      guard let firstBookmark = newBookmark(idref: "Intro",
+                                          chapter: "1",
+                                          progressWithinChapter: 0.1,
+                                          progressWithinBook: 0.1),
+        let secondBookmark = newBookmark(idref: "Intro",
+                                         chapter: "1",
+                                         progressWithinChapter: 0.2,
+                                         progressWithinBook: 0.1) else {
+        XCTFail("Failed to create new bookmark")
+        return
+      }
+        
+      serverBookmarks.append(firstBookmark)
+      bookRegistryMock.add(firstBookmark, forIdentifier: bookIdentifier)
+      bookRegistryMock.add(secondBookmark, forIdentifier: bookIdentifier)
+      XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
+
+      // There are one duplicated bookmark and one extra (local) bookmark,
+      // which means it has been delete from another device and should be removed locally
+      bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
+                                                 localBookmarks: bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier),
+                                                 bookmarksFailedToUpload: [NYPLReadiumBookmark]()) {
+        XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
+      }
+    }
+    
+    func testSyncServerBookmarksWithFailedUploadBookmarks() throws {
+      var serverBookmarks = [NYPLReadiumBookmark]()
+
+      // Make sure BookRegistry contains no bookmark
+      XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
+      
+      guard let firstBookmark = newBookmark(idref: "Intro",
+                                          chapter: "1",
+                                          progressWithinChapter: 0.1,
+                                          progressWithinBook: 0.1),
+        let secondBookmark = newBookmark(idref: "Intro",
+                                         chapter: "1",
+                                         progressWithinChapter: 0.2,
+                                         progressWithinBook: 0.1) else {
+        XCTFail("Failed to create new bookmark")
+        return
+      }
+        
+      serverBookmarks.append(firstBookmark)
+      bookRegistryMock.add(firstBookmark, forIdentifier: bookIdentifier)
+      XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
+        
+      // There are one duplicated bookmark and one failed-to-upload bookmark
+      bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
+                                                 localBookmarks: bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier),
+                                                 bookmarksFailedToUpload: [secondBookmark]) {
+        XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
+      }
     }
 
+    // MARK: Helper
+    
+    func newBookmark(idref: String,
+                     chapter: String,
+                     progressWithinChapter: Float,
+                     progressWithinBook: Float,
+                     device: String? = nil) -> NYPLReadiumBookmark? {
+      // Annotation id needs to be unique
+      // contentCFI should be empty string for R2 bookmark
+      bookmarkCounter += 1
+      return NYPLReadiumBookmark(annotationId: "fakeAnnotationID\(bookmarkCounter)",
+                                 contentCFI: "",
+                                 idref: idref,
+                                 chapter: chapter,
+                                 page: nil,
+                                 location: nil,
+                                 progressWithinChapter: progressWithinChapter,
+                                 progressWithinBook: progressWithinBook,
+                                 time:nil,
+                                 device:device)
+    }
 }


### PR DESCRIPTION
**What's this do?**
Add unit tests and related mock models
Fix build error after pulling latest changes
Remove unnecessary background worker
Update bookmark UI on location changes

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-2804](https://jira.nypl.org/browse/SIMPLY-2804?filter=-1)

**How should this be tested? / Do these changes have associated tests?**
Run tests `NYPLReaderBookmarksBusinessLogicTests`

**Dependencies for merging? Releasing to production?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 
