### PR TITLE
Fix usage of R2 deprecated methods

### DIFF
--- a/Simplified/Reader2/Internal/DRMLibraryService.swift
+++ b/Simplified/Reader2/Internal/DRMLibraryService.swift
@@ -12,7 +12,6 @@ import R2Shared
 
 struct DRMFulfilledPublication {
   let localURL: URL
-  let downloadTask: URLSessionDownloadTask?
   let suggestedFilename: String
 }
 

--- a/Simplified/Reader2/Internal/R2+NYPLAdditions.swift
+++ b/Simplified/Reader2/Internal/R2+NYPLAdditions.swift
@@ -24,11 +24,10 @@ extension Publication {
   /// - Returns: The Link object matching the given ID, if it exists in the
   /// publication.
   func link(withIDref idref: String) -> Link? {
-    // The Publication stores all positions from the Epub in various
-    // collections of Link objects. For bookmarks, these are contained inside
+    // The Publication stores all bookmarks (and TOC; positions in general) in
     // the `readingOrder` list. Each `Link` stores its metadata in a
     // `properties` dictionary.
-    return link { $0.properties["id"] as? String == idref }
+    return readingOrder.first { $0.properties["id"] as? String == idref }
   }
 
   /// Derives the `idref` (often used in Readium 1) from a Readium 2 `href`.

--- a/Simplified/Reader2/LCP/LCPLibraryService.swift
+++ b/Simplified/Reader2/LCP/LCPLibraryService.swift
@@ -47,7 +47,6 @@ import ReadiumLCP
           .map {
             DRMFulfilledPublication(
               localURL: $0.localURL,
-              downloadTask: $0.downloadTask,
               suggestedFilename: $0.suggestedFilename
             )
         }

--- a/Simplified/Reader2/NYPLR2Owner.swift
+++ b/Simplified/Reader2/NYPLR2Owner.swift
@@ -18,8 +18,8 @@ import R2Streamer
 /// Base module delegate, that sub-modules' delegate can extend.
 /// Provides basic shared functionalities.
 protocol ModuleDelegate: AnyObject {
-    func presentAlert(_ title: String, message: String, from viewController: UIViewController)
-    func presentError(_ error: Error?, from viewController: UIViewController)
+  func presentAlert(_ title: String, message: String, from viewController: UIViewController)
+  func presentError(_ error: Error?, from viewController: UIViewController)
 }
 
 

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -54,10 +54,11 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       bookRegistryMock = NYPLBookRegistryMock()
       bookRegistryMock.addBook(book: fakeBook, state: .DownloadSuccessful)
       libraryAccountMock = NYPLLibraryAccountMock()
-      
+      let manifest = Manifest(metadata: Metadata(title: "fakeMetadata"))
+      let pub = Publication(manifest: manifest)
       bookmarkBusinessLogic = NYPLReaderBookmarksBusinessLogic(
         book: fakeBook,
-        r2Publication: Publication(metadata: Metadata(title: "fakeMetadata")),
+        r2Publication: pub,
         drmDeviceID: "fakeDeviceID",
         bookRegistryProvider: bookRegistryMock,
         currentLibraryAccountProvider: libraryAccountMock)


### PR DESCRIPTION
**What's this do?**
Some methods are now deprecated in R2, so this fixes those. 
In particular the `downloadTask` in DRMFulfilledPublication seemed unused so I removed, but let me know if that's not ok.

**Why are we doing this? (w/ JIRA link if applicable)**
trying to stay warning free.

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE build for QA?**
no

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 