### PR TITLE
SIMPLY-3292 Re-authenticate if authentication expired

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -485,6 +485,12 @@
 		7347F11D245A4DE200558D7F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 738EF2CB2405E38800F388FB /* GoogleService-Info.plist */; };
 		7347F133245A508400558D7F /* NYPLCardCreator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7347F132245A508400558D7F /* NYPLCardCreator.framework */; };
 		7347F135245A50CA00558D7F /* NYPLCardCreator.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7347F132245A508400558D7F /* NYPLCardCreator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		734B789125659611006FB8AD /* URLResponse+NYPLAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734B789025659611006FB8AD /* URLResponse+NYPLAuthentication.swift */; };
+		734B789225659611006FB8AD /* URLResponse+NYPLAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734B789025659611006FB8AD /* URLResponse+NYPLAuthentication.swift */; };
+		734B789325659611006FB8AD /* URLResponse+NYPLAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734B789025659611006FB8AD /* URLResponse+NYPLAuthentication.swift */; };
+		734B78992565F7DE006FB8AD /* NYPLReauthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734B78982565F7DE006FB8AD /* NYPLReauthenticator.swift */; };
+		734B789A2565F7DE006FB8AD /* NYPLReauthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734B78982565F7DE006FB8AD /* NYPLReauthenticator.swift */; };
+		734B789B2565F7DE006FB8AD /* NYPLReauthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734B78982565F7DE006FB8AD /* NYPLReauthenticator.swift */; };
 		735350B724918432006021BD /* URLRequest+NYPLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735350B624918432006021BD /* URLRequest+NYPLTests.swift */; };
 		7353940C250854A90043C800 /* NYPLSettingsSplitViewController+OE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7353940B250854A90043C800 /* NYPLSettingsSplitViewController+OE.swift */; };
 		7353940D25085DBB0043C800 /* NYPLPresentationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E192502DE88008F6244 /* NYPLPresentationUtils.swift */; };
@@ -1272,6 +1278,8 @@
 		7347312825142FE200BE3D2C /* NYPLSettings+SE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSettings+SE.swift"; sourceTree = "<group>"; };
 		7347F123245A4DE200558D7F /* SimplyECardCreator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SimplyECardCreator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7347F132245A508400558D7F /* NYPLCardCreator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = NYPLCardCreator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		734B789025659611006FB8AD /* URLResponse+NYPLAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLResponse+NYPLAuthentication.swift"; sourceTree = "<group>"; };
+		734B78982565F7DE006FB8AD /* NYPLReauthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLReauthenticator.swift; sourceTree = "<group>"; };
 		735350B624918432006021BD /* URLRequest+NYPLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+NYPLTests.swift"; sourceTree = "<group>"; };
 		735394012508161A0043C800 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		7353940B250854A90043C800 /* NYPLSettingsSplitViewController+OE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSettingsSplitViewController+OE.swift"; sourceTree = "<group>"; };
@@ -1979,6 +1987,7 @@
 				73422116252FE4950053DA9E /* NYPLAccountSignInViewController+OESelectAuth.swift */,
 				086C45D524AE77CA00F5108E /* NYPLBasicAuth.swift */,
 				089E42C5249A823800310360 /* NYPLCookiesWebViewController.swift */,
+				734B78982565F7DE006FB8AD /* NYPLReauthenticator.swift */,
 				730263AA2540DE4200A53891 /* NYPLSAMLHelper.h */,
 				730263AB2540DE4200A53891 /* NYPLSAMLHelper.m */,
 				731A5B1124621F2B00B5E663 /* NYPLSignInBusinessLogic.swift */,
@@ -1991,6 +2000,7 @@
 				739062D125358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift */,
 				73B72F10254C5A8B008725CA /* NYPLSignInURLSessionChallengeHandler.swift */,
 				73B501C024F48D4B00FBAD7D /* NYPLUserAccountFrontEndValidation.swift */,
+				734B789025659611006FB8AD /* URLResponse+NYPLAuthentication.swift */,
 			);
 			path = SignInLogic;
 			sourceTree = "<group>";
@@ -3195,6 +3205,7 @@
 				7347F09B245A4DE200558D7F /* NYPLMyBooksViewController.m in Sources */,
 				7347F09C245A4DE200558D7F /* NYPLBookDetailTableView.swift in Sources */,
 				739062D325358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift in Sources */,
+				734B789A2565F7DE006FB8AD /* NYPLReauthenticator.swift in Sources */,
 				7347312A25142FE200BE3D2C /* NYPLSettings+SE.swift in Sources */,
 				7347F09D245A4DE200558D7F /* Account.swift in Sources */,
 				7347F09E245A4DE200558D7F /* NYPLBookDownloadFailedCell.m in Sources */,
