### PR TITLE
SIMPLY-3462 Upload build to firebase

### DIFF
--- a/.github/workflows/archive-and-upload.yml
+++ b/.github/workflows/archive-and-upload.yml
@@ -7,6 +7,10 @@ jobs:
     steps:
       - name: Force Xcode 11.5
         run: sudo xcode-select -switch /Applications/Xcode_11.5.app
+      - name: Install Firebase Tools
+        run: npm install -g firebase-tools
+      - name: Check Firebase Tools
+        run: command -v firebase && firebase --version
       - name: Checkout main repo and submodules
         uses: actions/checkout@v2.3.4
         with:
@@ -74,6 +78,11 @@ jobs:
         run: ./scripts/xcode-export-appstore.sh simplye
         env:
           BUILD_CONTEXT: ci
+      - name: Upload to Firebase
+        run: ./scripts/firebase-upload.sh simplye
+        env:
+          BUILD_CONTEXT: ci
+          GITHUB_TOKEN: ${{ secrets.IOS_DEV_CI_PAT }}
       - name: Upload to TestFlight
         if: startsWith(github.ref, 'refs/heads/release/')
         run: ./scripts/testflight-upload.sh simplye

--- a/.github/workflows/check-build-number.yml
+++ b/.github/workflows/check-build-number.yml
@@ -1,4 +1,4 @@
-name: Check Build Number
+name: Check SimplyE Build Number
 on:
   push:
     branches:

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1550,7 +1550,7 @@
 		735771AA2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLLibraryAccountsProviderMock.swift; sourceTree = "<group>"; };
 		735771AD2537687D00067CEA /* NYPLURLSettingsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLURLSettingsProviderMock.swift; sourceTree = "<group>"; };
 		735771B02537691800067CEA /* NYPLDRMAuthorizingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLDRMAuthorizingMock.swift; sourceTree = "<group>"; };
-		7358A94B25898F4200E66D34 /* nypl-upload-symbols.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "nypl-upload-symbols.sh"; sourceTree = "<group>"; };
+		7358A94B25898F4200E66D34 /* firebase-upload-symbols.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "firebase-upload-symbols.sh"; sourceTree = "<group>"; };
 		7358A951258997A900E66D34 /* xcode-test.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xcode-test.sh"; sourceTree = "<group>"; };
 		7358A9532589A70B00E66D34 /* decode-install-secrets.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "decode-install-secrets.sh"; sourceTree = "<group>"; };
 		7358EE7B250062BD00DDA0CC /* OEImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = OEImages.xcassets; sourceTree = "<group>"; };
@@ -1562,6 +1562,7 @@
 		735FED252427494900144C97 /* NYPLNetworkResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLNetworkResponder.swift; sourceTree = "<group>"; };
 		73609AD8245B53CB00F0E08B /* update-certificates.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = "update-certificates.sh"; path = "scripts/update-certificates.sh"; sourceTree = SOURCE_ROOT; };
 		7360D0D424BFCB9700C8AD16 /* NYPLUserFriendlyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserFriendlyError.swift; sourceTree = "<group>"; };
+		7364FC6025B7C5AB00B0A9FD /* firebase-upload.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "firebase-upload.sh"; sourceTree = "<group>"; };
 		73735306256828EA00FE1B7E /* OpenEBooks_OPDS2_Catalog_Feed-QA.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "OpenEBooks_OPDS2_Catalog_Feed-QA.json"; sourceTree = "<group>"; };
 		7375AE5925382AC900C85211 /* NYPLUserAccountMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserAccountMock.swift; sourceTree = "<group>"; };
 		737F4A522549D78100A3C34B /* NYPLBookCreationTestsObjc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NYPLBookCreationTestsObjc.m; sourceTree = "<group>"; };
@@ -2489,6 +2490,8 @@
 				733E3E05257ED49C00BEBA32 /* xcode-settings.sh */,
 				733E3E06257ED49C00BEBA32 /* ios-binaries-upload.sh */,
 				7312725C259A9AB00032D7B4 /* ios-binaries-check.sh */,
+				7364FC6025B7C5AB00B0A9FD /* firebase-upload.sh */,
+				7358A94B25898F4200E66D34 /* firebase-upload-symbols.sh */,
 				731272B1259CFB180032D7B4 /* testflight-upload.sh */,
 				73EB0B802582CD59006BC997 /* bootstrap-drm.sh */,
 				73EB0B812582CD59006BC997 /* setup-repo-drm.sh */,
@@ -2505,7 +2508,6 @@
 			children = (
 				73CEF8352526FE80006B2820 /* run */,
 				73CEF8362526FE80006B2820 /* upload-symbols */,
-				7358A94B25898F4200E66D34 /* nypl-upload-symbols.sh */,
 			);
 			path = firebase;
 			sourceTree = "<group>";

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -746,7 +746,7 @@ didCompleteWithError:(NSError *)error
             formattedMessage = [NSString stringWithFormat:NSLocalizedString(@"You have already checked out this loan. You may need to refresh your My Books list to download the title.",
                                                                             comment: @"When book is already checked out on patron's other device(s), they will get this message"), book.title];
             alert = [NYPLAlertUtils alertWithTitle:@"BorrowFailed" message:formattedMessage];
