### PR TITLE
SIMPLY-3102 Add R2 toggle in developer menu

### DIFF
--- a/Simplified/NYPLBookCellDelegate.m
+++ b/Simplified/NYPLBookCellDelegate.m
@@ -117,21 +117,21 @@
 
 - (void)openEPUB:(NYPLBook *)book
 {
-  // TODO: SIMPLY-2472
-  // R1
-//  NYPLReaderViewController *readerVC = [[NYPLReaderViewController alloc] initWithBookIdentifier:book.identifier];
-//  [[NYPLRootTabBarController sharedController] pushViewController:readerVC animated:YES];
+  if (NYPLSettings.shared.useR2) {
+    // R2
+    [[NYPLRootTabBarController sharedController] presentBook:book];
 
-  // R2
-  // TODO: SIMPLY-3102
-  [[NYPLRootTabBarController sharedController] presentBook:book];
-
-  [NYPLAnnotations requestServerSyncStatusForAccount:[NYPLUserAccount sharedAccount] completion:^(BOOL enableSync) {
-    if (enableSync == YES) {
-      Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
-      currentAccount.details.syncPermissionGranted = enableSync;
-    }
-  }];
+    [NYPLAnnotations requestServerSyncStatusForAccount:[NYPLUserAccount sharedAccount] completion:^(BOOL enableSync) {
+      if (enableSync == YES) {
+        Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
+        currentAccount.details.syncPermissionGranted = enableSync;
+      }
+    }];
+  } else {
+    // R1
+    NYPLReaderViewController *readerVC = [[NYPLReaderViewController alloc] initWithBookIdentifier:book.identifier];
+    [[NYPLRootTabBarController sharedController] pushViewController:readerVC animated:YES];
+  }
 }
 
 - (void)openPDF:(NYPLBook *)book {

--- a/Simplified/NYPLDeveloperSettingsTableViewController.swift
+++ b/Simplified/NYPLDeveloperSettingsTableViewController.swift
@@ -17,8 +17,12 @@ import Foundation
   func librarySwitchDidChange(sender: UISwitch!) {
     NYPLSettings.shared.useBetaLibraries = sender.isOn
   }
-  
-  // MARK: UIViewController
+
+  func r2SwitchDidChange(sender: UISwitch!) {
+    NYPLSettings.shared.useR2 = sender.isOn
+  }
+
+  // MARK:- UIViewController
   
   override func loadView() {
     self.view = UITableView(frame: CGRect.zero, style: .grouped)
@@ -30,21 +34,22 @@ import Foundation
     self.view.backgroundColor = NYPLConfiguration.backgroundColor()
   }
   
-  // MARK: UITableViewDataSource
+  // MARK:- UITableViewDataSource
   
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return 1
   }
   
   func numberOfSections(in tableView: UITableView) -> Int {
-    return 2
+    return 3
   }
   
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    if indexPath.section == 0 {
-      return cellForBetaLibraries()
+    switch indexPath.section {
+    case 0: return cellForBetaLibraries()
+    case 1: return cellForR2Toggle()
+    default: return cellForClearCache()
     }
-    return cellForClearCache()
   }
   
   func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
@@ -52,36 +57,49 @@ import Foundation
     case 0:
       return "Library Settings"
     case 1:
-      return "Data Management"
+      return "eReader Settings"
     default:
-      return ""
+      return "Data Management"
     }
   }
   
-  func cellForBetaLibraries() -> UITableViewCell {
+  private func cellForBetaLibraries() -> UITableViewCell {
     let cell = UITableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: "betaLibraryCell")
     cell.selectionStyle = .none
     cell.textLabel?.text = "Enable test libraries"
-    let betaLibrarySwitch = UISwitch.init()
+    let betaLibrarySwitch = UISwitch()
     betaLibrarySwitch.setOn(NYPLSettings.shared.useBetaLibraries, animated: false)
     betaLibrarySwitch.addTarget(self, action:#selector(librarySwitchDidChange), for:.valueChanged)
     cell.accessoryView = betaLibrarySwitch
     return cell
   }
+
+  private func cellForR2Toggle() -> UITableViewCell {
+    let cell = UITableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: "R2ToggleCell")
+    cell.selectionStyle = .none
+    cell.textLabel?.text = "Enable Readium 2"
+    let r2Switch = UISwitch()
+    r2Switch.setOn(NYPLSettings.shared.useR2, animated: false)
+    r2Switch.addTarget(self,
+                       action:#selector(r2SwitchDidChange),
+                       for:.valueChanged)
+    cell.accessoryView = r2Switch
+    return cell
+  }
   
-  func cellForClearCache() -> UITableViewCell {
+  private func cellForClearCache() -> UITableViewCell {
     let cell = UITableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: "clearCacheCell")
     cell.selectionStyle = .none
     cell.textLabel?.text = "Clear Cached Data"
     return cell
   }
   
-  // MARK: UITableViewDelegate
+  // MARK:- UITableViewDelegate
   
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     self.tableView.deselectRow(at: indexPath, animated: true)
     
-    if indexPath.section == 1 {
+    if indexPath.section == 2 {
       AccountsManager.shared.clearCache()
       let alert = NYPLAlertUtils.alert(title: "Data Management", message: "Cache Cleared")
       self.present(alert, animated: true, completion: nil)

--- a/Simplified/Settings/NYPLSettings.swift
+++ b/Simplified/Settings/NYPLSettings.swift
@@ -28,6 +28,7 @@ import Foundation
   static let userHasAcceptedEULAKey = "NYPLSettingsUserAcceptedEULA"
   static private let userSeenFirstTimeSyncMessageKey = "userSeenFirstTimeSyncMessageKey"
   static private let useBetaLibrariesKey = "NYPLUseBetaLibrariesKey"
+  static private let useR2Key = "NYPLUseR2Key"
   static let settingsLibraryAccountsKey = "NYPLSettingsLibraryAccountsKey"
   static private let versionKey = "NYPLSettingsVersionKey"
   
@@ -108,10 +109,21 @@ import Foundation
     set(b) {
       UserDefaults.standard.set(b, forKey: NYPLSettings.useBetaLibrariesKey)
       UserDefaults.standard.synchronize()
-      NotificationCenter.default.post(name: NSNotification.Name.NYPLUseBetaDidChange, object: self)
+      NotificationCenter.default.post(name: NSNotification.Name.NYPLUseBetaDidChange,
+                                      object: self)
     }
   }
-  
+
+  var useR2: Bool {
+    get {
+      return UserDefaults.standard.bool(forKey: NYPLSettings.useR2Key)
+    }
+    set(b) {
+      UserDefaults.standard.set(b, forKey: NYPLSettings.useR2Key)
+      UserDefaults.standard.synchronize()
+    }
+  }
+
   var appVersion: String? {
     get {
       return UserDefaults.standard.string(forKey: NYPLSettings.versionKey)


### PR DESCRIPTION
**What's this do?**
Adds a switch in the Developer/testing menu to enable / disable R2.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3102

**How should this be tested? / Do these changes have associated tests?**
Go to settings > developer menu and toggle the switch accordingly. Then open a book and verify it's being opened in R2 or R1. 
Closing and reopening the developer menu should persist the choice that was made.

**Dependencies for merging? Releasing to production?**
none

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 