### PR TITLE
SIMPLY-3361 Check nonDRM build on new PRs

### DIFF
--- a/.github/workflows/non-drm-build.yml
+++ b/.github/workflows/non-drm-build.yml
@@ -1,0 +1,22 @@
+name: NonDRM Build
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout main repo and submodules
+        uses: actions/checkout@v2.3.4
+        with:
+          submodules: true
+          token: ${{ secrets.IOS_DEV_CI_PAT }}
+      - name: Force Xcode 11.5
+        run: sudo xcode-select -switch /Applications/Xcode_11.5.app
+      - name: Set up repo for nonDRM build
+        run: exec ./scripts/setup-repo-nodrm.sh
+        env:
+          BUILD_CONTEXT: ci
+      - name: Build 3rd party dependencies
+        run: ./scripts/build-3rd-party-dependencies.sh --no-private
+      - name: Build SimplyE without DRM support
+        run: ./scripts/xcode-build-nodrm.sh

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -1,5 +1,6 @@
 name: Unit Tests
-on: pull_request
+on:
+  pull_request:
 jobs:
   build-and-test:
     runs-on: macOS-latest
@@ -31,12 +32,12 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_11.5.app
       - name: Fetch AudioEngine
         run: ./NYPLAEToolkit/scripts/fetch-audioengine.sh
-      - name: Build non-Carthage 3rd party dependencies
-        run: ./scripts/build-3rd-party-dependencies.sh ./NYPLAEToolkit/SimplyE/iOS/APIKeys.json
-        env:
-          BUILD_CONTEXT: ci
       - name: Set up repo for DRM build
         run: exec ./scripts/setup-repo-drm.sh
+        env:
+          BUILD_CONTEXT: ci
+      - name: Build non-Carthage 3rd party dependencies
+        run: ./scripts/build-3rd-party-dependencies.sh
         env:
           BUILD_CONTEXT: ci
       - name: Carthage Bootstrap

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1612,6 +1612,8 @@
 		73EB0B802582CD59006BC997 /* bootstrap-drm.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "bootstrap-drm.sh"; sourceTree = "<group>"; };
 		73EB0B812582CD59006BC997 /* setup-repo-drm.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "setup-repo-drm.sh"; sourceTree = "<group>"; };
 		73EB0B822582CD5A006BC997 /* setup-repo-nodrm.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "setup-repo-nodrm.sh"; sourceTree = "<group>"; };
+		73EC88FF258D88E100978955 /* non-drm-build.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = "non-drm-build.yml"; sourceTree = "<group>"; };
+		73EC8904258D8A2A00978955 /* xcode-build-nodrm.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xcode-build-nodrm.sh"; sourceTree = "<group>"; };
 		73FB0AC824EB403D0072E430 /* NYPLBookContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NYPLBookContentType.swift; path = Models/NYPLBookContentType.swift; sourceTree = "<group>"; };
 		73FCA3A425005BA4001B0C5D /* Open eBooks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Open eBooks.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		841B55411B740F2700FAC1AF /* NYPLSettingsEULAViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYPLSettingsEULAViewController.h; sourceTree = "<group>"; };
@@ -2182,6 +2184,7 @@
 			isa = PBXGroup;
 			children = (
 				7300D469258829E1002256A3 /* unit-testing.yml */,
+				73EC88FF258D88E100978955 /* non-drm-build.yml */,
 			);
 			path = workflows;
 			sourceTree = "<group>";
@@ -2463,6 +2466,7 @@
 				733E3E07257ED49C00BEBA32 /* xcode-archive.sh */,
 				733E3E09257ED49D00BEBA32 /* xcode-export-adhoc.sh */,
 				7358A951258997A900E66D34 /* xcode-test.sh */,
