### PR TITLE
SIMPLY-3161 Fix library card barcode scanning

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -3,8 +3,8 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.j
 github "NYPL-Simplified/CardCreator-iOS" ~> 1.2
 github "NYPL-Simplified/NYPLAEToolkit" "master"
 github "NYPL-Simplified/NYPLAudiobookToolkit" "master"
-github "PureLayout/PureLayout" ~> 3.1.2
-github "TheLevelUp/ZXingObjC" ~> 3.3
-github "stephencelis/SQLite.swift" ~> 0.11.5
 github "NYPL-Simplified/PDFRendererProvider-iOS" "master"
 github "NYPL-Simplified/audiobook-ios-overdrive" "master"
+github "PureLayout/PureLayout" ~> 3.1.2
+github "stephencelis/SQLite.swift" ~> 0.11.5
+github "zxingify/zxingify-objc" ~> 3.6

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -6,5 +6,5 @@ github "NYPL-Simplified/NYPLAudiobookToolkit" "e8fc7450bec441d35c540d2e395222038
 github "NYPL-Simplified/PDFRendererProvider-iOS" "b0ee13aa74e0d88193a401c29624dda8120a340d"
 github "NYPL-Simplified/audiobook-ios-overdrive" "26609934bd80ea1084c041d6f176b4c8ea331046"
 github "PureLayout/PureLayout" "v3.1.6"
-github "TheLevelUp/ZXingObjC" "3.6.4"
 github "stephencelis/SQLite.swift" "0.11.6"
+github "zxingify/zxingify-objc" "3.6.7"

--- a/Simplified/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/NYPLSettingsAccountDetailViewController.m
@@ -3,9 +3,6 @@
 @import CoreLocation;
 @import MessageUI;
 @import PureLayout;
-#ifndef OPENEBOOKS
-@import ZXingObjC;
-#endif
 
 #import "NYPLBookCoverRegistry.h"
 #import "NYPLBookRegistry.h"

--- a/Simplified/software-licenses.html
+++ b/Simplified/software-licenses.html
@@ -43,9 +43,9 @@ place of business at PO Box 809, Neutral Bay, New South Wales, 2089, Australia. 
 AGREEMENT to understand rights granted in the application for its use.</p>
 
 <h2 id="ZXing">Zebra Crossing</h2>
-<p>Copyright 2012 ZXing authors (<a href="https://github.com/TheLevelUp/ZXingObjC">
-https://github.com/TheLevelUp/ZXingObjC</a>)</p>
-<p>Licensed under the Apache License, Version 2.0 (the "License");
+<p>Copyright 2012 ZXing authors (<a href="https://github.com/zxingify/zxingify-objc">
+https://github.com/zxingify/zxingify-objc</a>)</p>
+<p><a href="https://github.com/zxingify/zxingify-objc/blob/master/COPYING">Licensed</a> under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at</p>
 <p><a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a></p>


### PR DESCRIPTION
**What's this do?**
Uses scanning view that matches the actual red rectangle displayed to the user.
Removes useless cruft.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3161

**How should this be tested? / Do these changes have associated tests?**
Sign out and open barcode scanner from Settings > NYPL.
Center barcode in red box.
Profit (hopefully)

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 