### PR TITLE
Fix OE AppStore submission error and enables links in welcome EULA screen

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -137,7 +137,6 @@
 		17DFC5F2251E80D6003A19CC /* AudioEngine.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; };
 		17DFC5F6251E84CF003A19CC /* AudioEngine.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		17DFC5F8251E8644003A19CC /* AudioEngine.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		21196605250956C000A6D0EF /* JWKResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2199020724FD35DC001BC727 /* JWKResponse.swift */; };
 		2198F910250A90EE000D9DAB /* AudioBookVendorsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2198F90F250A90EE000D9DAB /* AudioBookVendorsHelper.swift */; };
 		219901F524FD2DE9001BC727 /* jwk.json in Resources */ = {isa = PBXBuildFile; fileRef = 219901F324FD2DE9001BC727 /* jwk.json */; };
 		219901FB24FD2E56001BC727 /* jwk_public in Resources */ = {isa = PBXBuildFile; fileRef = 219901F924FD2E56001BC727 /* jwk_public */; };
@@ -147,7 +146,6 @@
 		21C504782513C9F00016A6C8 /* JWKResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2199020724FD35DC001BC727 /* JWKResponse.swift */; };
 		21C504792513C9F30016A6C8 /* DPLAAudiobooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E7E07A24FEA7E800189224 /* DPLAAudiobooks.swift */; };
 		21C5047A2513C9F40016A6C8 /* DPLAAudiobooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E7E07A24FEA7E800189224 /* DPLAAudiobooks.swift */; };
-		21C5047B2513C9F40016A6C8 /* DPLAAudiobooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E7E07A24FEA7E800189224 /* DPLAAudiobooks.swift */; };
 		21C5047C2513C9F60016A6C8 /* AudioBookVendors+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EC1B8E2501538600A12384 /* AudioBookVendors+Extensions.swift */; };
 		21C5047D2513C9F70016A6C8 /* AudioBookVendors+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EC1B8E2501538600A12384 /* AudioBookVendors+Extensions.swift */; };
 		21C5047F2513C9FA0016A6C8 /* AudioBookVendorsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2198F90F250A90EE000D9DAB /* AudioBookVendorsHelper.swift */; };
@@ -198,7 +196,6 @@
 		730263AD2540DE4200A53891 /* NYPLSAMLHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 730263AB2540DE4200A53891 /* NYPLSAMLHelper.m */; };
 		730263AE2540DE4200A53891 /* NYPLSAMLHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 730263AB2540DE4200A53891 /* NYPLSAMLHelper.m */; };
 		7307A5ED23FF1A8500DE53DE /* NYPLOpenSearchDescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7307A5EC23FF1A8500DE53DE /* NYPLOpenSearchDescriptionTests.swift */; };
-		7307A5F223FF22EC00DE53DE /* ZXingObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 145DA48D215441A70055DB93 /* ZXingObjC.framework */; };
 		73085E1A2502DE88008F6244 /* OETutorialChoiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E182502DE87008F6244 /* OETutorialChoiceViewController.swift */; };
 		73085E1B2502DE88008F6244 /* NYPLPresentationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E192502DE88008F6244 /* NYPLPresentationUtils.swift */; };
 		73085E212502E2CE008F6244 /* OpenEBooks_OPDS2_Catalog_Feed.json in Resources */ = {isa = PBXBuildFile; fileRef = 73085E202502E2CD008F6244 /* OpenEBooks_OPDS2_Catalog_Feed.json */; };
@@ -236,11 +233,8 @@
 		7314D1422551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7314D13F2551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift */; };
 		731A5B1224621F2B00B5E663 /* NYPLSignInBusinessLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731A5B1124621F2B00B5E663 /* NYPLSignInBusinessLogic.swift */; };
 		731A5B1324621F2B00B5E663 /* NYPLSignInBusinessLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731A5B1124621F2B00B5E663 /* NYPLSignInBusinessLogic.swift */; };