+				73EC8904258D8A2A00978955 /* xcode-build-nodrm.sh */,
 				733E3E05257ED49C00BEBA32 /* xcode-settings.sh */,
 				733E3E06257ED49C00BEBA32 /* ios-binaries-upload.sh */,
 				73EB0B802582CD59006BC997 /* bootstrap-drm.sh */,

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1546,6 +1546,9 @@
 		735771AA2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLLibraryAccountsProviderMock.swift; sourceTree = "<group>"; };
 		735771AD2537687D00067CEA /* NYPLURLSettingsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLURLSettingsProviderMock.swift; sourceTree = "<group>"; };
 		735771B02537691800067CEA /* NYPLDRMAuthorizingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLDRMAuthorizingMock.swift; sourceTree = "<group>"; };
+		7358A94B25898F4200E66D34 /* nypl-upload-symbols.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "nypl-upload-symbols.sh"; sourceTree = "<group>"; };
+		7358A951258997A900E66D34 /* xcode-test.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xcode-test.sh"; sourceTree = "<group>"; };
+		7358A9532589A70B00E66D34 /* decode-install-secrets.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "decode-install-secrets.sh"; sourceTree = "<group>"; };
 		7358EE7B250062BD00DDA0CC /* OEImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = OEImages.xcassets; sourceTree = "<group>"; };
 		7358EE902500642900DDA0CC /* OELaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OELaunchScreen.xib; sourceTree = "<group>"; };
 		7358EE922500675700DDA0CC /* Open-eBooks-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Open-eBooks-Info.plist"; sourceTree = "<group>"; };
@@ -2455,9 +2458,11 @@
 				73DA43A62404BA5600985482 /* build-carthage.sh */,
 				73EB0B7E2582CCE8006BC997 /* update-carthage.sh */,
 				73609AD8245B53CB00F0E08B /* update-certificates.sh */,
+				7358A9532589A70B00E66D34 /* decode-install-secrets.sh */,
 				733E3E08257ED49D00BEBA32 /* archive-and-upload-adhoc.sh */,
 				733E3E07257ED49C00BEBA32 /* xcode-archive.sh */,
 				733E3E09257ED49D00BEBA32 /* xcode-export-adhoc.sh */,
+				7358A951258997A900E66D34 /* xcode-test.sh */,
 				733E3E05257ED49C00BEBA32 /* xcode-settings.sh */,
 				733E3E06257ED49C00BEBA32 /* ios-binaries-upload.sh */,
 				73EB0B802582CD59006BC997 /* bootstrap-drm.sh */,
@@ -2475,6 +2480,7 @@
 			children = (
 				73CEF8352526FE80006B2820 /* run */,
 				73CEF8362526FE80006B2820 /* upload-symbols */,
+				7358A94B25898F4200E66D34 /* nypl-upload-symbols.sh */,
 			);
 			path = firebase;
 			sourceTree = "<group>";

--- a/scripts/archive-and-upload-adhoc.sh
+++ b/scripts/archive-and-upload-adhoc.sh
@@ -2,24 +2,19 @@
 
 # SUMMARY
 #   Archives and exports a build of SimplyE or Open eBooks and uploads it to
-#   https://github.com/NYPL-Simplified/iOS-binaries repo.
+#   https://github.com/NYPL-Simplified/iOS-binaries repo, assuming all
+#   third party dependencies have already been built.
 #
 # SYNOPSIS
-#   archive-and-upload-adhoc.sh [<app-name>] [skipping-adobe]
+#   archive-and-upload-adhoc.sh <app-name>
 #
 # PARAMETERS
-#   <app-name>     : Which app to build. If missing it defaults to SimplyE.
-#                    Possible values: simplye | SE | openebooks | OE
-#
-#   skipping-adobe : Build the app but skip rebuilding the Adobe SDK as well as
-#                    Readium 1 headers, since both rarely (if ever) change.
+#   See xcode-settings.sh for possible parameters.
 #
 # USAGE
 #   Run this script from the root of Simplified-iOS repo, e.g.:
 #
 #     ./scripts/archive-and-upload-adhoc simplye
-
-./scripts/build-3rd-parties-dependencies.sh $2
 
 source "$(dirname $0)/xcode-archive.sh"
 

--- a/scripts/build-3rd-party-dependencies.sh
+++ b/scripts/build-3rd-party-dependencies.sh
@@ -33,7 +33,7 @@ esac
 
 (cd readium-sdk; sh MakeHeaders.sh Apple)
 
