### PR TITLE
Exclude Overdrive dependency from nondrm build

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -811,7 +811,6 @@
 		73EB0B4725821DF4006BC997 /* ZXingObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 145DA48D215441A70055DB93 /* ZXingObjC.framework */; };
 		73EB0B4825821DF4006BC997 /* NYPLCardCreator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 145DA49321544A3F0055DB93 /* NYPLCardCreator.framework */; };
 		73EB0B4925821DF4006BC997 /* PureLayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 145DA49521544A420055DB93 /* PureLayout.framework */; };
-		73EB0B4A25821DF4006BC997 /* OverdriveProcessor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17D08378248E8EEB00092AA9 /* OverdriveProcessor.framework */; };
 		73EB0B4B25821DF4006BC997 /* SQLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 145DA4912154464F0055DB93 /* SQLite.framework */; };
 		73EB0B4D25821DF4006BC997 /* NYPLAudiobookToolkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 148B1C1C21710C6800FF64AB /* NYPLAudiobookToolkit.framework */; };
 		73EB0B4E25821DF4006BC997 /* FirebaseCoreDiagnostics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 738EF2D32405EA5F00F388FB /* FirebaseCoreDiagnostics.framework */; };
@@ -1211,15 +1210,6 @@
 			files = (
 				17DFC5F1251E802A003A19CC /* AudioEngine.xcframework in CopyFiles */,
 				7347F135245A50CA00558D7F /* NYPLCardCreator.framework in CopyFiles */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		73EB0B6F25821DF4006BC997 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1814,7 +1804,6 @@
 				73EB0B4725821DF4006BC997 /* ZXingObjC.framework in Frameworks */,
 				73EB0B4825821DF4006BC997 /* NYPLCardCreator.framework in Frameworks */,
 				73EB0B4925821DF4006BC997 /* PureLayout.framework in Frameworks */,
-				73EB0B4A25821DF4006BC997 /* OverdriveProcessor.framework in Frameworks */,
 				73EB0B4B25821DF4006BC997 /* SQLite.framework in Frameworks */,
 				73EB0B4D25821DF4006BC997 /* NYPLAudiobookToolkit.framework in Frameworks */,
 				73EB0B4E25821DF4006BC997 /* FirebaseCoreDiagnostics.framework in Frameworks */,
@@ -2902,7 +2891,6 @@
 				73EB0B2C25821DF4006BC997 /* Frameworks */,
 				73EB0B5825821DF4006BC997 /* Resources */,
 				73EB0B6E25821DF4006BC997 /* Copy Frameworks (Carthage) */,
-				73EB0B6F25821DF4006BC997 /* CopyFiles */,
 				73EB0B7125821DF4006BC997 /* Crashlytics */,
 			);
 			buildRules = (
@@ -3365,7 +3353,6 @@
 				"$(SRCROOT)/Carthage/Build/iOS/NYPLCardCreator.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/NYPLAudiobookToolkit.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/PDFRendererProvider.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/OverdriveProcessor.framework",
 			);
 			name = "Copy Frameworks (Carthage)";
 			outputFileListPaths = (
@@ -4608,6 +4595,7 @@
 					"DEBUG=1",
 					"FEATURE_DRM_CONNECTOR=1",
 					"FEATURE_CRASH_REPORTING=1",
+					"FEATURE_OVERDRIVE=1",
 				);
 				INFOPLIST_FILE = "SimplyE/Simplified-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -4620,7 +4608,7 @@
 				PRODUCT_MODULE_NAME = SimplyE;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "SimplyE Development";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING FEATURE_OVERDRIVE";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplified/AppInfrastructure/SimplyE-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "SimplyE-Swift.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -4665,6 +4653,7 @@
 					"DEBUG=0",
 					"FEATURE_DRM_CONNECTOR=1",
 					"FEATURE_CRASH_REPORTING=1",
+					"FEATURE_OVERDRIVE=1",
 				);
 				INFOPLIST_FILE = "SimplyE/Simplified-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -4677,7 +4666,7 @@
 				PRODUCT_MODULE_NAME = SimplyE;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "SimplyE Distribution";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING FEATURE_OVERDRIVE";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplified/AppInfrastructure/SimplyE-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "SimplyE-Swift.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -4830,6 +4819,7 @@
 					"DEBUG=1",
 					"FEATURE_DRM_CONNECTOR=1",
 					"FEATURE_CRASH_REPORTING=1",
