### PR TITLE
Fix OE build from script and add option to skip building Adobe SDK dependencies

### DIFF
--- a/OpenEbooks/exportOptions-adhoc.plist
+++ b/OpenEbooks/exportOptions-adhoc.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>destination</key>
+	<string>export</string>
+	<key>method</key>
+	<string>ad-hoc</string>
+	<key>signingCertificate</key>
+	<string>iOS Distribution</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>org.nypl.labs.SimplyE</key>
+		<string>Open eBooks Ad Hoc</string>
+	</dict>
+</dict>
+</plist>

--- a/OpenEbooks/exportOptions-appstore.plist
+++ b/OpenEbooks/exportOptions-appstore.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>destination</key>
+	<string>upload</string>
+	<key>method</key>
+	<string>app-store</string>
+	<key>uploadBitcode</key>
+	<true/>
+	<key>uploadSymbols</key>
+	<true/>
+	<key>signingCertificate</key>
+	<string>iOS Distribution</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>org.nypl.labs.SimplyE</key>
+		<string>Open eBooks Distribution</string>
+	</dict>
+</dict>
+</plist>

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1259,6 +1259,15 @@
 		732F929223ECB51F0099244C /* NYPLBackgroundExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBackgroundExecutor.swift; sourceTree = "<group>"; };
 		733875642423E1B0000FEB67 /* NYPLNetworkExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLNetworkExecutor.swift; sourceTree = "<group>"; };
 		733875662423E540000FEB67 /* NYPLCaching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLCaching.swift; sourceTree = "<group>"; };
+		733E3E05257ED49C00BEBA32 /* xcode-settings.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xcode-settings.sh"; sourceTree = "<group>"; };
+		733E3E06257ED49C00BEBA32 /* ios-binaries-upload.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "ios-binaries-upload.sh"; sourceTree = "<group>"; };
+		733E3E07257ED49C00BEBA32 /* xcode-archive.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xcode-archive.sh"; sourceTree = "<group>"; };
+		733E3E08257ED49D00BEBA32 /* archive-and-upload-adhoc.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "archive-and-upload-adhoc.sh"; sourceTree = "<group>"; };
+		733E3E09257ED49D00BEBA32 /* xcode-export-adhoc.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xcode-export-adhoc.sh"; sourceTree = "<group>"; };
+		733E3E0A257ED52400BEBA32 /* exportOptions-adhoc.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "exportOptions-adhoc.plist"; sourceTree = "<group>"; };
+		733E3E0B257ED52500BEBA32 /* exportOptions-appstore.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "exportOptions-appstore.plist"; sourceTree = "<group>"; };
+		733E3E0C257ED5DF00BEBA32 /* exportOptions-appstore.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "exportOptions-appstore.plist"; sourceTree = "<group>"; };
+		733E3E0D257ED5E000BEBA32 /* exportOptions-adhoc.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "exportOptions-adhoc.plist"; sourceTree = "<group>"; };
 		733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+OAuth.swift"; sourceTree = "<group>"; };
 		7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLResponse+NYPL.swift"; sourceTree = "<group>"; };
 		7340DA6724B7F27900361387 /* NYPLBook+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLBook+Additions.swift"; sourceTree = "<group>"; };
@@ -2119,12 +2128,17 @@
 			children = (
 				73CEF8342526FE80006B2820 /* firebase */,
 				73DA43A52404BA5500985482 /* build-3rd-parties-dependencies.sh */,
-				73609AD8245B53CB00F0E08B /* update-certificates.sh */,
 				73DA43A62404BA5600985482 /* build-carthage.sh */,
-				73DA43A82404BA5600985482 /* build-openssl-curl.sh */,
-				73DA43A72404BA5600985482 /* build_curl.sh */,
-				73CEF83E25270F38006B2820 /* adobe-rmsdk-build.sh */,
 				73C3A33F244108F200AFE44D /* carthage-update-simplye.sh */,
+				73609AD8245B53CB00F0E08B /* update-certificates.sh */,
+				733E3E08257ED49D00BEBA32 /* archive-and-upload-adhoc.sh */,
+				733E3E07257ED49C00BEBA32 /* xcode-archive.sh */,
+				733E3E09257ED49D00BEBA32 /* xcode-export-adhoc.sh */,
+				733E3E05257ED49C00BEBA32 /* xcode-settings.sh */,
+				733E3E06257ED49C00BEBA32 /* ios-binaries-upload.sh */,
+				73CEF83E25270F38006B2820 /* adobe-rmsdk-build.sh */,
+				73DA43A72404BA5600985482 /* build_curl.sh */,
+				73DA43A82404BA5600985482 /* build-openssl-curl.sh */,
 			);
 			path = scripts;
 			sourceTree = SOURCE_ROOT;