-		7320AB28251EBC9900E3F04D /* DPLAAudiobooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E7E07A24FEA7E800189224 /* DPLAAudiobooks.swift */; };
-		7320AB2B251EBC9900E3F04D /* JWKResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2199020724FD35DC001BC727 /* JWKResponse.swift */; };
 		7320AB30251EBC9900E3F04D /* NYPLJWKConversionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2199020524FD3334001BC727 /* NYPLJWKConversionTest.swift */; };
 		7320AB36251EBC9900E3F04D /* Date+NYPLAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7384C803242BCE5900D5F960 /* Date+NYPLAdditionsTests.swift */; };
-		7320AB38251EBC9900E3F04D /* ZXingObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 145DA48D215441A70055DB93 /* ZXingObjC.framework */; };
 		7320AB3A251EBC9900E3F04D /* NYPLBookAcquisitionPathEntry.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2D8790A220129AC400E2763F /* NYPLBookAcquisitionPathEntry.xml */; };
 		7320AB3B251EBC9900E3F04D /* UpdateCheckNeedsUpdate.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D2B478A1D08FC78007F7764 /* UpdateCheckNeedsUpdate.json */; };
 		7320AB3C251EBC9900E3F04D /* gpl_authentication_document.json in Resources */ = {isa = PBXBuildFile; fileRef = B51C1E14229456E2003B49A5 /* gpl_authentication_document.json */; };
@@ -679,7 +673,6 @@
 		73FCA2FD25005BA4001B0C5D /* URLResponse+NYPL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */; };
 		73FCA2FE25005BA4001B0C5D /* NYPLSettingsAccountDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E6202A011DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.m */; };
 		73FCA2FF25005BA4001B0C5D /* NYPLReaderReadiumView.m in Sources */ = {isa = PBXBuildFile; fileRef = 113137E61A48DAB90082954E /* NYPLReaderReadiumView.m */; };
-		73FCA30025005BA4001B0C5D /* NYPLBarcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68CCFC41F9F80CF003DDA6C /* NYPLBarcode.swift */; };
 		73FCA30125005BA4001B0C5D /* NYPLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 118B7ABE195CBF72005CE3E7 /* NYPLSession.m */; };
 		73FCA30225005BA4001B0C5D /* NYPLSettingsEULAViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 841B55421B740F2700FAC1AF /* NYPLSettingsEULAViewController.m */; };
 		73FCA30325005BA4001B0C5D /* NYPLMyBooksDownloadInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = A4276F471B00046300CA7194 /* NYPLMyBooksDownloadInfo.m */; };
@@ -708,7 +701,6 @@
 		73FCA31C25005BA4001B0C5D /* NYPLReaderTOCCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 11BFDB38199C117B00378691 /* NYPLReaderTOCCell.m */; };
 		73FCA31D25005BA4001B0C5D /* NYPLBookContentMetadataFilesHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F26E721DFF672F00C103CA /* NYPLBookContentMetadataFilesHelper.swift */; };
 		73FCA31E25005BA4001B0C5D /* NYPLContentTypeBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D848E22171334800CEC142 /* NYPLContentTypeBadge.swift */; };
-		73FCA31F25005BA4001B0C5D /* NYPLZXingEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = E6C91BC11FD5F63B00A32F42 /* NYPLZXingEncoder.m */; };
 		73FCA32025005BA4001B0C5D /* NYPLProblemReportViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 085D31D61BE29E38007F7672 /* NYPLProblemReportViewController.m */; };
 		73FCA32125005BA4001B0C5D /* NYPLHoldsNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 11C5DCF11976D1E0005A9945 /* NYPLHoldsNavigationController.m */; };
 		73FCA32225005BA4001B0C5D /* NYPLRemoteViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A42E0DF01B3F5A490095EBAE /* NYPLRemoteViewController.m */; };
@@ -755,7 +747,6 @@
 		73FCA34E25005BA4001B0C5D /* AccountsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F94CD01DD6288C00CE8F4F /* AccountsManager.swift */; };
 		73FCA34F25005BA4001B0C5D /* NYPLLocalization.m in Sources */ = {isa = PBXBuildFile; fileRef = 52592BB721220A1100587288 /* NYPLLocalization.m */; };
 		73FCA35025005BA4001B0C5D /* NYPLSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17071060242A923400E2648F /* NYPLSecrets.swift */; };