-if [ "$BUILD_CONTEXT" != "ci" ]; then
+if [ "$BUILD_CONTEXT" != "ci" ] || [ "$1" == "--no-private" ]; then
   # rebuild all Carthage dependencies from scratch
   ./scripts/build-carthage.sh $1
 fi

--- a/scripts/decode-install-secrets.sh
+++ b/scripts/decode-install-secrets.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# run from root of repo
+
+set -eo pipefail
+
+PROV_PROFILES_DIR_PATH="$HOME/Library/MobileDevice/Provisioning Profiles"
+mkdir -p "$PROV_PROFILES_DIR_PATH"
+
+# decode SimplyE / Open eBooks provisioning profiles for Ad Hoc distribution
+# to the NYPL-Simplified/iOS-binaries repo.
+base64 -d -o "$PROV_PROFILES_DIR_PATH"/SimplyE_Ad_Hoc.mobileprovision <<< "$SE_PROV_PROFILE_ADHOC"
+base64 -d -o "$PROV_PROFILES_DIR_PATH"/Open_eBooks_Ad_Hoc.mobileprovision <<< "$OE_PROV_PROFILE_ADHOC"
+echo "Decoded provisioning profiles:"
+ls -la "$PROV_PROFILES_DIR_PATH"
+
+# decode identity (cert+key)
+base64 -d -o ios_distribution.p12 <<< "$IOS_DISTR_IDENTITY_BASE64"
+echo "Decoded identity:"
+ls -la ios_distribution.p12
+
+echo "Default keychain:"
+security default-keychain
+
+# create a new keychain for our stuff
+#KEYCHAIN_PASSPHRASE="" #TODO: add secret for this after verify it works with ""
+KEYCHAIN_PASSPHRASE="$IOS_DISTR_IDENTITY_PASSPHRASE"
+security create-keychain -p "$KEYCHAIN_PASSPHRASE" build.keychain
+echo "Created build.keychain:"
+ls -la $HOME/Library/Keychains
+
+# add distribution certificate+key to keychain
+security import ios_distribution.p12 -t agg -k $HOME/Library/Keychains/build.keychain -P "$KEYCHAIN_PASSPHRASE" -A
+echo "Imported ios_distribution identity"
+
+# clean up
+rm -f ios_distribution.p12
+
+# set our keychain as default keychain and unlock it
+security list-keychains -s $HOME/Library/Keychains/build.keychain
+echo "Completed setting search list to build.keychain"
+
+security default-keychain -s $HOME/Library/Keychains/build.keychain
+echo "Completed setting build keychain as default"
+
+security unlock-keychain -p "$KEYCHAIN_PASSPHRASE" $HOME/Library/Keychains/build.keychain
+echo "Unlocked build keychain"
+
+# enable keychain so that we can use to codesign our builds
+security set-key-partition-list -S apple-tool:,apple: -s \
+    -k "$KEYCHAIN_PASSPHRASE" ~/Library/Keychains/build.keychain

--- a/scripts/firebase/nypl-upload-symbols.sh
+++ b/scripts/firebase/nypl-upload-symbols.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#  nypl-upload-symbols.sh
+#  Created by Ettore Pasquini on 12/15/20.
+#  Copyright © 2020 NYPL Labs. All rights reserved.
+#
+# SUMMARY
+#   This script facilitates uploading dSYMs to Firebase for SimplyE and
+#   Open eBooks.
+#
+# USAGE
+#   Run this script from the root of Simplified-iOS repo. Note that both
+#   parameters are mandatory and must appear in this order:
+#
+#     ./scripts/firebase/nypl-upload-symbols.sh <app-name> <dSYMs-dir-path>
+#
+# PARAMETERS
+#   <app-name> : simplye | openebooks
+#   <dSYMs-dir-path> : absolute path to the directory containing the dSYMs
+#       for the build you need to update. Given an archive, typically this is
+#       ~/Library/Developer/Xcode/Archives/<date>/<archive-name>.xcarchive/dSYMs
+
+# lower case of app name param
+APPNAME=`echo "$1" | tr '[:upper:]' '[:lower:]'`
+
+case $APPNAME in
+  simplye | se)
+    GOOGLE_PLIST_PATH="./SimplyE/GoogleService-Info.plist"
+    ;;
+  openebooks | oe | open_ebooks)
+    GOOGLE_PLIST_PATH="./OpenEbooks/GoogleService-Info.plist"
+    ;;
+  *)
+    echo "nypl-upload-symbols.sh: please specify a valid app. Possible values: simplye | openebooks"
+    exit 1
+    ;;
+esac
+
+echo "Using Google plist: $GOOGLE_PLIST_PATH"
+
+./scripts/firebase/upload-symbols -gsp "$GOOGLE_PLIST_PATH" -p ios "$2"

