### PR TITLE
SIMPLY-3292 Add QA library support to OE

### DIFF
--- a/OpenEbooks/OpenEBooks_OPDS2_Catalog_Feed-QA.json
+++ b/OpenEbooks/OpenEBooks_OPDS2_Catalog_Feed-QA.json
@@ -1,0 +1,36 @@
+{
+  "catalogs": [
+    {
+      "links": [
+        {
+          "href": "https://qa-circulation.openebooks.us/USOEI/",
+          "type": "application/atom+xml;profile=opds-catalog;kind=acquisition",
+          "rel": "http://opds-spec.org/catalog"
+        },
+        {
+          "href": "https://qa-circulation.openebooks.us/USOEI/authentication_document",
+          "type": "application/vnd.opds.authentication.v1.0+json"
+        },
+        {
+          "href": "https://openebooks.net/",
+          "type": "text/html",
+          "rel": "alternate"
+        },
+        {
+          "href": "mailto:info@openebooks.net",
+          "rel": "help"
+        }
+      ],
+      "metadata": {
+        "updated": "2020-11-20T17:51:51Z",
+        "description": "Open eBooks",
+        "id": "urn:uuid:e1a01c16-04e7-4781-89fd-b442dd1be666",
+        "title": "Open eBooks"
+      }
+    }
+  ],
+  "links": [],
+  "metadata": {
+    "title": "Libraries"
+  }
+}

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -526,6 +526,7 @@
 		735FED262427494900144C97 /* NYPLNetworkResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735FED252427494900144C97 /* NYPLNetworkResponder.swift */; };
 		7360D0D524BFCB9700C8AD16 /* NYPLUserFriendlyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7360D0D424BFCB9700C8AD16 /* NYPLUserFriendlyError.swift */; };
 		7360D0D624BFCB9700C8AD16 /* NYPLUserFriendlyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7360D0D424BFCB9700C8AD16 /* NYPLUserFriendlyError.swift */; };
+		7373530B25682E3200FE1B7E /* OpenEBooks_OPDS2_Catalog_Feed-QA.json in Resources */ = {isa = PBXBuildFile; fileRef = 73735306256828EA00FE1B7E /* OpenEBooks_OPDS2_Catalog_Feed-QA.json */; };
 		7375AE5A25382AC900C85211 /* NYPLUserAccountMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7375AE5925382AC900C85211 /* NYPLUserAccountMock.swift */; };
 		7375AE5B25382AC900C85211 /* NYPLUserAccountMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7375AE5925382AC900C85211 /* NYPLUserAccountMock.swift */; };
 		737F4A532549D78100A3C34B /* NYPLBookCreationTestsObjc.m in Sources */ = {isa = PBXBuildFile; fileRef = 737F4A522549D78100A3C34B /* NYPLBookCreationTestsObjc.m */; };
@@ -1297,6 +1298,7 @@
 		735FED252427494900144C97 /* NYPLNetworkResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLNetworkResponder.swift; sourceTree = "<group>"; };
 		73609AD8245B53CB00F0E08B /* update-certificates.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = "update-certificates.sh"; path = "scripts/update-certificates.sh"; sourceTree = SOURCE_ROOT; };
 		7360D0D424BFCB9700C8AD16 /* NYPLUserFriendlyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserFriendlyError.swift; sourceTree = "<group>"; };
+		73735306256828EA00FE1B7E /* OpenEBooks_OPDS2_Catalog_Feed-QA.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "OpenEBooks_OPDS2_Catalog_Feed-QA.json"; sourceTree = "<group>"; };
 		7375AE5925382AC900C85211 /* NYPLUserAccountMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserAccountMock.swift; sourceTree = "<group>"; };
 		737F4A522549D78100A3C34B /* NYPLBookCreationTestsObjc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NYPLBookCreationTestsObjc.m; sourceTree = "<group>"; };
 		737F4A6A254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+DRM.swift"; sourceTree = "<group>"; };
@@ -2168,6 +2170,7 @@
 				735FCB392506FACF009A8C95 /* ReaderClientCert.sig */,
 				738170142526504800BA2C44 /* GoogleService-Info.plist */,
 				73085E202502E2CD008F6244 /* OpenEBooks_OPDS2_Catalog_Feed.json */,