-		73FCA35125005BA4001B0C5D /* NYPLBarcodeScanningViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E6D7753D1F9FE0AF00C0B722 /* NYPLBarcodeScanningViewController.m */; };
 		73FCA35225005BA4001B0C5D /* NYPLBookDetailDownloadFailedView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1111973E1988226F0014462F /* NYPLBookDetailDownloadFailedView.m */; };
 		73FCA35325005BA4001B0C5D /* NYPLOPDSFeed.m in Sources */ = {isa = PBXBuildFile; fileRef = AE77E94D56B65997B861C0C0 /* NYPLOPDSFeed.m */; };
 		73FCA35425005BA4001B0C5D /* NYPLRoundedButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 114C8CD919BF55F900719B72 /* NYPLRoundedButton.m */; };
@@ -788,7 +779,6 @@
 		73FCA37125005BA4001B0C5D /* libTenPrintCover.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1112A81F1A322C53002B8CC1 /* libTenPrintCover.a */; };
 		73FCA37225005BA4001B0C5D /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 119503E81993F919009FB788 /* libz.dylib */; };
 		73FCA37325005BA4001B0C5D /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 119503E61993F914009FB788 /* libxml2.dylib */; };
-		73FCA37425005BA4001B0C5D /* ZXingObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 145DA48D215441A70055DB93 /* ZXingObjC.framework */; };
 		73FCA37525005BA4001B0C5D /* NYPLCardCreator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 145DA49321544A3F0055DB93 /* NYPLCardCreator.framework */; };
 		73FCA37625005BA4001B0C5D /* PureLayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 145DA49521544A420055DB93 /* PureLayout.framework */; };
 		73FCA37725005BA4001B0C5D /* OverdriveProcessor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17D08378248E8EEB00092AA9 /* OverdriveProcessor.framework */; };
@@ -1453,7 +1443,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7307A5F223FF22EC00DE53DE /* ZXingObjC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1461,7 +1450,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7320AB38251EBC9900E3F04D /* ZXingObjC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1544,7 +1532,6 @@
 				17DFC5F2251E80D6003A19CC /* AudioEngine.xcframework in Frameworks */,
 				73FCA37225005BA4001B0C5D /* libz.dylib in Frameworks */,
 				73FCA37325005BA4001B0C5D /* libxml2.dylib in Frameworks */,
-				73FCA37425005BA4001B0C5D /* ZXingObjC.framework in Frameworks */,
 				73FCA37525005BA4001B0C5D /* NYPLCardCreator.framework in Frameworks */,
 				73FCA37625005BA4001B0C5D /* PureLayout.framework in Frameworks */,
 				73FCA37725005BA4001B0C5D /* OverdriveProcessor.framework in Frameworks */,
