### PR TITLE
Improve check build # workflow and enable Feature branches CI

### DIFF
--- a/.github/workflows/archive-and-upload.yml
+++ b/.github/workflows/archive-and-upload.yml
@@ -3,7 +3,7 @@ on: workflow_dispatch
 jobs:
   upload-arc:
     runs-on: macOS-latest
-    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/')
+    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/feature/')
     steps:
       - name: Force Xcode 11.5
         run: sudo xcode-select -switch /Applications/Xcode_11.5.app

--- a/.github/workflows/check-build-number.yml
+++ b/.github/workflows/check-build-number.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - develop
       - release/**
+      - feature/**
 jobs:
   check-binaries:
     runs-on: macOS-latest

--- a/.github/workflows/check-build-number.yml
+++ b/.github/workflows/check-build-number.yml
@@ -12,14 +12,6 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           token: ${{ secrets.IOS_DEV_CI_PAT }}
-      - name: Checkout iOS Binaries repo
-        uses: actions/checkout@v2.3.4
-        with:
-          repository: NYPL-Simplified/iOS-binaries
-          token: ${{ secrets.IOS_DEV_CI_PAT }}
-          path: ./iOS-binaries
-      - name: Force Xcode 11.5
-        run: sudo xcode-select -switch /Applications/Xcode_11.5.app
       - name: Check Build Number
         run: ./scripts/ios-binaries-check.sh simplye
         env:

--- a/README.md
+++ b/README.md
@@ -68,23 +68,22 @@ The Xcode project contains 2 additional targets beside the main one referenced e
 
 This codebase follows Google's [Swift](https://google.github.io/swift/) and [Objective-C](https://google.github.io/styleguide/objcguide.xml) style guides, including the use of two-space indentation. More details are available in [our wiki](https://github.com/NYPL-Simplified/Simplified/wiki/Mobile-client-applications#code-style-1).
 
-The primary services/singletons within the program are as follows:
-
-* `AccountsManager`
-* `NYPLUserAccount`
-* `NYPLBookRegistry`
-* `NYPLMyBooksDownloadCenter`
-* `NYPLSettings`
-* `NYPLKeychain`
-
-Most of the above contain appropriate documentation in the header files.
-
-The rest of the program follows Apple's usual pattern of passive views,
+Most of the code follows Apple's usual pattern of passive views,
 relatively passive models, and one-off controllers for integrating everything.
 Immutability is preferred wherever possible.
 
 Questions, suggestions, and general discussion occurs via Slack: Email
 `swans062@umn.edu` for access.
+
+## Branching and CI
+
+`develop` is the main development branch.
+
+Release branch names follow the convention: `release/<appname>/<version>`. For example, `release/simplye/3.7.0`.
+
+Feature branch names (for feature whose development is a month or more): `feature/<feature-name>`, e.g. `feature/readium2`.
+
+Continuous integration is enabled on push events on `develop`, release and feature branches, archiving and uploading a device build of SimplyE to [iOS-binaries](https://github.com/NYPL-Simplified/iOS-binaries). Commits on release branches also send the same build to TestFlight.
 
 # License
 

--- a/scripts/ios-binaries-check.sh
+++ b/scripts/ios-binaries-check.sh
@@ -25,7 +25,7 @@ if [ "$CURL_RESULT" == 200 ]; then
   echo "Build ${BUILD_NAME} already exists in iOS-binaries"
   exit 1
 else if [ "$CURL_RESULT" != 404 ]; then
-  echo "Obtained unexpected result from iOS-binaries for file named \"${ARCHIVE_NAME}.ipa\""
+  echo "Obtained unexpected result [$CURL_RESULT] from iOS-binaries for file named \"${ARCHIVE_NAME}.ipa\""
   exit 1
 fi
 

--- a/scripts/ios-binaries-check.sh
+++ b/scripts/ios-binaries-check.sh
@@ -17,29 +17,15 @@
 
 source "$(dirname $0)/xcode-settings.sh"
 
-echo "Checking if $ARCHIVE_NAME already exists on 'iOS-binaries' repo..."
+echo "Checking if $ARCHIVE_NAME.ipa already exists on 'iOS-binaries' repo..."
 
-# In a GitHub Actions CI context we can't clone a repo as a sibling
-if [ "$BUILD_CONTEXT" != "ci" ]; then
-  cd ..
-fi
+CURL_RESULT=`curl -I -s -o /dev/null -w "%{http_code}"  https://github.com/NYPL-Simplified/iOS-binaries/blob/master/$ARCHIVE_NAME.ipa`
 
-if [[ -d "iOS-binaries" ]]; then
-  echo "iOS-binaries repo appears to be cloned already..."
-  IOS_BINARIES_DIR_NAME=iOS-binaries
-elif [[ -d "NYPL-iOS-binaries" ]]; then
-  echo "iOS-binaries repo appears to be cloned already..."
-  IOS_BINARIES_DIR_NAME=NYPL-iOS-binaries
-else
-  IOS_BINARIES_DIR_NAME=iOS-binaries
-  git clone https://${GITHUB_TOKEN}@github.com/NYPL-Simplified/iOS-binaries.git
-fi
-
-IOS_BINARIES_DIR_PATH="$PWD/$IOS_BINARIES_DIR_NAME"
-
-FOUND_BUILD=`find "$IOS_BINARIES_DIR_PATH" -name ${BUILD_NAME}*`
-if [ "$FOUND_BUILD" != "" ]; then
+if [ "$CURL_RESULT" == 200 ]; then
   echo "Build ${BUILD_NAME} already exists in iOS-binaries"
+  exit 1
+else if [ "$CURL_RESULT" != 404 ]; then
+  echo "Obtained unexpected result from iOS-binaries for file named \"${ARCHIVE_NAME}.ipa\""
   exit 1
 fi
 


### PR DESCRIPTION
**What's this do?**
Avoids checking out the entire iOS-binaries repo to just check the build number, and enables CI on feature branches.

**Why are we doing this? (w/ JIRA link if applicable)**
better CI

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
yes

**Did you bump the SimplyE build number?**
n/a

**Did someone actually run this code to verify it works?**
@ettore 