### PR TITLE
Change branch reference for r2-navigator

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -11,4 +11,4 @@ github "zxingify/zxingify-objc" ~> 3.6
 github "NYPL-Simplified/r2-lcp-swift" "develop"
 github "NYPL-Simplified/r2-shared-swift" "develop"
 github "NYPL-Simplified/r2-streamer-swift" "develop"
-github "NYPL-Simplified/r2-navigator-swift" "develop"
+github "NYPL-Simplified/r2-navigator-swift" "develop-before-CP"


### PR DESCRIPTION
**What's this do?**
In order to get the fixes for race conditions when restoring the reading progress in [our fork of r2-navigator-swift](https://github.com/NYPL-Simplified/r2-navigator-swift), we will need to bring its `develop` branch up-to-date with upstream. However, that will break the current SimplyE build. To address this, I pushed a new [`develop-before-CP`](https://github.com/NYPL-Simplified/r2-navigator-swift/tree/develop-before-CP) branch on our fork that matches the same commit we currently use (`51a8dc1154fad6ad206bda00c8f3c4002cbada0d`). This way we can refer to that in the Cartfile (instead of `develop`) on the current SimplyE `develop` builds.

**Why are we doing this? (w/ JIRA link if applicable)**
There are effectively no changes in build behavior for SimplyE on `develop`. However, SimplyE on the `feature/content-protection` branch will need to use our fork of `r2-navigator-swift` because the fixes for race conditions are only available on top of `develop`, and to integrate that (1) further work is required, and (2) we'd be using potentially unstable code that hasn't even reached an official alpha stage from the readium team.

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE build for QA?**
no

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ettore 