@@ -2965,7 +2952,6 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/ZXingObjC.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/SQLite.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/PureLayout.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/NYPLCardCreator.framework",
@@ -2978,7 +2964,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ZXingObjC.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/SQLite.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/PureLayout.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/NYPLCardCreator.framework",
@@ -3020,13 +3005,11 @@
 			files = (
 				735DD0C225229DAC0096D1F9 /* NYPLCatalogFacetTests.m in Sources */,
 				7384C800242BB43400D5F960 /* NYPLCachingTests.swift in Sources */,
-				21C5047B2513C9F40016A6C8 /* DPLAAudiobooks.swift in Sources */,
 				5D3A28D522D400D00042B3BD /* UserProfileDocumentTests.swift in Sources */,
 				7307A5ED23FF1A8500DE53DE /* NYPLOpenSearchDescriptionTests.swift in Sources */,
 				735771A8253763E800067CEA /* NYPLBookRegistryMock.swift in Sources */,
 				737F4A532549D78100A3C34B /* NYPLBookCreationTestsObjc.m in Sources */,
 				735771A02537635600067CEA /* NYPLSignInBusinessLogicTests.swift in Sources */,
-				21196605250956C000A6D0EF /* JWKResponse.swift in Sources */,
 				7375AE5A25382AC900C85211 /* NYPLUserAccountMock.swift in Sources */,
 				735771AE2537687D00067CEA /* NYPLURLSettingsProviderMock.swift in Sources */,
 				735771B12537691800067CEA /* NYPLDRMAuthorizingMock.swift in Sources */,
@@ -3053,7 +3036,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				735DD0CA2522A0610096D1F9 /* NYPLOpenSearchDescriptionTests.swift in Sources */,
-				7320AB28251EBC9900E3F04D /* DPLAAudiobooks.swift in Sources */,
 				735DD0D02522A0730096D1F9 /* UserProfileDocumentTests.swift in Sources */,
 				735DD0AD252293580096D1F9 /* NYPLBookStateTests.swift in Sources */,
 				735DD0C92522A0590096D1F9 /* NYPLCatalogFacetTests.m in Sources */,
@@ -3072,7 +3054,6 @@
 				7320AB51251EC07300E3F04D /* NYPLBookAcquisitionPathTests.swift in Sources */,
 				735DD0D12522A0730096D1F9 /* URLRequest+NYPLTests.swift in Sources */,
 				735771AC2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift in Sources */,
-				7320AB2B251EBC9900E3F04D /* JWKResponse.swift in Sources */,
 				735DD0AE2522935B0096D1F9 /* NYPLCachingTests.swift in Sources */,
 				7320AB30251EBC9900E3F04D /* NYPLJWKConversionTest.swift in Sources */,
 				735DD0CC2522A06C0096D1F9 /* OPDS2CatalogsFeedTests.swift in Sources */,
@@ -3398,7 +3379,6 @@
 				21C5047D2513C9F70016A6C8 /* AudioBookVendors+Extensions.swift in Sources */,
 				73FCA2FE25005BA4001B0C5D /* NYPLSettingsAccountDetailViewController.m in Sources */,
 				73FCA2FF25005BA4001B0C5D /* NYPLReaderReadiumView.m in Sources */,
-				73FCA30025005BA4001B0C5D /* NYPLBarcode.swift in Sources */,
 				73085E1B2502DE88008F6244 /* NYPLPresentationUtils.swift in Sources */,
 				73FCA30125005BA4001B0C5D /* NYPLSession.m in Sources */,
 				73FCA30225005BA4001B0C5D /* NYPLSettingsEULAViewController.m in Sources */,
@@ -3433,7 +3413,6 @@
 				73FCA31C25005BA4001B0C5D /* NYPLReaderTOCCell.m in Sources */,
 				73FCA31D25005BA4001B0C5D /* NYPLBookContentMetadataFilesHelper.swift in Sources */,
 				73FCA31E25005BA4001B0C5D /* NYPLContentTypeBadge.swift in Sources */,
-				73FCA31F25005BA4001B0C5D /* NYPLZXingEncoder.m in Sources */,
 				73FCA32025005BA4001B0C5D /* NYPLProblemReportViewController.m in Sources */,
 				73FCA32125005BA4001B0C5D /* NYPLHoldsNavigationController.m in Sources */,
 				73FCA32225005BA4001B0C5D /* NYPLRemoteViewController.m in Sources */,
@@ -3487,7 +3466,6 @@
 				73FCA34E25005BA4001B0C5D /* AccountsManager.swift in Sources */,
 				73FCA34F25005BA4001B0C5D /* NYPLLocalization.m in Sources */,
 				73FCA35025005BA4001B0C5D /* NYPLSecrets.swift in Sources */,
-				73FCA35125005BA4001B0C5D /* NYPLBarcodeScanningViewController.m in Sources */,
 				73FCA35225005BA4001B0C5D /* NYPLBookDetailDownloadFailedView.m in Sources */,
 				73FCA35325005BA4001B0C5D /* NYPLOPDSFeed.m in Sources */,
 				73FCA35425005BA4001B0C5D /* NYPLRoundedButton.m in Sources */,
@@ -3767,6 +3745,10 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SIMPLYE=1",
+				);
 				INFOPLIST_FILE = SimplifiedTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3812,6 +3794,10 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SIMPLYE=1",
+				);
 				INFOPLIST_FILE = SimplifiedTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3856,7 +3842,11 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = SimplyETests/Info.plist;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"OPENEBOOKS=1",