+					"FEATURE_OVERDRIVE=1",
 				);
 				INFOPLIST_FILE = "OpenEbooks/Open-eBooks-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -4843,7 +4833,7 @@
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Open eBooks Development";
 				RUN_CLANG_STATIC_ANALYZER = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG OPENEBOOKS FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG OPENEBOOKS FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING FEATURE_OVERDRIVE";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplified/AppInfrastructure/SimplyE-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "SimplyE-Swift.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -4888,6 +4878,7 @@
 					"DEBUG=0",
 					"FEATURE_DRM_CONNECTOR=1",
 					"FEATURE_CRASH_REPORTING=1",
+					"FEATURE_OVERDRIVE=1",
 				);
 				INFOPLIST_FILE = "OpenEbooks/Open-eBooks-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -4901,7 +4892,7 @@
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "Open eBooks Distribution";
 				RUN_CLANG_STATIC_ANALYZER = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "OPENEBOOKS FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "OPENEBOOKS FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING FEATURE_OVERDRIVE";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplified/AppInfrastructure/SimplyE-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "SimplyE-Swift.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -5066,6 +5057,7 @@
 					"DEBUG=1",
 					"FEATURE_DRM_CONNECTOR=1",
 					"FEATURE_CRASH_REPORTING=1",
+					"FEATURE_OVERDRIVE=1",
 				);
 				INFOPLIST_FILE = "SimplyE/Simplified-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -5078,7 +5070,7 @@
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "SimplyE Development";
 				RUN_CLANG_STATIC_ANALYZER = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING FEATURE_OVERDRIVE";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplified/AppInfrastructure/SimplyE-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -5122,6 +5114,7 @@
 					"DEBUG=0",
 					"FEATURE_DRM_CONNECTOR=1",
 					"FEATURE_CRASH_REPORTING=1",
+					"FEATURE_OVERDRIVE=1",
 				);
 				INFOPLIST_FILE = "SimplyE/Simplified-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
@@ -5134,7 +5127,7 @@
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "SimplyE Distribution";
 				RUN_CLANG_STATIC_ANALYZER = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SIMPLYE FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING FEATURE_OVERDRIVE";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplified/AppInfrastructure/SimplyE-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.2;

--- a/Simplified/MyBooks/NYPLBook+DistributorChecks.swift
+++ b/Simplified/MyBooks/NYPLBook+DistributorChecks.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if FEATURE_OVERDRIVE
 import OverdriveProcessor
+#endif
 
 extension NYPLBook {
 
@@ -25,6 +27,7 @@ extension NYPLBook {
       return true
     }
 
+    #if FEATURE_OVERDRIVE
     // Overdrive may return a response whose Content-Type doesn't match the
     // one that was promised in this book's OPDS document
     if distributor?.lowercased() == OverdriveDistributorKey.lowercased() {
@@ -40,7 +43,8 @@ extension NYPLBook {
         return true
       }
     }
-
+    #endif
+    
     return false
   }
 }

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -1,5 +1,7 @@
 @import NYPLAudiobookToolkit;
+#if FEATURE_OVERDRIVE
 @import OverdriveProcessor;
+#endif
 
 #import "NSString+NYPLStringAdditions.h"
 #import "NYPLAccountSignInViewController.h"
@@ -133,11 +135,13 @@ totalBytesExpectedToWrite:(int64_t const)totalBytesExpectedToWrite
       self.bookIdentifierToDownloadInfo[book.identifier] =
         [[self downloadInfoForBookIdentifier:book.identifier]
          withRightsManagement:NYPLMyBooksDownloadRightsManagementSimplifiedBearerTokenJSON];
