### PR TITLE
SIMPLY-3578: Fixed crashes on iOS 14.5 beta when generating cover from book with non ASCII characters

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1631,6 +1631,13 @@
 			remoteGlobalIDString = A823D80C192BABA400B55DE2;
 			remoteInfo = SimplyE;
 		};
+		59D9CC1B25FFDE1B00C89B81 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1112A8191A322C53002B8CC1 /* TenPrintCover.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 59D9CBF525FFDBC500C89B81;
+			remoteInfo = TenPrintCoverTests;
+		};
 		5A569A2B1B8351C6003B5B61 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5A569A261B8351C6003B5B61 /* ADEPT.xcodeproj */;
@@ -2637,6 +2644,7 @@
 			isa = PBXGroup;
 			children = (
 				1112A81F1A322C53002B8CC1 /* libTenPrintCover.a */,
+				59D9CC1C25FFDE1B00C89B81 /* TenPrintCoverTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3899,6 +3907,13 @@
 			fileType = archive.ar;
 			path = libTenPrintCover.a;
 			remoteRef = 1112A81E1A322C53002B8CC1 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		59D9CC1C25FFDE1B00C89B81 /* TenPrintCoverTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = TenPrintCoverTests.xctest;
+			remoteRef = 59D9CC1B25FFDE1B00C89B81 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		5A569A2C1B8351C6003B5B61 /* libADEPT.a */ = {

--- a/Simplified.xcodeproj/xcshareddata/xcschemes/Open eBooks.xcscheme
+++ b/Simplified.xcodeproj/xcshareddata/xcschemes/Open eBooks.xcscheme
@@ -75,6 +75,16 @@
                </Test>
             </SkippedTests>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "59D9CBF425FFDBC500C89B81"
+               BuildableName = "TenPrintCoverTests.xctest"
+               BlueprintName = "TenPrintCoverTests"
+               ReferencedContainer = "container:tenprintcover-ios/TenPrintCover.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Simplified.xcodeproj/xcshareddata/xcschemes/SimplyE.xcscheme
+++ b/Simplified.xcodeproj/xcshareddata/xcschemes/SimplyE.xcscheme
@@ -71,6 +71,17 @@
                ReferencedContainer = "container:Simplified.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "59D9CBF425FFDBC500C89B81"
+               BuildableName = "TenPrintCoverTests.xctest"
+               BlueprintName = "TenPrintCoverTests"
+               ReferencedContainer = "container:tenprintcover-ios/TenPrintCover.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
**What's this do?**
Fixes crashes on iOS 14.5 beta when generating cover from book with non ASCII characters

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3578

**How should this be tested? / Do these changes have associated tests?**
The original crash was found on iOS devices running iOS 14.5 beta while displaying books with no covers that have accented letters in their title (https://cdncms.fonts.net/images/de7722aa7a6beee0/D.Accents.jpg). To test the fix, try viewing such books in the list on a device running iOS 14.5 beta. The app should not crash while viewing those books.

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE build for QA?**
Yes

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
Raman Singh tested on iOS 14.5 beta and iOS 13.7