+				);
+				INFOPLIST_FILE = SimplifiedTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3901,7 +3891,11 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = SimplyETests/Info.plist;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"OPENEBOOKS=1",
+				);
+				INFOPLIST_FILE = SimplifiedTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3949,7 +3943,11 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Simplified/AppInfrastructure/Simplified-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "SIMPLYE=1";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"SIMPLYE=1",
+					"DEBUG=1",
+					"$(inherited)",
+				);
 				INFOPLIST_FILE = "SimplyE/Simplified-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4002,10 +4000,10 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Simplified/AppInfrastructure/Simplified-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
+					"SIMPLYE=1",
 					"DEBUG=0",
 					"$(inherited)",
 				);
-				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "SIMPLYE=1";
 				INFOPLIST_FILE = "SimplyE/Simplified-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4046,7 +4044,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4056,7 +4054,11 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Simplified/AppInfrastructure/Simplified-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "OPENEBOOKS=1";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"OPENEBOOKS=1",
+					"DEBUG=1",
+					"$(inherited)",
+				);
 				INFOPLIST_FILE = "OpenEbooks/Open-eBooks-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4099,7 +4101,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4110,10 +4112,10 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Simplified/AppInfrastructure/Simplified-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
+					"OPENEBOOKS=1",
 					"DEBUG=0",
 					"$(inherited)",
 				);
-				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "OPENEBOOKS=1";
 				INFOPLIST_FILE = "OpenEbooks/Open-eBooks-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4286,7 +4288,11 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Simplified/AppInfrastructure/Simplified-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "SIMPLYE=1";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"SIMPLYE=1",
+					"DEBUG=1",
+					"$(inherited)",
+				);
 				INFOPLIST_FILE = "SimplyE/Simplified-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4338,10 +4344,10 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Simplified/AppInfrastructure/Simplified-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
+					"SIMPLYE=1",
 					"DEBUG=0",
 					"$(inherited)",
 				);
-				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = "SIMPLYE=1";
 				INFOPLIST_FILE = "SimplyE/Simplified-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
@@ -42,4 +42,8 @@ extension NYPLConfiguration {
 
     return .white
   }
+
+  static func cardCreationEnabled() -> Bool {
+    return false
+  }
 }

--- a/Simplified/AppInfrastructure/NYPLConfiguration+SE.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+SE.swift
@@ -38,4 +38,8 @@ extension NYPLConfiguration {
   @objc static func iconLogoGreenColor() -> UIColor {
     return UIColor(red: 141.0/255.0, green: 199.0/255.0, blue: 64.0/255.0, alpha: 1.0)
   }
+
+  static func cardCreationEnabled() -> Bool {
+    return true
+  }
 }

--- a/Simplified/AppInfrastructure/NYPLConfiguration.h
+++ b/Simplified/AppInfrastructure/NYPLConfiguration.h
@@ -7,8 +7,6 @@
 
 + (id)new NS_UNAVAILABLE;
 
-+ (BOOL)cardCreationEnabled;
-
 // This can be overriden by setting |customMainFeedURL| in NYPLSettings.
 + (NSURL *)mainFeedURL;
 

--- a/Simplified/AppInfrastructure/NYPLConfiguration.m
+++ b/Simplified/AppInfrastructure/NYPLConfiguration.m
@@ -24,11 +24,6 @@
   return nil;
 }
 