+#if FEATURE_OVERDRIVE
     } else if ([downloadTask.response.MIMEType
                    isEqualToString:@"application/json"]) {
          self.bookIdentifierToDownloadInfo[book.identifier] =
            [[self downloadInfoForBookIdentifier:book.identifier]
             withRightsManagement:NYPLMyBooksDownloadRightsManagementOverdriveManifestJSON];
+#endif
     } else if ([NYPLBookAcquisitionPath.supportedTypes containsObject:downloadTask.response.MIMEType]) {
       // if response type represents supported type of book, proceed
       NYPLLOG_F(@"Presuming no DRM for unrecognized MIME type \"%@\".", downloadTask.response.MIMEType);
@@ -535,11 +539,13 @@ didCompleteWithError:(NSError *)error
         
       NSMutableDictionary *dict = nil;
         
+#if FEATURE_OVERDRIVE
       if ([book.distributor isEqualToString:OverdriveDistributorKey]) {
         dict = [(NSMutableDictionary *)json mutableCopy];
         dict[@"id"] = book.identifier;
       }
-      
+#endif
+
       [[AudiobookFactory audiobook:dict ?: json] deleteLocalContent];
       break;
     }
@@ -867,6 +873,7 @@ didCompleteWithError:(NSError *)error
     if(state == NYPLBookStateUnregistered || state == NYPLBookStateHolding) {
       // Check out the book
       [self startBorrowForBook:book attemptDownload:YES borrowCompletion:nil];
+#if FEATURE_OVERDRIVE
     } else if ([book.distributor isEqualToString:OverdriveDistributorKey] && book.defaultBookContentType == NYPLBookContentTypeAudiobook) {
       NSURL *URL = book.defaultAcquisition.hrefURL;
         
@@ -933,7 +940,7 @@ didCompleteWithError:(NSError *)error
           }];
         }
       }];
