### PR TITLE
Get build scripts closer to CI build

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: macOS-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
+      - name: Force Xcode 11.5
+        run: sudo xcode-select -switch /Applications/Xcode_11.5.app
       - name: Checkout main repo and submodules
         uses: actions/checkout@v2.3.4
         with:
@@ -29,8 +31,6 @@ jobs:
           repository: NYPL-Simplified/NYPLAEToolkit
           token: ${{ secrets.IOS_DEV_CI_PAT }}
           path: ./NYPLAEToolkit
-      - name: Force Xcode 11.5
-        run: sudo xcode-select -switch /Applications/Xcode_11.5.app
       - name: Fetch AudioEngine
         run: ./NYPLAEToolkit/scripts/fetch-audioengine.sh
       - name: Set up repo for DRM build

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ Build
 adobe-rmsdk
 **/ReaderClientCert.sig
 **/APIKeys.swift
-Carthage
+Carthage*
 **/GoogleService-Info.plist
 **/NYPLSecrets.swift
 fastlane/report.xml

--- a/scripts/build-3rd-party-dependencies.sh
+++ b/scripts/build-3rd-party-dependencies.sh
@@ -41,7 +41,5 @@ esac
 
 (cd readium-sdk; sh MakeHeaders.sh Apple) || fatal "Error making Readium headers"
 
-if [ "$BUILD_CONTEXT" != "ci" ] || [ "$1" == "--no-private" ]; then
-  # rebuild all Carthage dependencies from scratch
-  ./scripts/build-carthage.sh $1
-fi
+# rebuild all Carthage dependencies from scratch
+./scripts/build-carthage.sh $1

--- a/scripts/build-carthage.sh
+++ b/scripts/build-carthage.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 
 # SUMMARY
-#   This script builds all the dependencies managed by Carthage.
-#   It wipes the Carthage folder beforehand.
+#   Sets up and build dependencies for the SimplyE, SimplyE-noDRM and
+#   Open eBooks targets.
 #
-# USAGE
-#   Run this script from the root of Simplified-iOS repo:
-#
-#     ./scripts/build-carthage.sh [--no-private]
+# SYNOPSIS
+#     ./scripts/build-carthage.sh [--no-private ]
 #
 # PARAMETERS
-#   --no-private: skips building private repos.
+#     --no-private: skips building private repos.
 #
-# NOTE
-#   This script is idempotent so it can be run safely over and over.
+# USAGE
+#   Make sure to run this script from a clean checkout and from the root
+#   of Simplified-iOS, e.g.:
+#
+#     git checkout Cartfile
+#     git checkout Cartfile.resolved
+#     ./scripts/build-carthage.sh
 
 set -eo pipefail
 
@@ -25,18 +28,16 @@ fi
 
 # deep clean to avoid any caching issues
 rm -rf ~/Library/Caches/org.carthage.CarthageKit
-rm -rf Carthage
 
-if [ "$1" == "--no-private" ]; then
-  carthage checkout
-else
-  carthage checkout --use-ssh
+# In a CI context we are unable to pass the proper git authentication to
+# the `carthage` commands, so we skip them here
+if [ "$BUILD_CONTEXT" != "ci" ] && [ "$1" != "--no-private" ]; then
+  # checkout NYPLAEToolkit to use the private script to fetch AudioEngine
+  carthage checkout NYPLAEToolkit
   ./Carthage/Checkouts/NYPLAEToolkit/scripts/fetch-audioengine.sh
 fi
 
-echo "List of carthage checkouts to be built:"
-ls -la ./Carthage/Checkouts/
-
-echo "Carthage build..."
-carthage build --platform ios
-
+if [ "$BUILD_CONTEXT" != "ci" ] || [ "$1" == "--no-private" ]; then
+  echo "Carthage build..."
+  carthage bootstrap --platform ios
+fi


### PR DESCRIPTION
**What's this do?**
Changes the way we build the carthage dependencies so that they use the same command (`carthage bootstrap`) that we use on CI.

**Why are we doing this? (w/ JIRA link if applicable)**
We should strive to have the local and CI builds match as much as possible.

**How should this be tested? / Do these changes have associated tests?**
CI should do this for us :)

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did you bump the SimplyE build number?**
no code changes, so not needed

**Did someone actually run this code to verify it works?**
@ettore 