@@ -2141,6 +2155,8 @@
 		73CEF839252706E3006B2820 /* SimplyE */ = {
 			isa = PBXGroup;
 			children = (
+				733E3E0A257ED52400BEBA32 /* exportOptions-adhoc.plist */,
+				733E3E0B257ED52500BEBA32 /* exportOptions-appstore.plist */,
 				A823D818192BABA400B55DE2 /* Simplified-Info.plist */,
 				085D31FB1BE7BE86007F7672 /* ReaderClientCert.sig */,
 				738EF2CB2405E38800F388FB /* GoogleService-Info.plist */,
@@ -2153,6 +2169,8 @@
 		73CEF83B25270929006B2820 /* OpenEbooks */ = {
 			isa = PBXGroup;
 			children = (
+				733E3E0D257ED5E000BEBA32 /* exportOptions-adhoc.plist */,
+				733E3E0C257ED5DF00BEBA32 /* exportOptions-appstore.plist */,
 				7358EE922500675700DDA0CC /* Open-eBooks-Info.plist */,
 				735FCB392506FACF009A8C95 /* ReaderClientCert.sig */,
 				738170142526504800BA2C44 /* GoogleService-Info.plist */,

--- a/scripts/adobe-rmsdk-build.sh
+++ b/scripts/adobe-rmsdk-build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+echo "Building Adobe RMSDK..."
+
 ADOBE_RMSDK="`pwd`/adobe-rmsdk"
 CONFIGURATIONS=(Debug Release)
 SDKS=(iphoneos iphonesimulator)

--- a/scripts/archive-and-upload-adhoc.sh
+++ b/scripts/archive-and-upload-adhoc.sh
@@ -5,14 +5,21 @@
 #   https://github.com/NYPL-Simplified/iOS-binaries repo.
 #
 # SYNOPSIS
-#   archive-and-upload-adhoc.sh [ simplye | SE | openebooks | OE ]
+#   archive-and-upload-adhoc.sh [<app-name>] [skipping-adobe]
+#
+# PARAMETERS
+#   <app-name>     : Which app to build. If missing it defaults to SimplyE.
+#                    Possible values: simplye | SE | openebooks | OE
+#
+#   skipping-adobe : Build the app but skip rebuilding the Adobe SDK as well as
+#                    Readium 1 headers, since both rarely (if ever) change.
 #
 # USAGE
 #   Run this script from the root of Simplified-iOS repo, e.g.:
 #
 #     ./scripts/archive-and-upload-adhoc simplye
 
-#./scripts/build-3rd-parties-dependencies
+./scripts/build-3rd-parties-dependencies.sh $2
 
 source "$(dirname $0)/xcode-archive.sh"
 

--- a/scripts/build-3rd-parties-dependencies.sh
+++ b/scripts/build-3rd-parties-dependencies.sh
@@ -2,7 +2,12 @@
 
 # Usage: run this script from the root of Simplified-iOS repo.
 #
-#     ./scripts/build-3rd-parties-dependencies.sh
+#     ./scripts/build-3rd-parties-dependencies.sh [skipping-adobe]
+#
+# Parameters:
+#   skipping-adobe: skips building the dependencies of the Adobe SDK (OpenSSL,
+#                   cURL, etc as well as generating the R1 headers. All this
+#                   stuff almost never changes.
 #
 # Description: This scripts wipes your Carthage folder, checks out and rebuilds
 #              all Carthage dependencies. It also rebuilds OpenSSL and cURL
@@ -13,12 +18,21 @@ echo "Building 3rd party dependencies..."
 # update dependencies from Certificates repo
 ./scripts/update-certificates.sh
 
-# this is required for the Adobe SDK
-./scripts/build-openssl-curl.sh
+case $1 in
+  skipping-adobe | skip-adobe | no-adobe )
+    echo "Skipping build of Adobe SDK dependencies..."
+    ;;
+  *)
+    echo "Building Adobe SDK dependencies..."
 
-# these commands must always be run from the Simplified-iOS repo root.
-sh ./scripts/adobe-rmsdk-build.sh
-(cd readium-sdk; sh MakeHeaders.sh Apple)
+    # this is required for the Adobe SDK
+    ./scripts/build-openssl-curl.sh
+
+    # these commands must always be run from the Simplified-iOS repo root.
+    sh ./scripts/adobe-rmsdk-build.sh
+    (cd readium-sdk; sh MakeHeaders.sh Apple)
+    ;;
+esac
 
 # rebuild all Carthage dependencies from scratch
 ./scripts/build-carthage.sh

--- a/scripts/xcode-export-adhoc.sh
+++ b/scripts/xcode-export-adhoc.sh
@@ -22,7 +22,7 @@ echo "Exporting $ARCHIVE_NAME for Ad-Hoc distribution..."
 mkdir -p "$ADHOC_EXPORT_PATH"
 
 xcodebuild -archivePath "$ARCHIVE_PATH.xcarchive" \
-            -exportOptionsPlist "$APP_NAME/exportOptions-adhoc.plist" \
+            -exportOptionsPlist "$APP_NAME_FOLDER/exportOptions-adhoc.plist" \
             -exportPath "$ADHOC_EXPORT_PATH" \
             -allowProvisioningUpdates \
             -exportArchive #| xcpretty

--- a/scripts/xcode-settings.sh
+++ b/scripts/xcode-settings.sh
@@ -21,9 +21,11 @@ set -eo pipefail
 case $1 in
   --SE | SE | SimplyE | simplye | "")
     APP_NAME=SimplyE
+    APP_NAME_FOLDER=SimplyE
     ;;
   --OE | OE | OpenEbooks | Open_eBooks | "Open eBooks" | openebooks | open_ebooks)
     APP_NAME="Open eBooks"
+    APP_NAME_FOLDER=OpenEbooks
     ;;
   *)
     echo "xcode-settings: please specify a valid app. Possible values: simplye | openebooks"


### PR DESCRIPTION
**What's this do?**
- Fixes some loose ends on the script to build Open Ebooks
- In the main script to build all 3rd parties dependencies, adds an option to skip building Adobe and R1 headers, since those almost never change.

**Why are we doing this? (w/ JIRA link if applicable)**
CI

**How should this be tested? / Do these changes have associated tests?**
as usual, run these scripts from the root of the repo.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 