### PR TITLE
SIMPLY-3429 Fix a few R2 strings and remove obsolete ones

### DIFF
--- a/Simplified/Reader2/Internal/LibraryError.swift
+++ b/Simplified/Reader2/Internal/LibraryError.swift
@@ -21,9 +21,9 @@ enum LibraryError: LocalizedError {
   var errorDescription: String? {
     switch self {
     case .invalidBook:
-      return NSLocalizedString("The book you were trying to open is invalid", comment: "Error message used when trying to import a publication that is not valid")
+      return NSLocalizedString("The book you were trying to open is invalid.", comment: "Error message used when trying to import a publication that is not valid")
     case .openFailed(let error):
-      return String(format: NSLocalizedString("An error was encountered while trying to open this book", comment: "Error message used when a low-level error occured while opening a publication"), error.localizedDescription)
+      return String(format: NSLocalizedString("An error was encountered while trying to open this book.", comment: "Error message used when a low-level error occured while opening a publication"), error.localizedDescription)
     }
   }
   

--- a/Simplified/Reader2/NYPLR2Owner.swift
+++ b/Simplified/Reader2/NYPLR2Owner.swift
@@ -57,7 +57,7 @@ extension NYPLR2Owner: ModuleDelegate {
                     message: String,
                     from viewController: UIViewController) {
     let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-    let dismissButton = UIAlertAction(title: NSLocalizedString("ok_button", comment: "Alert button"), style: .cancel)
+    let dismissButton = UIAlertAction(title: NSLocalizedString("OK", comment: "Alert button"), style: .cancel)
     alert.addAction(dismissButton)
     viewController.present(alert, animated: true)
   }
@@ -65,7 +65,7 @@ extension NYPLR2Owner: ModuleDelegate {
   func presentError(_ error: Error?, from viewController: UIViewController) {
     guard let error = error else { return }
     presentAlert(
-      NSLocalizedString("error_title", comment: "Alert title for errors"),
+      NSLocalizedString("Error", comment: "Alert title for errors"),
       message: error.localizedDescription,
       from: viewController
     )

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -174,6 +174,13 @@
 "%@ through chapter" = "%@ through chapter";
 "There are no bookmarks for this book." = "There are no bookmarks for this book.";
 
+// Reader error messages (R2)
+"Content Protection Error" = "Content Protection Error";
+"The book you were trying to open is invalid." = "The book you were trying to open is invalid.";
+"An error was encountered while trying to open this book." = "An error was encountered while trying to open this book.";
+"The book you were trying to read is in an unsupported format." = "The book you were trying to read is in an unsupported format.";
+"The book you were trying to read is corrupted. Please try downloading it again." = "The book you were trying to read is corrupted. Please try downloading it again.";
+
 // NYPLSettings
 "The page could not load due to a connection error." = "The page could not load due to a connection error.";
 
@@ -248,25 +255,3 @@
 "Open eBooks provides free books to the children who need them the most.\n\nThe collection includes thousands of popular and award-winning titles as well as hundreds of public domain works." =
 "The Open eBooks app provides free books to the children who need them the most.\n\nThe collection includes thousands of popular and award-winning titles as well as hundreds of public domain works.\n\nChildren from low-income areas may qualify for access in several ways.";
 "You need to login to access the collection." = "You need to login to access the collection.";
-
-// LCPAuthenticationViewController localizable strings
-// Passphrase request screen
-"Passphrase Required" = "Passphrase Required";
-"Incorrect Passphrase" = "Incorrect Passphrase";
-"This publication is protected by Readium LCP." = "This publication is protected by Readium LCP.";
-"In order to open it, we need to know the passphrase required by:\n\n%@\n\nTo help you remember it, the following hint is available:" = "In order to open it, we need to know the passphrase required by:\n\n%@\n\nTo help you remember it, the following hint is available:";
-// Button to contact the support when entering the passphrase
-"Website" = "Website";
-"Phone" = "Phone";
-"Mail" = "Mail";
-"Support" = "Support";
-// Content protection error
-"Content Protection Error" = "Content Protection Error";
-
-// LibraryError messages
-"The book you were trying to open is invalid" = "The book you were trying to open is invalid";
-"An error was encountered while trying to open this book" = "An error was encountered while trying to open this book";
-
-// ReaderError messages
-"The book you were trying to read is in an unsupported format." = "The book you were trying to read is in an unsupported format.";
-"The book you were trying to read is corrupted. Please try downloading it again." = "The book you were trying to read is corrupted. Please try downloading it again.";

--- a/Simplified/it.lproj/Localizable.strings
+++ b/Simplified/it.lproj/Localizable.strings
@@ -169,8 +169,12 @@
 "%@ through chapter" = "%@ del capitolo";
 "There are no bookmarks for this book." = "Non ci sono segnalibri per questo libro.";
 
-// Settings
-"SettingsConnectionFailureMessage" = "Non è stato possibile caricare la pagina per via di un errore nella connessione a internet.";
+// Reader error messages (R2)
+"Content Protection Error" = "Errore nella protezione del contenuto";
+"The book you were trying to open is invalid." = "Il libro che stavi cercando di leggere è in un formato non valido.";
+"An error was encountered while trying to open this book." = "Si è verificato un errore durante l'apertura di questo libro.";
+"The book you were trying to read is in an unsupported format." = "Il libro che stavi cercando di aprire è in un formato non supportato.";
+"The book you were trying to read is corrupted. Please try downloading it again." = "Il libro che stavi cercando di leggere è danneggiato. Prova a scaricarlo di nuovo.";
 
 // NYPLSettings
 "The page could not load due to a connection error." = "Non è stato possibile caricare questa pagina per via di un problema nella connessione.";


### PR DESCRIPTION
**What's this do?**
Fixes a couple CP R2 localization strings and removed the ones related to the LCP passphrase screen which we no longer have.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3429

**How should this be tested? / Do these changes have associated tests?**
When there's an error in the R2 reader, these strings will be presented for invalid books, open failures, unsupported format, corrupted book, DRM errors.

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE build for QA?**
not really-- these changes are trivial, and we can wait for the next build

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ettore 