### PR TITLE
[SIMPLY-3375] Fix NYPLProblemDocumentCacheManager

### DIFF
--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -222,6 +222,8 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
   }
 
   if (success) {
+    [[NYPLProblemDocumentCacheManager sharedInstance] clearCachedDocForBookIdentifier:book.identifier];
+    
     switch(rights) {
       case NYPLMyBooksDownloadRightsManagementUnknown:
         [self logBookDownloadFailure:book

--- a/Simplified/NYPLBookDetailViewController.m
+++ b/Simplified/NYPLBookDetailViewController.m
@@ -266,7 +266,7 @@
 }
 
 - (void)didSelectViewIssuesForBook:(NYPLBook *)book sender:(id)__unused sender {
-  NYPLProblemDocument* pDoc = [[NYPLProblemDocumentCacheManager shared] getLastCachedDoc:book.identifier];
+  NYPLProblemDocument* pDoc = [[NYPLProblemDocumentCacheManager sharedInstance] getLastCachedDoc:book.identifier];
   if (pDoc) {
     NYPLBookDetailsProblemDocumentViewController* vc = [[NYPLBookDetailsProblemDocumentViewController alloc] initWithProblemDocument:pDoc book:book];
     UINavigationController* navVC = [self navigationController];


### PR DESCRIPTION
**What's this do?**
Complete the implementation of NYPLProblemDocumentCacheManager (Clear cache, get cached document etc)

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-3375](https://jira.nypl.org/browse/SIMPLY-3375)

**How should this be tested? / Do these changes have associated tests?**
Force a download fail on two different books, they should both show a problem document in the "View Issue" section
A download success on a book should remove the "View Issue" section

**Dependencies for merging? Releasing to production?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 