@@ -3222,6 +3233,7 @@
 				730D17CD25535954004CAC83 /* NYPLSignInBusinessLogic+BookmarkSyncing.swift in Sources */,
 				730EDFF3251538630038DD9F /* NYPLSamlIDPCell.swift in Sources */,
 				7347F0B4245A4DE200558D7F /* OPDS2Link.swift in Sources */,
+				734B789225659611006FB8AD /* URLResponse+NYPLAuthentication.swift in Sources */,
 				7347F0B5245A4DE200558D7F /* NYPLBookAuthor.swift in Sources */,
 				7347F0B6245A4DE200558D7F /* NYPLCatalogSearchViewController.m in Sources */,
 				7347F0B7245A4DE200558D7F /* UIColor+LabelColor.swift in Sources */,
@@ -3434,6 +3446,7 @@
 				73FCA33425005BA4001B0C5D /* NYPLNetworkResponder.swift in Sources */,
 				73FCA33525005BA4001B0C5D /* NYPLReaderSettings.m in Sources */,
 				73FCA33625005BA4001B0C5D /* NYPLKeychain.m in Sources */,
+				734B789B2565F7DE006FB8AD /* NYPLReauthenticator.swift in Sources */,
 				73085E30250308A4008F6244 /* NYPLSettingsSplitViewController.swift in Sources */,
 				73FCA33725005BA4001B0C5D /* NYPLReaderContainerDelegateBase.m in Sources */,
 				73FCA33825005BA4001B0C5D /* NYPLOPDSEntry.m in Sources */,
@@ -3473,6 +3486,7 @@
 				7314D1422551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift in Sources */,
 				73FCA35625005BA4001B0C5D /* NYPLOPDSType.m in Sources */,
 				73FCA35725005BA4001B0C5D /* NYPLBook+Additions.swift in Sources */,
+				734B789325659611006FB8AD /* URLResponse+NYPLAuthentication.swift in Sources */,
 				73FCA35825005BA4001B0C5D /* NYPLPDFViewControllerDelegate.swift in Sources */,
 				73FCA35925005BA4001B0C5D /* NYPLUserAccountFrontEndValidation.swift in Sources */,
 			);
@@ -3610,6 +3624,7 @@
 				2D754BC22002F1B10061D34F /* NYPLOPDSIndirectAcquisition.m in Sources */,
 				116A5EB3194767DC00491A21 /* NYPLMyBooksViewController.m in Sources */,
 				E6B3269F1EE066DE00DB877A /* NYPLBookDetailTableView.swift in Sources */,
+				734B78992565F7DE006FB8AD /* NYPLReauthenticator.swift in Sources */,
 				175E480824EF36520066A6CF /* NYPLAnnouncementBusinessLogic.swift in Sources */,
 				8CC26F832370C1DF0000D8E1 /* Account.swift in Sources */,
 				11078357198160A50071AB1E /* NYPLBookDownloadFailedCell.m in Sources */,
@@ -3637,6 +3652,7 @@
 				730D17CC25535954004CAC83 /* NYPLSignInBusinessLogic+BookmarkSyncing.swift in Sources */,
 				E6DA7EA01F2A718600CFBEC8 /* NYPLBookAuthor.swift in Sources */,
 				739ECB2425101CCE00691A70 /* NSNotification+NYPL.swift in Sources */,
+				734B789125659611006FB8AD /* URLResponse+NYPLAuthentication.swift in Sources */,
 				118A0B1B19915BDF00792DDE /* NYPLCatalogSearchViewController.m in Sources */,
 				179699D124131BA500EC309F /* UIColor+LabelColor.swift in Sources */,
 				735FED262427494900144C97 /* NYPLNetworkResponder.swift in Sources */,
