### PR TITLE
Always upload ad-hoc builds to firebase

### DIFF
--- a/scripts/firebase-upload.sh
+++ b/scripts/firebase-upload.sh
@@ -30,12 +30,10 @@ FIREBASE_TOKEN=$(head -n 1 "$CERTIFICATES_PATH/Firebase/token.txt") ||
 FIREBASE_APP_ID=`/usr/libexec/PlistBuddy -c "Print :GOOGLE_APP_ID" "$CERTIFICATES_PATH/$APP_NAME_FOLDER/iOS/GoogleService-Info.plist"`
 
 # find ipa
-if [[ -d "$APPSTORE_EXPORT_PATH" ]]; then
-  IPA_PATH="$APPSTORE_EXPORT_PATH/$APP_NAME.ipa"
-elif [[ -d "$ADHOC_EXPORT_PATH" ]]; then
+if [[ -d "$ADHOC_EXPORT_PATH" ]]; then
   IPA_PATH="$ADHOC_EXPORT_PATH/$APP_NAME.ipa"
 else
-  fatal "Unable to upload to firebase: No known exported builds exist!"
+  fatal "Unable to upload to firebase: missing ad-hoc export!"
 fi
 
 # upload app binary


### PR DESCRIPTION
**What's this do?**
Fixes a CI error where the app-store exported build was uploaded to firebase, which is a problem because app-store builds are not directly installable. Ad-hoc should be used instead.

**Why are we doing this? (w/ JIRA link if applicable)**
without this release builds on firebase are useless.

**How should this be tested? / Do these changes have associated tests?**
trigger CI on a release branch

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE build for QA?**
no

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 