--- a/scripts/ios-binaries-upload.sh
+++ b/scripts/ios-binaries-upload.sh
@@ -5,7 +5,10 @@
 #   https://github.com/NYPL-Simplified/iOS-binaries repo.
 #
 # SYNOPSIS
-#   ios-binaries-upload.sh [ simplye | SE | openebooks | OE ]
+#   ios-binaries-upload.sh <app_name>
+#
+# PARAMETERS
+#   See xcode-settings.sh for possible parameters.
 #
 # USAGE
 #   Run this script from the root of Simplified-iOS repo, e.g.:
@@ -17,31 +20,39 @@ source "$(dirname $0)/xcode-settings.sh"
 echo "Uploading $ARCHIVE_NAME to 'ios-binaries' repo..."
 
 SIMPLIFIED_DIR=$PWD
-cd ..
+
+# In a GitHub Actions CI context we can't clone a repo as a sibling
+if [ "$BUILD_CONTEXT" != "ci" ]; then
+  cd ..
+fi
+
 if [[ -d "iOS-binaries" ]]; then
   echo "iOS-binaries repo appears to be cloned already..."
-  IOS_BINARIES_DIR=iOS-binaries
+  IOS_BINARIES_DIR_NAME=iOS-binaries
 elif [[ -d "NYPL-iOS-binaries" ]]; then
   echo "iOS-binaries repo appears to be cloned already..."
-  IOS_BINARIES_DIR=NYPL-iOS-binaries
+  IOS_BINARIES_DIR_NAME=NYPL-iOS-binaries
 else
+  IOS_BINARIES_DIR_NAME=iOS-binaries
   git clone git@github.com:NYPL-Simplified/iOS-binaries.git
-  IOS_BINARIES_DIR=iOS-binaries
 fi
+
+IOS_BINARIES_DIR_PATH="$PWD/$IOS_BINARIES_DIR_NAME"
 
 cd "$SIMPLIFIED_DIR"
 IPA_NAME="${ARCHIVE_NAME}.ipa"
-echo "Copying .ipa to $PWD/../$IOS_BINARIES_DIR/$IPA_NAME"
-cp "$ADHOC_EXPORT_PATH/$APP_NAME.ipa" "../$IOS_BINARIES_DIR/$IPA_NAME"
+echo "Copying .ipa to $IOS_BINARIES_DIR_PATH/$IPA_NAME"
+cp "$ADHOC_EXPORT_PATH/$APP_NAME.ipa" "$IOS_BINARIES_DIR_PATH/$IPA_NAME"
 
-cd "../$IOS_BINARIES_DIR"
+cd "$IOS_BINARIES_DIR_PATH"
 git add "$IPA_NAME"
 
-# enable once we have CI
-# git config --global user.email "ci@librarysimplified.org" ||
-#   fatal "could not configure git"
-# git config --global user.name "Library Simplified CI" ||
-#   fatal "could not configure git"
+if [ "$BUILD_CONTEXT" == "ci" ]; then
+  git config --global user.email "ci@librarysimplified.org" ||
+    fatal "could not configure git"
+  git config --global user.name "Library Simplified CI" ||
+    fatal "could not configure git"
+fi
 
 COMMIT_MSG="Add ${BUILD_NAME} build"
 git commit -m "$COMMIT_MSG" || fatal "could not commit ${BUILD_NAME} binary"