@@ -4044,7 +4060,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4101,7 +4117,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Simplified/Accounts/Library/Account.swift
+++ b/Simplified/Accounts/Library/Account.swift
@@ -31,7 +31,7 @@ class OPDS2SamlIDP: NSObject, Codable {
 @objcMembers final class AccountDetails: NSObject {
   enum AuthType: String, Codable {
     case basic = "http://opds-spec.org/auth/basic"
-    case coppa = "http://librarysimplified.org/terms/authentication/gate/coppa"
+    case coppa = "http://librarysimplified.org/terms/authentication/gate/coppa" //used for Simplified collection
     case anonymous = "http://librarysimplified.org/rel/auth/anonymous"
     case oauthIntermediary = "http://librarysimplified.org/authtype/OAuth-with-intermediary"
     case saml = "http://librarysimplified.org/authtype/SAML-2.0"
@@ -108,12 +108,14 @@ class OPDS2SamlIDP: NSObject, Codable {
       isOfAge ? coppaOverUrl : coppaUnderUrl
     }
 
-    // use for Objective-C only, authType is the prefered way to do it in Swift
+    var isBasic: Bool {
+      return authType == .basic
+    }
+
     var isOauth: Bool {
       return authType == .oauthIntermediary
     }
 
-    // use for Objective-C only, authType is the prefered way to do it in Swift
     var isSaml: Bool {
       return authType == .saml
     }

--- a/Simplified/AppInfrastructure/NYPLAppDelegate.m
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate.m
@@ -86,8 +86,8 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))backgroundF
     NYPLLOG_F(@"[Background Fetch] Starting book registry sync. "
               "ElapsedTime=%f", -startDate.timeIntervalSinceNow);
     // Only the "current library" account syncs during a background fetch.
-    [[NYPLBookRegistry sharedRegistry] syncResettingCache:NO completionHandler:^(BOOL success) {
-      if (success) {
+    [[NYPLBookRegistry sharedRegistry] syncResettingCache:NO completionHandler:^(NSDictionary *errorDict) {
+      if (errorDict == nil) {
         [[NYPLBookRegistry sharedRegistry] save];
       }
     } backgroundFetchHandler:^(UIBackgroundFetchResult result) {

--- a/Simplified/Catalog/NYPLCatalogFeedViewController.m
+++ b/Simplified/Catalog/NYPLCatalogFeedViewController.m
@@ -161,15 +161,9 @@
 {
   UIApplicationState applicationState = [[UIApplication sharedApplication] applicationState];
   if (applicationState == UIApplicationStateActive) {
-    __weak __auto_type wSelf = self;
-    [[NYPLBookRegistry sharedRegistry] syncResettingCache:NO completionHandler:^(BOOL success) {
-      if (success) {
+    [[NYPLBookRegistry sharedRegistry] syncResettingCache:NO completionHandler:^(NSDictionary *errorDict) {
+      if (errorDict == nil) {
         [[NYPLBookRegistry sharedRegistry] save];
-      } else {
-        [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeRegistrySyncFailure
-                                  summary:@"NYPLCatalogFeedViewController"
-                                  message:@"Book registry sync failed"
-                                 metadata:@{@"Catalog feed URL": wSelf.URL ?: @"N/A"}];
       }
     }];
   }

--- a/Simplified/Catalog/NYPLCatalogNavigationController.m
+++ b/Simplified/Catalog/NYPLCatalogNavigationController.m
@@ -146,7 +146,7 @@
     }];
   } else if (NYPLUserAccount.sharedAccount.isCatalogSecured && !NYPLUserAccount.sharedAccount.hasCredentials) {
     // sign in
-    [NYPLAccountSignInViewController requestCredentialsUsingExistingBarcode:NO authorizeImmediately:YES completionHandler:^{
+    [NYPLAccountSignInViewController requestCredentialsUsingExisting:NO authorizeImmediately:YES completionHandler:^{
       dispatch_async(dispatch_get_main_queue(), ^{
         completion();
       });

--- a/Simplified/Catalog/NYPLCatalogNavigationController.m
+++ b/Simplified/Catalog/NYPLCatalogNavigationController.m
@@ -127,8 +127,8 @@
     [UIApplication sharedApplication].delegate.window.tintColor = [NYPLConfiguration mainColor];
     
     [[NYPLBookRegistry sharedRegistry] justLoad];
-    [[NYPLBookRegistry sharedRegistry] syncResettingCache:NO completionHandler:^(BOOL success) {
-      if (success) {
+    [[NYPLBookRegistry sharedRegistry] syncResettingCache:NO completionHandler:^(NSDictionary *errorDict) {
+      if (errorDict == nil) {
         [[NYPLBookRegistry sharedRegistry] save];
       }
     }];

--- a/Simplified/ErrorHandling/NYPLProblemDocument.swift
+++ b/Simplified/ErrorHandling/NYPLProblemDocument.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /**
-  Represents a Problem Document, outlined in https://tools.ietf.org/html/rfc7807
+ Represents a Problem Document, outlined in https://tools.ietf.org/html/rfc7807
  */
 @objcMembers class NYPLProblemDocument: NSObject, Codable {
   static let TypeNoActiveLoan =
@@ -43,6 +43,41 @@ import Foundation
     self.detail = dict[NYPLProblemDocument.detailKey] as? String
     self.instance = dict[NYPLProblemDocument.instanceKey] as? String
     super.init()
+  }
+
+  /// Synthesizes a problem document for expired or missing credentials.
+  ///
+  /// The type will always be `NYPLProblemDocument.TypeInvalidCredentials`.
+  ///
+  /// - Note: Use this sparingly. Problem Documents are by definition
+  /// objects representing a server result. This is provided only to facilitate
+  /// interfacing with existing logic that expects a problem document, but
+  /// the problem originated on the client.
+  ///
+  /// - Parameter hasCredentials: if `true` the problem document will represent
+  /// an expired credentials situation, otherwise the missing credentials case.
+  /// - Returns: A problem document with `type`, `title`, `detail`.
+  @objc(forExpiredOrMissingCredentials:)
+  static func forExpiredOrMissingCredentials(hasCredentials: Bool) -> NYPLProblemDocument {
+    if hasCredentials {
+      return NYPLProblemDocument([
+        NYPLProblemDocument.typeKey: NYPLProblemDocument.TypeInvalidCredentials,
+        NYPLProblemDocument.titleKey:
+          NSLocalizedString("Authentication Expired",
+                            comment: "Title for an error related to expired credentials"),
+        NYPLProblemDocument.detailKey:
+          NSLocalizedString("Your authentication details have expired. Please sign in again.",
+                            comment: "Message to prompt user to re-authenticate")])
+    } else {
+      return NYPLProblemDocument([
+        NYPLProblemDocument.typeKey: NYPLProblemDocument.TypeInvalidCredentials,
+        NYPLProblemDocument.titleKey:
+          NSLocalizedString("Authentication Required",
+                            comment: "Title for an error related to credentials being required"),
+        NYPLProblemDocument.detailKey:
+          NSLocalizedString("Please sign in to use this functionality.",
+                            comment: "Message to prompt user to authenticate")])
+    }
   }
 
   /**

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -352,10 +352,10 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
   if (!success) {
     dispatch_async(dispatch_get_main_queue(), ^{
       if (problemDocument) {
-        if ([problemDocument.type isEqualToString:NYPLProblemDocument.TypeInvalidCredentials]) {
+        if ([downloadTask.response indicatesAuthenticationNeedsRefresh:problemDocument]) {
           NYPLLOG(@"Invalid credentials problem when downloading a book, present sign in VC");
           [NYPLAccountSignInViewController
-           requestCredentialsUsingExistingBarcode:NO
+           requestCredentialsUsingExisting:NO
            completionHandler:^{
             [self startDownloadForBook:book];
           }];
@@ -376,7 +376,7 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
       } else if (needsAuth) {
         NYPLLOG(@"Present sign in VC");
         [NYPLAccountSignInViewController
-         requestCredentialsUsingExistingBarcode:NO
+         requestCredentialsUsingExisting:NO
          completionHandler:^{
           [self startDownloadForBook:book];
         }];
@@ -610,7 +610,7 @@ didCompleteWithError:(NSError *)error
         } else if ([error[@"type"] isEqualToString:NYPLProblemDocument.TypeInvalidCredentials]) {
           NYPLLOG(@"Invalid credentials problem when returning a book, present sign in VC");
           [NYPLAccountSignInViewController
-           requestCredentialsUsingExistingBarcode:NO
+           requestCredentialsUsingExisting:NO
            completionHandler:^{
             [[NYPLMyBooksDownloadCenter sharedDownloadCenter] returnBookWithIdentifier:identifier];
           }];
@@ -752,7 +752,7 @@ didCompleteWithError:(NSError *)error
           } if ([error[@"type"] isEqualToString:NYPLProblemDocument.TypeInvalidCredentials]) {
             NYPLLOG(@"Invalid credentials problem when borrowing a book, present sign in VC");
             [NYPLAccountSignInViewController
-             requestCredentialsUsingExistingBarcode:NO
+             requestCredentialsUsingExisting:NO
              completionHandler:^{
               [[NYPLMyBooksDownloadCenter sharedDownloadCenter] startDownloadForBook:book];
             }];
@@ -984,7 +984,7 @@ didCompleteWithError:(NSError *)error
           void (^problemFoundHandler)(NYPLProblemDocument * _Nullable) = ^(__unused NYPLProblemDocument * _Nullable problemDocument) {
             [[NYPLBookRegistry sharedRegistry] setState:NYPLBookStateDownloadNeeded forIdentifier:book.identifier];
             [NYPLAccountSignInViewController
-             requestCredentialsUsingExistingBarcode:NO
+             requestCredentialsUsingExisting:NO
              completionHandler:^{
               [[NYPLMyBooksDownloadCenter sharedDownloadCenter] startDownloadForBook:book];
             }];
@@ -1018,7 +1018,7 @@ didCompleteWithError:(NSError *)error
     }
   } else {
     [NYPLAccountSignInViewController
-     requestCredentialsUsingExistingBarcode:NO
+     requestCredentialsUsingExisting:NO
      completionHandler:^{
        [[NYPLMyBooksDownloadCenter sharedDownloadCenter] startDownloadForBook:book];
      }];
@@ -1327,7 +1327,7 @@ didFinishDownload:(BOOL)didFinishDownload
 
 - (void)didIgnoreFulfillmentWithNoAuthorizationPresent
 {
-  [NYPLAccountSignInViewController authorizeUsingExistingBarcodeAndPinWithCompletionHandler:nil];
+  [NYPLAccountSignInViewController authorizeUsingExistingCredentialsWithCompletionHandler:nil];
 }
 
 #endif

--- a/Simplified/MyBooks/NYPLMyBooksViewController.m
+++ b/Simplified/MyBooks/NYPLMyBooksViewController.m
@@ -369,7 +369,7 @@ OK:
     if([[NYPLUserAccount sharedAccount] hasCredentials]) {
       [[NYPLBookRegistry sharedRegistry] syncWithStandardAlertsOnCompletion];
     } else {
-      [NYPLAccountSignInViewController requestCredentialsUsingExistingBarcode:NO completionHandler:nil];
+      [NYPLAccountSignInViewController requestCredentialsUsingExisting:NO completionHandler:nil];
       [self.refreshControl endRefreshing];
       [[NSNotificationCenter defaultCenter] postNotificationName:NSNotification.NYPLSyncEnded object:nil];
     }

--- a/Simplified/NYPLBookCellDelegate.m
+++ b/Simplified/NYPLBookCellDelegate.m
@@ -84,7 +84,7 @@
     if ((![[NYPLADEPT sharedInstance] isUserAuthorized:[[NYPLUserAccount sharedAccount] userID]
                                            withDevice:[[NYPLUserAccount sharedAccount] deviceID]]) &&
         ([[NYPLUserAccount sharedAccount] hasCredentials])) {
-      [NYPLAccountSignInViewController authorizeUsingExistingBarcodeAndPinWithCompletionHandler:^{
+      [NYPLAccountSignInViewController authorizeUsingExistingCredentialsWithCompletionHandler:^{
         [self openBook:book];   // with successful DRM activation
       }];
     } else {

--- a/Simplified/NYPLBookRegistry.h
+++ b/Simplified/NYPLBookRegistry.h
@@ -52,12 +52,14 @@ static NSString *const _Nonnull NYPLBookProcessingDidChangeNotification =
  @param handler Completion Handler is on main thread, but not gauranteed to be called.
  */
 - (void)syncResettingCache:(BOOL)shouldResetCache
-         completionHandler:(void (^ _Nullable)(BOOL success))handler;
+         completionHandler:(void (^ _Nullable)(NSDictionary * _Nullable errorDict))handler;
 
 /**
  Syncs the latest loans content from the server. Attempting to sync while one is
  already in progress will be ignored. Resetting the registry while a sync is in
  progress will cause the handler not to be called.
+
+ Errors are logged via NYPLErrorLogger.
 
  @param shouldResetCache Whether we should wipe the whole cache of
  loans/holds/book details/open search/ungrouped feeds in its entirety or not.
@@ -68,7 +70,7 @@ static NSString *const _Nonnull NYPLBookProcessingDidChangeNotification =
  block should be balanced with calls to the method.
  */
 - (void)syncResettingCache:(BOOL)shouldResetCache
-         completionHandler:(void (^ _Nullable)(BOOL success))handler
+         completionHandler:(void (^ _Nullable)(NSDictionary * _Nullable errorDict))handler
     backgroundFetchHandler:(void (^ _Nullable)(UIBackgroundFetchResult))fetchHandler;
 
 /**

--- a/Simplified/NYPLErrorLogger.swift
+++ b/Simplified/NYPLErrorLogger.swift
@@ -35,12 +35,13 @@ fileprivate let nullString = "null"
   case appLogicInconsistency = 101
   case genericErrorMsgDisplayed = 103
 
-  // book registry
+  // book registry / My books
   case unknownBookState = 203
   case registrySyncFailure = 204
 
   // sign in/out/up
   case invalidLicensor = 300
+  case invalidCredentials = 301
   case barcodeException = 302
   case remoteLoginError = 303
   case userProfileDocFail = 305

--- a/Simplified/NYPLHoldsViewController.m
+++ b/Simplified/NYPLHoldsViewController.m
@@ -258,7 +258,7 @@ didSelectItemAtIndexPath:(NSIndexPath *const)indexPath
     if([[NYPLUserAccount sharedAccount] hasCredentials]) {
       [[NYPLBookRegistry sharedRegistry] syncWithStandardAlertsOnCompletion];
     } else {
-      [NYPLAccountSignInViewController requestCredentialsUsingExistingBarcode:NO completionHandler:nil];
+      [NYPLAccountSignInViewController requestCredentialsUsingExisting:NO completionHandler:nil];
       [self.refreshControl endRefreshing];
       [[NSNotificationCenter defaultCenter] postNotificationName:NSNotification.NYPLSyncEnded object:nil];
     }

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -164,7 +164,7 @@ extension NYPLNetworkResponder: URLSessionDataDelegate {
 
     // no problem document nor error, but response could still be a failure
     if let httpResponse = task.response as? HTTPURLResponse {
-      guard !httpResponse.isFailure() else {
+      guard httpResponse.isSuccess() else {
         logMetadata["response"] = httpResponse
         logMetadata[NSLocalizedDescriptionKey] = NSLocalizedString("UnknownRequestError", comment: "A generic error message for when a network request fails")
         let err = NSError(domain: "Api call with failure HTTP status",

--- a/Simplified/Network/NYPLRemoteViewController.m
+++ b/Simplified/Network/NYPLRemoteViewController.m
@@ -134,14 +134,23 @@
       NSURLSessionDataTask *dataTaskCopy = self.dataTask;
       self.dataTask = nil;
 
-      if ([response.MIMEType isEqualToString:@"application/vnd.opds.authentication.v1.0+json"]) {
-        self.reloadView.hidden = false;
-        [NYPLAccountSignInViewController
-         requestCredentialsUsingExistingBarcode:([NYPLUserAccount sharedAccount].barcode != nil)
-         completionHandler:^{
-          NYPLLOG(@"Re-loading from RemoteVC because got response w/ MIMEtype == application/vnd.opds.authentication.v1.0+json and then authenticated");
-          [self load];
-        }];
+      __auto_type user = [NYPLUserAccount sharedAccount];
+
+      __block NYPLReauthenticator *reauthenticator = [[NYPLReauthenticator alloc] init];
+      BOOL authenticating = [reauthenticator authenticateUser:user
+                                          ifNeededForResponse:response
+                                                 responseData:data
+                                                responseError:error
+                                      authenticationPreflight:^{ self.reloadView.hidden = NO; }
+                                     authenticationCompletion:^{
+        // make sure to retain the reauthenticator until end of auth flow and
+        // then break any possible retain cycle
+        reauthenticator = nil;
+        NYPLLOG(@"Re-loading from RemoteVC because authentication expired");
+        [self load];
+      }];
+
+      if (authenticating) {
         return;
       }
 

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.h
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.h
@@ -15,34 +15,34 @@
 /**
  * Presents itself to begin the login process.
  *
- * @param useExistingBarcode Should the screen be filled with the barcode when available?
+ * @param useExistingCredentials Should the screen be filled with the barcode when available?
  * @param authorizeImmediately Should the authentication process begin automatically after presenting? For Oauth2 and SAML it would mean opening a webview.
  * @param completionHandler Called upon successful authentication
  */
-- (void)presentUsingExistingBarcode:(BOOL const)useExistingBarcode
-               authorizeImmediately:(BOOL)authorizeImmediately
-                  completionHandler:(void (^)(void))handler;
+- (void)presentUsingExistingCredentials:(BOOL const)useExistingBarcode
+                   authorizeImmediately:(BOOL)authorizeImmediately
+                      completionHandler:(void (^)(void))completionHandler;
 
 /**
  * Present sign in view controller to begin a login process.
  *
- * @param useExistingBarcode      Should the screen be filled with barcode and pin when available?
+ * @param useExistingCredentials      Should the screen be filled with barcode and pin when available?
  * @param authorizeImmediately  Should the authentication process begin automatically after presenting? For Oauth2 and SAML it would mean opening a webview
  * @param completionHandler Called upon successful authentication.
  */
-+ (void)requestCredentialsUsingExistingBarcode:(BOOL const)useExistingCredentials
-                          authorizeImmediately:(BOOL)authorizeImmediately
-                             completionHandler:(void (^)(void))handler;
++ (void)requestCredentialsUsingExisting:(BOOL const)useExistingCredentials
+                   authorizeImmediately:(BOOL)authorizeImmediately
+                      completionHandler:(void (^)(void))completionHandler;
 
 // TODO: All calls to this method probably should go through NYPLAccount.
 // The existing barcode may only be used if set in the shared NYPLAccount.
-+ (void)requestCredentialsUsingExistingBarcode:(BOOL)useExistingBarcode
-                             completionHandler:(void (^)(void))handler;
++ (void)requestCredentialsUsingExisting:(BOOL)useExistingBarcode
+                      completionHandler:(void (^)(void))completionHandler;
 
 // This method is here almost entirely so we can handle a bug that seems to occur
 // when the user updates, where the barcode and pin are entered but accoring to
 // ADEPT the device is not authorized. To be used, the account must have a barcode
 // and pin.
-+ (void)authorizeUsingExistingBarcodeAndPinWithCompletionHandler:(void (^)(void))handler;
++ (void)authorizeUsingExistingCredentialsWithCompletionHandler:(void (^)(void))completionHandler;
 
 @end

--- a/Simplified/SignInLogic/NYPLReauthenticator.swift
+++ b/Simplified/SignInLogic/NYPLReauthenticator.swift
@@ -1,0 +1,63 @@
+//
+//  NYPLReauthenticator.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 11/18/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+@objc class NYPLReauthenticator: NSObject {
+
+  /// Determines if the current authentication state has changed based on
+  /// this response metadata and the returned data.
+  ///
+  /// - Parameters:
+  ///   - user: The current user.
+  ///   - response: The response to inspect.
+  ///   - responseData: The data returned by the server for this response.
+  ///   - responseError: Any error returned by URLSession or the like. If you
+  ///   used `NYPLNetworkExecutor`, this should include the problem document
+  ///   if the server sent it.
+  ///   - authenticationPreflight: Code to run before starting the
+  ///   authentication flow.
+  ///   - authenticationCompletion: Code to run after the authentication
+  ///   flow completes.
+  /// - Returns: `true` if an authentication flow was started to refresh the
+  /// credentials, `false` otherwise.
+  @objc func authenticateUser(_ user: NYPLUserAccount,
+                              ifNeededForResponse response: URLResponse,
+                              responseData: Data?,
+                              responseError: NSError?,
+                              authenticationPreflight: (() -> Void)?,
+                              authenticationCompletion: (()-> Void)?) -> Bool {
+    let problemDoc: NYPLProblemDocument?
+    if let problemDocFromError = responseError?.problemDocument {
+      problemDoc = problemDocFromError
+    } else if let responseData = responseData {
+      problemDoc = try? NYPLProblemDocument.fromData(responseData)
+    } else {
+      problemDoc = nil
+    }
+
+    if response.indicatesAuthenticationNeedsRefresh(with: problemDoc) {
+      authenticate(user: user,
+                   preflight: authenticationPreflight,
+                   completion: authenticationCompletion)
+      return true
+    }
+
+    return false
+  }
+
+  private func authenticate(user: NYPLUserAccount,
+                            preflight: (() -> Void)?,
+                            completion: (()-> Void)?) {
+    preflight?()
+    NYPLAccountSignInViewController.requestCredentials(
+      usingExisting: user.authDefinition?.authType == .basic,
+      authorizeImmediately: user.authDefinition?.authType == .basic,
+      completionHandler: completion ?? {})
+  }
+}

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
@@ -23,7 +23,7 @@ extension NYPLMyBooksDownloadCenter: NYPLBookDownloadsDeleting {}
   var syncing: Bool {get}
   func reset(_ libraryAccountUUID: String)
   func syncResettingCache(_ resetCache: Bool,
-                          completionHandler: ((_ success: Bool) -> Void)?)
+                          completionHandler: ((_ errorDict: [AnyHashable: Any]?) -> Void)?)
   func save()
 }
 
@@ -427,8 +427,8 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider {
     userAccount.authDefinition = selectedAuthentication
 
     if libraryAccountID == libraryAccountsProvider.currentAccountId {
-      bookRegistry.syncResettingCache(false) { [weak bookRegistry] success in
-        if success {
+      bookRegistry.syncResettingCache(false) { [weak bookRegistry] errorDict in
+        if errorDict == nil {
           bookRegistry?.save()
         }
       }

--- a/Simplified/SignInLogic/URLResponse+NYPLAuthentication.swift
+++ b/Simplified/SignInLogic/URLResponse+NYPLAuthentication.swift
@@ -1,0 +1,57 @@
+//
+//  URLResponse+NYPLAuthentication.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 11/18/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+extension URLResponse {
+
+  /// Attempts to determine if the response indicates that the user's
+  /// credentials are expired or invalid.
+  ///
+  /// The idea is that if the user was authenticated and an error is returned,
+  /// this may indicate that the credentials that were used in the request
+  /// are no longer valid. The problem document, if available, is the
+  /// primary source of truth.
+  ///
+  /// You could use this api even when the user was not authenticated to begin
+  /// with, but in that case you'd already know the reason of the error.
+  ///
+  /// - Parameter problemDoc: The problem document returned by the server.
+  /// - Returns: `true` if the response or problem document indicate that the
+  /// authentication needs to be refreshed.
+  @objc(indicatesAuthenticationNeedsRefresh:)
+  func indicatesAuthenticationNeedsRefresh(with problemDoc: NYPLProblemDocument?) -> Bool {
+    if let problemDoc = problemDoc, isProblemDocument() {
+      if problemDoc.type == NYPLProblemDocument.TypeInvalidCredentials {
+        return true
+      }
+    }
+
+    return false
+  }
+}
+
+extension HTTPURLResponse {
+  @objc(indicatesAuthenticationNeedsRefresh:)
+  override func indicatesAuthenticationNeedsRefresh(with problemDoc: NYPLProblemDocument?) -> Bool {
+
+    if super.indicatesAuthenticationNeedsRefresh(with: problemDoc) {
+      return true
+    }
+
+    if statusCode == 401 {
+      return true
+    }
+
+    if !isSuccess() && mimeType == "application/vnd.opds.authentication.v1.0+json" {
+      return true
+    }
+
+    return false
+  }
+}

--- a/Simplified/Utilities/URLResponse+NYPL.swift
+++ b/Simplified/Utilities/URLResponse+NYPL.swift
@@ -25,7 +25,7 @@ extension URLResponse {
 }
 
 extension HTTPURLResponse {
-  @objc func isFailure() -> Bool {
-    return statusCode < 200 || statusCode > 299
+  @objc func isSuccess() -> Bool {
+    return statusCode >= 200 && statusCode <= 299
   }
 }

--- a/Simplified/WelcomeScreen/OETutorialChoiceViewController.swift
+++ b/Simplified/WelcomeScreen/OETutorialChoiceViewController.swift
@@ -128,7 +128,7 @@ class OETutorialChoiceViewController : UIViewController {
 
   private func presentSignInVC(for loginChoice: LoginChoice) {
     let signInVC = NYPLAccountSignInViewController(loginChoice: loginChoice)
-    signInVC.present(usingExistingBarcode: false,
+    signInVC.present(usingExistingCredentials: false,
                      authorizeImmediately: false,
                      completionHandler: self.loginCompletionHandler)
   }

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -24,7 +24,7 @@
 "ConnectionFailed" = "Connection Failed";
 "Unable to load the web page at this time." = "Unable to load the web page at this time.";
 "Content Licenses" = "Content Licenses";
-"We found a problem. Please check your connection or close and reopen the app to retry." = "We found a problem. Please check your connection or close and reopen the app to retry.";
+"We found a problem. Please check your connection or close and reopen the app to retry." = "We found a problem. Please check your connection and your credentials in Settings, or close and reopen the app to retry.";
 "Delete" = "Delete";
 "Description" = "Description";
 "DeviceAuthorizationError" = "An error occurred while authorizing this device.";
@@ -171,6 +171,12 @@
 
 // NYPLSettings
 "The page could not load due to a connection error." = "The page could not load due to a connection error.";
+
+// Authentication generic
+"Authentication Expired" = "Authentication Expired";
+"Your authentication details have expired. Please sign in again." = "Your authentication details have expired. Please sign in again.";
+"Authentication Required" = "Authentication Required";
+"Please sign in to use this functionality." = "Please sign in to use this functionality.";
 
 // NYPLSettingsAccountDetailViewController and NYPLAccountSignInViewController
 "Add Library" = "Add Library";

--- a/Simplified/it.lproj/Localizable.strings
+++ b/Simplified/it.lproj/Localizable.strings
@@ -169,6 +169,12 @@
 // NYPLSettings
 "The page could not load due to a connection error." = "Non è stato possibile caricare questa pagina per via di un problema nella connessione.";
 
+// Authentication generic
+"Authentication Expired" = "Credenziali di accesso scadute";
+"Your authentication details have expired. Please sign in again." = "Le tue credenziali di identificazione non sono più valide. Riaccedi per continuare.";
+"Authentication Required" = "Autenticazione necessaria";
+"Please sign in to use this functionality." = "Accedi con uno dei meccanismi di identificazione per poter usare questa funzionalità.";
+
 // NYPLSettingsAccountDetailViewController and NYPLAccountSignInViewController
 "Add Library" = "Aggiungi";
 "Report an Issue" = "Riferisci un problema";


### PR DESCRIPTION
**What's this do?**
Centralizes the logic to determine if an api call indicates that the authentication credentials have somehow expired for a currently signed-in user. Typically this can happen for Clever (and I think SAML) which is common in OE. In that case, the app will prompt the user to re-authenticate. I have not observed this happening ever for basic (barcode) authentication flows, although this should be able to handle that too.

The logic in question is `URLResponse+NYPLAuthentication.swift`. @leonardr I'd really appreciate it if you can take a look at that file and let me know if it makes sense to you, or if it's too generic. The idea is that we should be able to use it for any api call in SimplyE/OE (except card creator stuff I suppose).

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3292

**How should this be tested? / Do these changes have associated tests?**
1. sign in via Clever, and make sure to say that "this computer is shared" on the Clever pages in Safari.
2. leave the app alone for some time -- I think 1 day, although I am unclear on exactly how long it takes for the token to expire.
3. reopen the app. Usually it should automatically direct you to the Catalog (for example if you had force-quit the app, or if the system killed it in case it was strapped for resources)
4. at this point if the token was expired you should see a modal sign-in pane popup in Catalog, with Clever automatically selected. If you now tap on `Login` you should be directed to Safari to get a new token, and then come back to OE. This "going back" step sometimes fails with a 404, but that's outside of my control: if you see that, let me know how persistent it is. Otherwise, it should proceed as normal and display the Catalog.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 