-        
+#endif
     } else {
       // Actually download the book.
       NSURL *URL = book.defaultAcquisition.hrefURL;

--- a/Simplified/NYPLBookCellDelegate.m
+++ b/Simplified/NYPLBookCellDelegate.m
@@ -1,7 +1,9 @@
 @import MediaPlayer;
 @import NYPLAudiobookToolkit;
 @import PDFRendererProvider;
+#if FEATURE_OVERDRIVE
 @import OverdriveProcessor;
+#endif
 
 #import "NYPLAccountSignInViewController.h"
 #import "NYPLBook.h"
@@ -170,11 +172,13 @@
     
   NSMutableDictionary *dict = nil;
     
+#if FEATURE_OVERDRIVE
   if ([book.distributor isEqualToString:OverdriveDistributorKey]) {
     dict = [(NSMutableDictionary *)json mutableCopy];
     dict[@"id"] = book.identifier;
   }
-  
+#endif
+
   [AudioBookVendorsHelper updateVendorKeyWithBook:json completion:^(NSError * _Nullable error) {
     [NSOperationQueue.mainQueue addOperationWithBlock:^{
       id<Audiobook> const audiobook = [AudiobookFactory audiobook: dict ?: json];
@@ -367,11 +371,13 @@
     
   [[NYPLBookRegistry sharedRegistry] setState:NYPLBookStateDownloadNeeded forIdentifier:self.book.identifier];
 
+#if FEATURE_OVERDRIVE
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateODAudiobookManifest) name:NYPLMyBooksDownloadCenterDidChangeNotification object:nil];
-    
+#endif
   [[NYPLMyBooksDownloadCenter sharedDownloadCenter] startDownloadForBook:self.book];
 }
 
+#if FEATURE_OVERDRIVE
 - (void)updateODAudiobookManifest {
   if ([[NYPLBookRegistry sharedRegistry] stateForIdentifier:self.book.identifier] == NYPLBookStateDownloadSuccessful) {
     OverdriveAudiobook *odAudiobook = (OverdriveAudiobook *)self.manager.audiobook;
@@ -399,5 +405,6 @@
     [self.refreshAudiobookLock unlock];
   }
 }
+#endif
 
 @end

--- a/scripts/build-3rd-party-dependencies.sh
+++ b/scripts/build-3rd-party-dependencies.sh
@@ -16,7 +16,11 @@
 # NOTE
 #   This script is idempotent so it can be run safely over and over.
 
-echo "Building 3rd party dependencies for [$BUILD_CONTEXT]..."
+if [ "$BUILD_CONTEXT" == "" ]; then
+  echo "Building 3rd party dependencies..."
+else
+  echo "Building 3rd party dependencies for [$BUILD_CONTEXT]..."
+fi
 
 case $1 in
   --no-private )
@@ -31,5 +35,5 @@ esac
 
 if [ "$BUILD_CONTEXT" != "ci" ]; then
   # rebuild all Carthage dependencies from scratch
-  ./scripts/build-carthage.sh
+  ./scripts/build-carthage.sh $1
 fi

--- a/scripts/build-carthage.sh
+++ b/scripts/build-carthage.sh
@@ -1,25 +1,36 @@
 #!/bin/bash
 
-# TODO: Remove the script in Certificate repo
-# for extracting AudioEngine URL when this is being merge
-
-# Usage: run this script from the root of Simplified-iOS repo.
+# SUMMARY
+#   This script builds all the dependencies managed by Carthage.
+#   It wipes the Carthage folder beforehand.
 #
-#     ./scripts/build-carthage.sh
+# USAGE
+#   Run this script from the root of Simplified-iOS repo:
 #
-# Description: This scripts wipes your Carthage folder, checks out and rebuilds
-#              all dependencies.
+#     ./scripts/build-carthage.sh [--no-private]
+#
+# PARAMETERS
+#   --no-private: skips building private repos.
+#
+# NOTE
+#   This script is idempotent so it can be run safely over and over.
 
-echo "Building Carthage for [$BUILD_CONTEXT]..."
-
-if [ "$BUILD_CONTEXT" != "ci" ]; then
-  # deep clean to avoid any caching issues
-  rm -rf ~/Library/Caches/org.carthage.CarthageKit
-  rm -rf Carthage
-  carthage checkout --use-ssh
+if [ "$BUILD_CONTEXT" == "" ]; then
+  echo "Building Carthage..."
+else
+  echo "Building Carthage for [$BUILD_CONTEXT]..."
 fi
 
-./Carthage/Checkouts/NYPLAEToolkit/scripts/fetch-audioengine.sh
+# deep clean to avoid any caching issues
+rm -rf ~/Library/Caches/org.carthage.CarthageKit
+rm -rf Carthage
+
+if [ "$1" == "--no-private" ]; then
+  carthage checkout
+else
+  carthage checkout --use-ssh
+  ./Carthage/Checkouts/NYPLAEToolkit/scripts/fetch-audioengine.sh
+fi
 
 echo "List of carthage checkouts to be built:"
 ls -la ./Carthage/Checkouts/

--- a/scripts/setup-repo-nodrm.sh
+++ b/scripts/setup-repo-nodrm.sh
@@ -9,9 +9,11 @@
 #
 #     ./scripts/setup-repo-nodrm.sh
 #
-# NOTE
-#   Building Open eBooks without DRM is not supported.
-#
+# NOTES
+#   1. Building Open eBooks without DRM is not supported.
+#   2. On a fresh checkout this script will produce some errors while trying
+#      to deinit the adobe repos. This is expected and does not affect the
+#      build process.
 
 echo "Setting up repo for non-DRM build"
 
@@ -19,9 +21,11 @@ git submodule deinit adept-ios && git rm -rf adept-ios
 git submodule deinit adobe-content-filter && git rm -rf adobe-content-filter
 git submodule update --init --recursive
 
-# Remove "NYPL-Simplified/NYPLAEToolkit" from Cartfile and Cartfile.resolved.
+# Remove private repos from Cartfile and Cartfile.resolved.
 sed -i '' "s#.*NYPL-Simplified/NYPLAEToolkit.*##" Cartfile
 sed -i '' "s#.*NYPL-Simplified/NYPLAEToolkit.*##" Cartfile.resolved
+sed -i '' "s#.*NYPL-Simplified/audiobook-ios-overdrive.*##" Cartfile
+sed -i '' "s#.*NYPL-Simplified/audiobook-ios-overdrive.*##" Cartfile.resolved
 
 if [ ! -f "APIKeys.swift" ]; then
   cp Simplified/AppInfrastructure/APIKeys.swift.example Simplified/AppInfrastructure/APIKeys.swift


### PR DESCRIPTION
**What's this do?**
This fixes the build without DRM by excluding the private framework for processing Overdrive audiobooks.

**Why are we doing this? (w/ JIRA link if applicable)**
The app should build without DRM / private repos.

**How should this be tested? / Do these changes have associated tests?**
Follow steps in README.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 