--- a/scripts/setup-repo-drm.sh
+++ b/scripts/setup-repo-drm.sh
@@ -11,7 +11,11 @@
 #     ./scripts/setup-repo-drm.sh
 #
 
-echo "Setting up repo for building with DRM support for [$BUILD_CONTEXT]..."
+if [ "$BUILD_CONTEXT" == "" ]; then
+  echo "Setting up repo for building with DRM support..."
+else
+  echo "Setting up repo for building with DRM support for [$BUILD_CONTEXT]..."
+fi
 
 git submodule update --init --recursive
 

--- a/scripts/update-certificates.sh
+++ b/scripts/update-certificates.sh
@@ -6,7 +6,11 @@
 #
 # Note: this script assumes you have the Certificates repo cloned as a sibling of Simplified-iOS.
 
-echo "Updating repo with info from Certificates repo for [$BUILD_CONTEXT]..."
+if [ "$BUILD_CONTEXT" == "" ]; then
+  echo "Updating repo with info from Certificates repo..."
+else
+  echo "Updating repo with info from Certificates repo for [$BUILD_CONTEXT]..."
+fi
 
 if [ "$BUILD_CONTEXT" == "ci" ]; then
   CERTIFICATES_PATH="./Certificates"

--- a/scripts/xcode-archive.sh
+++ b/scripts/xcode-archive.sh
@@ -33,4 +33,5 @@ xcodebuild -project $PROJECT_NAME \
            -sdk iphoneos \
            -configuration Release \
            -archivePath $ARCHIVE_PATH \
-           clean archive
+           clean archive | \
+           if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi

--- a/scripts/xcode-archive.sh
+++ b/scripts/xcode-archive.sh
@@ -4,7 +4,10 @@
 #   Creates an archive for SimplyE or Open eBooks
 #
 # SYNOPSIS
-#   xcode-archive.sh [ simplye | SE | openebooks | OE ]
+#   xcode-archive.sh <app_name>
+#
+# PARAMETERS
+#   See xcode-settings.sh for possible parameters.
 #
 # USAGE
 #   Run this script from the root of Simplified-iOS repo, e.g.:

--- a/scripts/xcode-build-nodrm.sh
+++ b/scripts/xcode-build-nodrm.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# SUMMARY
+#   Builds SimplyE without DRM support.
+#
+# SYNOPSIS
+#   xcode-build-nodrm.sh
+#
+# USAGE
+#   Run this script from the root of Simplified-iOS repo, e.g.:
+#
+#     ./scripts/xcode-build-nodrm.sh
+
+echo "Building SimplyE without DRM support..."
+
+xcodebuild -project Simplified.xcodeproj \
+           -scheme SimplyE-noDRM \
+           -destination platform=iOS\ Simulator,OS=13.5,name=iPhone\ 11\ Pro\
+           clean build | \
+           if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi

--- a/scripts/xcode-export-adhoc.sh
+++ b/scripts/xcode-export-adhoc.sh
@@ -4,7 +4,10 @@
 #   Exports an archive for SimplyE / Open eBooks and generates the related ipa.
 #
 # SYNOPSIS
-#   xcode-export-adhoc.sh [ simplye | SE | openebooks | OE ]
+#   xcode-export-adhoc.sh <app_name>
+#
+# PARAMETERS
+#   See xcode-settings.sh for possible parameters.
 #
 # USAGE
 #   Run this script from the root of Simplified-iOS repo, e.g.:

--- a/scripts/xcode-export-adhoc.sh
+++ b/scripts/xcode-export-adhoc.sh
@@ -28,4 +28,5 @@ xcodebuild -archivePath "$ARCHIVE_PATH.xcarchive" \
             -exportOptionsPlist "$APP_NAME_FOLDER/exportOptions-adhoc.plist" \
             -exportPath "$ADHOC_EXPORT_PATH" \
             -allowProvisioningUpdates \