-+ (BOOL)cardCreationEnabled
-{
-  return YES;
-}
-
 + (NSURL *)minimumVersionURL
 {
   return [NSURL URLWithString:@"http://www.librarysimplified.org/simplye-client/minimum-version"];

--- a/Simplified/AppInfrastructure/SimplyE-Bridging-Header.h
+++ b/Simplified/AppInfrastructure/SimplyE-Bridging-Header.h
@@ -2,10 +2,15 @@
 #import "ADEPT/NYPLADEPTErrors.h"
 #import "ADEPT/NYPLADEPT.h"
 #endif
+
+#ifndef OPENEBOOKS
+#import "NYPLBarcodeScanningViewController.h"
+#import "NYPLZXingEncoder.h"
+#endif
+
 #import "NSDate+NYPLDateAdditions.h"
 #import "NYPLAccountSignInViewController.h"
 #import "NYPLAppDelegate.h"
-#import "NYPLBarcodeScanningViewController.h"
 #import "NYPLBook.h"
 #import "NYPLBookDetailView.h"
 #import "NYPLBookDetailViewController.h"
@@ -29,11 +34,10 @@
 #import "NYPLOPDS.h"
 #import "NYPLReachability.h"
 #import "NYPLReloadView.h"
-#import "NYPLRoundedButton.h"
 #import "NYPLRootTabBarController.h"
+#import "NYPLRoundedButton.h"
 #import "NYPLSAMLHelper.h"
 #import "NYPLSettingsAccountDetailViewController.h"
 #import "NYPLXML.h"
-#import "NYPLZXingEncoder.h"
 #import "UIView+NYPLViewAdditions.h"
 #import "UIFont+NYPLSystemFontOverride.h"

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -32,6 +32,7 @@ fileprivate let nullString = "null"
 
   // generic app related
   case appLaunch = 100
+  case appLogicInconsistency = 101
   case genericErrorMsgDisplayed = 103
 
   // book registry
@@ -111,12 +112,11 @@ fileprivate let nullString = "null"
   // low-level / system related
   case missingSystemPaths = 1200
   case fileMoveFail = 1201
-    
-  // keychain
-  case keychainItemAddFail = 1300
-
   case directoryURLCreateFail = 1202
   case missingExpectedObject = 1203
+
+  // keychain
+  case keychainItemAddFail = 1300
 }
 
 @objcMembers class NYPLErrorLogger : NSObject {

--- a/Simplified/Settings/BarcodeScanning/NYPLBarcodeScanningViewController.h
+++ b/Simplified/Settings/BarcodeScanning/NYPLBarcodeScanningViewController.h
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-#import <ZXingObjC/ZXingObjC.h>
+@import UIKit;
+@import ZXingObjC;
 
 @interface NYPLBarcodeScanningViewController : UIViewController <ZXCaptureDelegate>
 

--- a/Simplified/Settings/NYPLSettingsPrimaryTableItem.swift
+++ b/Simplified/Settings/NYPLSettingsPrimaryTableItem.swift
@@ -9,8 +9,8 @@
 class NYPLSettingsPrimaryTableItem {
   let path: IndexPath
   let name: String
-  fileprivate let vc: UIViewController?
-  fileprivate let handler: ((UISplitViewController, UITableViewController)->())?
+  private let vc: UIViewController?
+  private let handler: ((UISplitViewController, UITableViewController)->())?
   
   init(indexPath: IndexPath, title: String, viewController: UIViewController) {
     path = indexPath

--- a/Simplified/Settings/NYPLSettingsPrimaryTableViewController.swift
+++ b/Simplified/Settings/NYPLSettingsPrimaryTableViewController.swift
@@ -102,6 +102,15 @@ class NYPLSettingsPrimaryTableViewController : UITableViewController {
     super.viewDidLoad()
     self.view.backgroundColor = NYPLConfiguration.backgroundColor()
   }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    if self.splitViewController?.traitCollection.horizontalSizeClass == .compact {
+      if let indexPath = tableView.indexPathForSelectedRow {
+        tableView.deselectRow(at: indexPath, animated: true)
+      }
+    }
+  }
   
   // MARK: UITableViewDelegate
   

--- a/Simplified/Settings/NYPLSettingsPrimaryTableViewController.swift
+++ b/Simplified/Settings/NYPLSettingsPrimaryTableViewController.swift
@@ -25,7 +25,8 @@ class NYPLSettingsPrimaryTableViewController : UITableViewController {
     self.items = []
     self.itemsMap = [:]
     self.developerVC = NYPLDeveloperSettingsTableViewController()
-    
+    self.shouldShowDeveloperMenuItem = false
+
     // Init info label
     self.infoLabel = UILabel()
     self.infoLabel.font = UIFont.systemFont(ofSize: 12.0)
@@ -35,11 +36,12 @@ class NYPLSettingsPrimaryTableViewController : UITableViewController {
     self.infoLabel.text = "\(productName) version \(version) (\(build))"
     self.infoLabel.textAlignment = .center
     self.infoLabel.sizeToFit()
-    
-    self.shouldShowDeveloperMenuItem = false
-    
+
     super.init(nibName: nil, bundle: nil)
-    
+    self.title = NSLocalizedString("Settings", comment: "")
+    self.clearsSelectionOnViewWillAppear = false
+
+    // add gesture recognizer for debug menu
     let tap = UITapGestureRecognizer.init(target: self, action: #selector(revealDeveloperSettings))
     tap.numberOfTapsRequired = 7;
     self.infoLabel.isUserInteractionEnabled = true
@@ -125,7 +127,7 @@ class NYPLSettingsPrimaryTableViewController : UITableViewController {
     if section == sectionCount - 1 {
       return 45.0
     }
-    return 15.0
+    return 0
   }
   
   override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {

--- a/Simplified/Settings/NYPLSettingsSplitViewController.swift
+++ b/Simplified/Settings/NYPLSettingsSplitViewController.swift
@@ -36,7 +36,7 @@ class NYPLSettingsSplitViewController : UISplitViewController, UISplitViewContro
     return navVC?.viewControllers.first as? NYPLSettingsPrimaryTableViewController
   }
 
-  // MARK: UIView
+  // MARK: UIViewController
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.m
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.m
@@ -8,7 +8,6 @@
 
 #import "NYPLAccountSignInViewController.h"
 #import "NYPLAppDelegate.h"
-#import "NYPLBarcodeScanningViewController.h"
 #import "NYPLBookCoverRegistry.h"
 #import "NYPLBookRegistry.h"
 #import "NYPLConfiguration.h"
@@ -724,6 +723,17 @@ completionHandler:(void (^)(void))handler
 
 - (void)scanLibraryCard
 {
+#ifdef OPENEBOOKS
+  __auto_type auth = self.businessLogic.selectedAuthentication;
+  [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeAppLogicInconsistency
+                            summary:@"Barcode button was displayed"
+                            message:nil
+                           metadata:@{
+                             @"Supports barcode display": @(auth.supportsBarcodeDisplay) ?: @"N/A",
+                             @"Supports barcode scanner": @(auth.supportsBarcodeScanner) ?: @"N/A",
+                             @"Context": @"Sign-in modal",
+                           }];
+#else
   [NYPLBarcode presentScannerWithCompletion:^(NSString * _Nullable resultString) {
     if (resultString) {
       self.usernameTextField.text = resultString;
@@ -731,6 +741,7 @@ completionHandler:(void (^)(void))handler
       self.loggingInAfterBarcodeScan = YES;
     }
   }];
+#endif
 }
 
 - (void)didSelectCancel

--- a/Simplified/WelcomeScreen/NYPLWelcomeEULAViewController.swift
+++ b/Simplified/WelcomeScreen/NYPLWelcomeEULAViewController.swift
@@ -134,9 +134,19 @@ extension NYPLWelcomeEULAViewController: WKNavigationDelegate {
                decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
     if navigationAction.request.url == onlineEULAURL {
       return decisionHandler(.allow)
+
     } else if navigationAction.request.url?.lastPathComponent == NYPLWelcomeEULAViewController.offlineEULAPathComponent {
       return decisionHandler(.allow)
+
+    } else if navigationAction.navigationType == .linkActivated,
+      let url = navigationAction.request.url {
+
+      // do not open inside the app: we need to continue displaying the EULA
+      if UIApplication.shared.canOpenURL(url) {
+        UIApplication.shared.open(url)
+      }
     }
+
     return decisionHandler(.cancel)
   }
 


### PR DESCRIPTION
**What's this do?**
Removes the ZXing library and related client code from Open eBooks binary. 
It also enables opening links in the EULA welcome screen. Links are opened in Safari in order to continue to display the EULA in OE.

**Why are we doing this? (w/ JIRA link if applicable)**
We cannot include and/or link to ZXing because that library accesses the camera, and that requires the NSCameraUsageDescription key in the app's info.plist. However, OE does not even use the camera.

**How should this be tested? / Do these changes have associated tests?**
The app settings tab should still be working as before.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore -- I built and ran all targets and unit tests.