-          } if ([error[@"type"] isEqualToString:NYPLProblemDocument.TypeInvalidCredentials]) {
+          } else if ([error[@"type"] isEqualToString:NYPLProblemDocument.TypeInvalidCredentials]) {
             NYPLLOG(@"Invalid credentials problem when borrowing a book, present sign in VC");
             __weak __auto_type wSelf = self;
             [self.reauthenticator authenticateIfNeeded:NYPLUserAccount.sharedAccount

--- a/scripts/firebase-upload-symbols.sh
+++ b/scripts/firebase-upload-symbols.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
-#  nypl-upload-symbols.sh
-#  Created by Ettore Pasquini on 12/15/20.
-#  Copyright © 2020 NYPL Labs. All rights reserved.
-#
+
 # SUMMARY
 #   This script facilitates uploading dSYMs to Firebase for SimplyE and
 #   Open eBooks.
@@ -11,7 +8,7 @@
 #   Run this script from the root of Simplified-iOS repo. Note that both
 #   parameters are mandatory and must appear in this order:
 #
-#     ./scripts/firebase/nypl-upload-symbols.sh <app-name> <dSYMs-dir-path>
+#     ./scripts/firebase-upload-symbols.sh <app-name> <dSYMs-dir-path>
 #
 # PARAMETERS
 #   <app-name> : simplye | openebooks
@@ -20,6 +17,8 @@
 #       ~/Library/Developer/Xcode/Archives/<date>/<archive-name>.xcarchive/dSYMs
 
 set -eo pipefail
+
+echo "Uploading dSYMs for $1..."
 
 # lower case of app name param
 APPNAME=`echo "$1" | tr '[:upper:]' '[:lower:]'`
@@ -32,7 +31,7 @@ case $APPNAME in
     GOOGLE_PLIST_PATH="./OpenEbooks/GoogleService-Info.plist"
     ;;
   *)
-    echo "nypl-upload-symbols.sh: please specify a valid app. Possible values: simplye | openebooks"
+    echo "firebase-upload-symbols.sh: please specify a valid app. Possible values: simplye | openebooks"
     exit 1
     ;;
 esac

--- a/scripts/firebase-upload.sh
+++ b/scripts/firebase-upload.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# SUMMARY
+#   Uploads an exported .ipa for SimplyE or Open eBooks to Firebase.
+#
+# SYNOPSIS
+#   firebase-upload.sh <app_name>
+#
+# PARAMETERS
+#   See xcode-settings.sh for possible parameters.
+#
+# USAGE
+#   Run this script from the root of Simplified-iOS repo, e.g.:
+#
+#     ./scripts/firebase-upload simplye
+
+source "$(dirname $0)/xcode-settings.sh"
+
+echo "Uploading $ARCHIVE_NAME binary to Firebase..."
+
+if [ "$BUILD_CONTEXT" == "ci" ]; then
+  CERTIFICATES_PATH="./Certificates"
+else
+  CERTIFICATES_PATH="../Certificates"
+fi
+
+FIREBASE_TOKEN=$(head -n 1 "$CERTIFICATES_PATH/Firebase/token.txt") ||
+  fatal "could not read firebase token from Certificates repo"
+
+FIREBASE_APP_ID=`/usr/libexec/PlistBuddy -c "Print :GOOGLE_APP_ID" "$CERTIFICATES_PATH/$APP_NAME_FOLDER/iOS/GoogleService-Info.plist"`
+
+# find ipa
+if [[ -d "$APPSTORE_EXPORT_PATH" ]]; then
+  IPA_PATH="$APPSTORE_EXPORT_PATH/$APP_NAME.ipa"
+elif [[ -d "$ADHOC_EXPORT_PATH" ]]; then
+  IPA_PATH="$ADHOC_EXPORT_PATH/$APP_NAME.ipa"
+else
+  fatal "Unable to upload to firebase: No known exported builds exist!"
+fi
+
+# upload app binary
+echo "Using ipa at $IPA_PATH"
+firebase appdistribution:distribute \
+  --token "${FIREBASE_TOKEN}" \
+  --app "${FIREBASE_APP_ID}" \
+  "${IPA_PATH}"
+
+# upload symbols
+./scripts/firebase-upload-symbols.sh "$APPNAME_PARAM" "$DSYMS_PATH"


### PR DESCRIPTION
**What's this do?**
Uploads build and dSYMs to Firebase. 
Note that the build is not automatically sent to testers because we need to add release notes first. 
The 2nd commit is unrelated but fixes a oversight bug introduced long time ago.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3462

**How should this be tested? / Do these changes have associated tests?**
If the we are pushing to a release branch, we will upload to Firebase the App Store export instead of the adhoc. Otherwise, when pushing to develop or feature branch, we will upload the ad-hoc.

**Dependencies for merging? Releasing to production?**
no and no

**Does this include changes that require a new SimplyE build for QA?**
no

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 