-            -exportArchive #| xcpretty
+            -exportArchive | \
+            if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi

--- a/scripts/xcode-settings.sh
+++ b/scripts/xcode-settings.sh
@@ -1,25 +1,29 @@
 #!/bin/bash
 
 # SUMMARY
-# Configures common environment variables for building Simplified apps.
+#   Configures common environment variables for building Simplified apps.
 #
 # USAGE
-# Source this script from other scripts (e.g. xcode-archive.sh)
+#   Source this script from other scripts (e.g. xcode-archive.sh)
 #
-# in xcode-archive.sh:
-#   source "path/to/xcode-settings.sh"
-#   ...
+#   in xcode-archive.sh:
+#     source "path/to/xcode-settings.sh"
+#     ...
 #
-# invocation:
-#   xcode-archive.sh SimplyE
+#   invocation:
+#     xcode-archive.sh <app_name>
 #
-# The assumption here is that the app name (visible to the end-user) coincides
-# with the Xcode target and scheme names.
+#   The assumption here is that the app name (visible to the end-user)
+#   coincides with the Xcode target and scheme names.
+#
+# PARAMETERS
+#     <app_name> : Which app to build. Mandatory. Possible values:
+#         [ simplye | SE | openebooks | OE ]
 
 set -eo pipefail
 
 case $1 in
-  --SE | SE | SimplyE | simplye | "")
+  --SE | SE | SimplyE | simplye)
     APP_NAME=SimplyE
     APP_NAME_FOLDER=SimplyE
     ;;
@@ -38,6 +42,7 @@ BUILD_PATH='./Build'
 PROJECT_NAME=Simplified.xcodeproj
 TARGET_NAME=$APP_NAME
 SCHEME=$APP_NAME
+PROV_PROFILES_DIR_PATH="$HOME/Library/MobileDevice/Provisioning Profiles"
 
 # app agnostic build settings
 BUILD_SETTINGS="`xcodebuild -project $PROJECT_NAME -showBuildSettings -target \"$TARGET_NAME\"`"

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -21,4 +21,5 @@ echo "Running unit tests for $APP_NAME..."
 xcodebuild -project "$PROJECT_NAME" \
            -scheme "$SCHEME" \
            -destination platform=iOS\ Simulator,OS=13.5,name=iPhone\ 11 \
-           clean test | xcpretty
+           clean test | \
+           if command -v xcpretty &> /dev/null; then xcpretty; else cat; fi

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -4,13 +4,15 @@
 #   Runs the unit tests for SimplyE / Open eBooks.
 #
 # SYNOPSIS
-#   xcode-test.sh [ simplye | SE | openebooks | OE ]
+#   xcode-test.sh <app_name>
+#
+# PARAMETERS
+#   See xcode-settings.sh for possible parameters.
 #
 # USAGE
 #   Run this script from the root of Simplified-iOS repo, e.g.:
 #
 #     ./scripts/xcode-test.sh simplye
-#
 
 source "$(dirname $0)/xcode-settings.sh"
 
@@ -19,4 +21,4 @@ echo "Running unit tests for $APP_NAME..."
 xcodebuild -project "$PROJECT_NAME" \
            -scheme "$SCHEME" \
            -destination platform=iOS\ Simulator,OS=13.5,name=iPhone\ 11 \
-           clean test
+           clean test | xcpretty


### PR DESCRIPTION
**What's this do?**
Verifies that a new PR doesn't brake the non-DRM build.

This also contains some prep work for the bigger action to upload builds to iOS-binaries plus a minor refactor of the scripts. I left it here because I sort of developed those first before switching to the non-DRM build. Since it's foundation work I figure it's ok. This work is also divided in separate commits.

**Why are we doing this? (w/ JIRA link if applicable)**
Since Simplified-iOS is a public repo that requires private dependencies to build with DRM support, we want to be good citizens and continue to support a version of the app without DRM support, using only publicly available code.
https://jira.nypl.org/browse/SIMPLY-3361

**How should this be tested? / Do these changes have associated tests?**
This will happen for every new PR being published.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 