+				73735306256828EA00FE1B7E /* OpenEBooks_OPDS2_Catalog_Feed-QA.json */,
 				7358EE7B250062BD00DDA0CC /* OEImages.xcassets */,
 				7358EE902500642900DDA0CC /* OELaunchScreen.xib */,
 				73E64E6B252BB89A00276953 /* eula.html */,
@@ -2794,6 +2797,7 @@
 				738170152526504800BA2C44 /* GoogleService-Info.plist in Resources */,
 				73085E212502E2CE008F6244 /* OpenEBooks_OPDS2_Catalog_Feed.json in Resources */,
 				73E64E6C252BB89A00276953 /* eula.html in Resources */,
+				7373530B25682E3200FE1B7E /* OpenEBooks_OPDS2_Catalog_Feed-QA.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4060,7 +4064,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4117,7 +4121,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
@@ -9,25 +9,34 @@
 import Foundation
 
 extension NYPLConfiguration {
-  /// The only "library" account ID that Open eBooks will ever handle.
-  static let OpenEBooksUUID = "urn:uuid:e1a01c16-04e7-4781-89fd-b442dd1be001"
+  // MARK:- Prod library catalog
 
-  static let circulationBaseURLProduction = "https://circulation.openebooks.us"
-  static let circulationBaseURLBeta = "http://qa-circulation.openebooks.us"
-  static let circulationURL = URL(string: circulationBaseURLProduction)!
-
-  static let openEBooksRequestCodesURL = URL(string: "http://openebooks.net/getstarted.html")!
+  /// The only "library" ID that Open eBooks will ever handle (beside beta).
+  /// This value is taken from `OpenEBooks_OPDS2_Catalog_Feed.json`.
+  static let OpenEBooksUUIDProd = "urn:uuid:e1a01c16-04e7-4781-89fd-b442dd1be001"
 
   private static let feedFileUrl = URL(fileURLWithPath:
     Bundle.main.path(forResource: "OpenEBooks_OPDS2_Catalog_Feed",
                      ofType: "json")!)
   private static let feedFileUrlHash = feedFileUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
-
-  static let betaUrl = feedFileUrl
   static var prodUrl = feedFileUrl
-
-  static var betaUrlHash = feedFileUrlHash
   static var prodUrlHash = feedFileUrlHash
+
+  // MARK:- Beta library catalog
+
+  /// This value is taken from `OpenEBooks_OPDS2_Catalog_Feed-QA.json`.
+  static let OpenEBooksUUIDBeta = "urn:uuid:e1a01c16-04e7-4781-89fd-b442dd1be666"
+  private static let betaFeedFileUrl = URL(fileURLWithPath:
+    Bundle.main.path(forResource: "OpenEBooks_OPDS2_Catalog_Feed-QA",
+                     ofType: "json")!)
+  private static let betaFeedFileUrlHash = feedFileUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+
+  static var betaUrl = betaFeedFileUrl
+  static var betaUrlHash = feedFileUrlHash
+
+  // MARK:-
+
+  static let openEBooksRequestCodesURL = URL(string: "http://openebooks.net/getstarted.html")!
 
   @objc static func mainColor() -> UIColor {
     return UIColor(red: 141.0/255.0, green: 199.0/255.0, blue: 64.0/255.0, alpha: 1.0)

--- a/Simplified/Migrations/OEMigrations.swift
+++ b/Simplified/Migrations/OEMigrations.swift
@@ -54,7 +54,7 @@ extension NYPLMigrationManager {
     Log.info(#file, "Running 1.9.0 migration")
 
     // translate old User settings from keychain
-    let user = NYPLUserAccount.sharedAccount(libraryUUID: NYPLConfiguration.OpenEBooksUUID)
+    let user = NYPLUserAccount.sharedAccount(libraryUUID: NYPLConfiguration.OpenEBooksUUIDProd)
     let keychain = NYPLKeychain.shared()
 
     if let oldBarcode = keychain?.object(forKey: "OpenEbooksAccountBarcode") as? String,

--- a/Simplified/NYPLDeveloperSettingsTableViewController.swift
+++ b/Simplified/NYPLDeveloperSettingsTableViewController.swift
@@ -15,6 +15,18 @@ import Foundation
   }
   
   func librarySwitchDidChange(sender: UISwitch!) {
+    #if OPENEBOOKS
+    // we need to sign out because OE doesn't have the UX of handling multiple
+    // accounts at the same time.
+    if NYPLUserAccount.sharedAccount().isSignedIn() {
+      let alert = NYPLAlertUtils.alert(title: "Warning",
+                                       message: "Please sign out before changing to/from QA libraries")
+      NYPLPresentationUtils.safelyPresent(alert, animated: true) {
+        sender.setOn(!sender.isOn, animated: true)
+      }
+      return
+    }
+    #endif
     NYPLSettings.shared.useBetaLibraries = sender.isOn
   }
   

--- a/Simplified/Settings/NYPLSettings+OE.swift
+++ b/Simplified/Settings/NYPLSettings+OE.swift
@@ -18,12 +18,16 @@ extension NYPLSettings {
 
   var settingsAccountsList: [String] {
     get {
-      if let libraryAccounts = UserDefaults.standard.array(forKey: NYPLSettings.settingsLibraryAccountsKey) {
-        return libraryAccounts as! [String]
+      if let libraryAccounts = UserDefaults.standard.array(forKey: NYPLSettings.settingsLibraryAccountsKey) as? [String] {
+        return libraryAccounts
       }
       
       // Avoid crash in case currentLibrary isn't set yet
-      return [NYPLConfiguration.OpenEBooksUUID]
+      if useBetaLibraries {
+        return [NYPLConfiguration.OpenEBooksUUIDBeta]
+      } else {
+        return [NYPLConfiguration.OpenEBooksUUIDProd]
+      }
     }
     set(newAccountsList) {
       UserDefaults.standard.set(newAccountsList, forKey: NYPLSettings.settingsLibraryAccountsKey)

--- a/Simplified/WelcomeScreen/OETutorialChoiceViewController.swift
+++ b/Simplified/WelcomeScreen/OETutorialChoiceViewController.swift
@@ -114,11 +114,13 @@ class OETutorialChoiceViewController : UIViewController {
     let userAccount = NYPLUserAccount.sharedAccount()
     if libAccount?.details == nil {
       libAccount?.loadAuthenticationDocument(using: userAccount) { success in
-        if success {
-          self.presentSignInVC(for: loginChoice)
-        } else {
-          let alert = NYPLAlertUtils.alert(title: "Sign-in Error", message: "We could not find a match for the credentials provided.")
-          self.present(alert, animated: true, completion: nil)
+        NYPLMainThreadRun.asyncIfNeeded {
+          if success {
+            self.presentSignInVC(for: loginChoice)
+          } else {
+            let alert = NYPLAlertUtils.alert(title: "Sign-in Error", message: "We could not find a match for the credentials provided.")
+            self.present(alert, animated: true, completion: nil)
+          }
         }
       }
     } else {


### PR DESCRIPTION
**What's this do?**
- Adds QA library support to Open eBooks
- fixes a possible crash in OE.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3292
This is necessary to test SIMPLY-3292 easily

**How should this be tested? / Do these changes have associated tests?**
Go to developer/testing menu to enable QA library, same as SimplyE

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
y

**Did someone actually run this code to verify it works?**
@ettore 