### PR TITLE
SIMPLY-2961 "View Issues" section on Book Detail pages doesn't appear

### DIFF
--- a/Simplified/NYPLBookDetailDownloadFailedView.h
+++ b/Simplified/NYPLBookDetailDownloadFailedView.h
@@ -1,5 +1,4 @@
-#import "SimplyE-Swift.h"
-
+@class NYPLProblemDocument;
 @class NYPLBookDetailDownloadFailedView;
 
 @interface NYPLBookDetailDownloadFailedView : UIView

--- a/Simplified/NYPLBookDetailDownloadFailedView.h
+++ b/Simplified/NYPLBookDetailDownloadFailedView.h
@@ -1,8 +1,12 @@
+#import "SimplyE-Swift.h"
+
 @class NYPLBookDetailDownloadFailedView;
 
 @interface NYPLBookDetailDownloadFailedView : UIView
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
+
+- (void)configureFailMessageWithProblemDocument:(NYPLProblemDocument *)problemDoc;
 
 @end

--- a/Simplified/NYPLBookDetailDownloadFailedView.m
+++ b/Simplified/NYPLBookDetailDownloadFailedView.m
@@ -1,4 +1,5 @@
 @import PureLayout;
+#import "SimplyE-Swift.h"
 
 #import "NYPLConfiguration.h"
 #import "NYPLLinearView.h"

--- a/Simplified/NYPLBookDetailDownloadFailedView.m
+++ b/Simplified/NYPLBookDetailDownloadFailedView.m
@@ -1,5 +1,4 @@
 @import PureLayout;
-#import "SimplyE-Swift.h"
 
 #import "NYPLConfiguration.h"
 #import "NYPLLinearView.h"
@@ -51,6 +50,14 @@
 - (void)didChangePreferredContentSize
 {
   self.messageLabel.font = [UIFont customFontForTextStyle:UIFontTextStyleBody];
+}
+
+- (void)configureFailMessageWithProblemDocument:(NYPLProblemDocument *)problemDoc {
+  if (problemDoc != nil) {
+    self.messageLabel.text = NSLocalizedString(@"The download could not be completed.\nScroll down to 'View Issues' to see details.", nil);
+  } else {
+    self.messageLabel.text = NSLocalizedString(@"The download could not be completed.", nil);
+  }
 }
 
 @end

--- a/Simplified/NYPLBookDetailView.m
+++ b/Simplified/NYPLBookDetailView.m
@@ -567,6 +567,7 @@ static NSString *DetailHTMLTemplate = nil;
       self.buttonsView.state = NYPLBookButtonsStateDownloadInProgress;
       break;
     case NYPLBookStateDownloadFailed:
+      [self.downloadFailedView configureFailMessageWithProblemDocument:[[NYPLProblemDocumentCacheManager shared] getLastCachedDoc:self.book.identifier]];
       self.downloadFailedView.hidden = NO;
       [self hideDownloadingView:YES];
       self.buttonsView.hidden = NO;

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -32,6 +32,7 @@
 "DownloadCouldNotBeCompleted" = "The download could not be completed.";
 "DownloadCouldNotBeCompletedFormat" = "The download for %@ could not be completed.";
 "The download could not be completed.\nScroll down to 'View Issues' to see details." = "The download could not be completed.\nScroll down to 'View Issues' to see details.";
+"The download could not be completed." = "The download could not be completed.";
 "View Issues" = "View Issues";
 "Report a Problem" = "Report a Problem";
 "Related Books" = "Related Books";

--- a/Simplified/it.lproj/Localizable.strings
+++ b/Simplified/it.lproj/Localizable.strings
@@ -31,6 +31,7 @@
 "DownloadCouldNotBeCompleted" = "Il download è fallito.";
 "DownloadCouldNotBeCompletedFormat" = "Il download di %@ non può essere completato.";
 "The download could not be completed.\nScroll down to 'View Issues' to see details." = "Il download non è stato completato.\nScorri in fondo alla pagina per i dettagli dell'errore.";
+"The download could not be completed." = "Il download non è stato completato.";
 "View Issues" = "Mostra il problema";
 "Report a Problem" = "Riferisci un problema";
 "Related Books" = "Libri correlati";


### PR DESCRIPTION
**What's this do?**
"View Issues" section doesn't appear because there is no problem document when download failed.
The only fix for now is to remove the "Scroll down to view issue" message.

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-2961](https://jira.nypl.org/browse/SIMPLY-2961)

**How should this be tested? / Do these changes have associated tests?**
Force a download fail
The error message should be one line "The download could not be completed"

**Dependencies for merging? Releasing to production?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 
