### PR TITLE
Fix R2dev build and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For working on integrating R2 into SimplyE, first clone the following frameworks
 cd Simplified-iOS/..
 git clone https://github.com/readium/r2-shared-swift
 git clone https://github.com/readium/r2-streamer-swift
-git clone https://github.com/readium/r2-navigator-swift
+git clone https://github.com/NYPL-Simplified/r2-navigator-swift
 git clone https://github.com/readium/r2-lcp-swift
 ```
 Then rebuild the dependencies:

--- a/scripts/build-carthage-R2-integration.sh
+++ b/scripts/build-carthage-R2-integration.sh
@@ -47,7 +47,7 @@ carthage build --platform iOS
 
 echo "Building r2-navigator-swift Carthage dependencies..."
 cd ../r2-navigator-swift
-git checkout 2.0.0-beta.1
+git checkout 2.0.0-beta.1.nypl
 rm -rf Carthage
 carthage checkout
 carthage build --platform iOS
@@ -57,7 +57,9 @@ cd ../Simplified-iOS
 
 # remove R2 dependencies from Carthage since we'll build them in the R2 workspace
 sed -i '' "s|github \"readium/r2|#github \"readium/r2|" Cartfile
+sed -i '' "s|github \"NYPL-Simplified/r2|#github \"NYPL-Simplified/r2|" Cartfile
 sed -i '' "s|github \"readium/r2.*||" Cartfile.resolved
+sed -i '' "s|github \"NYPL-Simplified/r2.*||" Cartfile.resolved
 
 carthage checkout
 ./Carthage/Checkouts/NYPLAEToolkit/scripts/fetch-audioengine.sh


### PR DESCRIPTION
**What's this do?**
This is fixing the build with the R2dev target.

**Why are we doing this? (w/ JIRA link if applicable)**
I recently broke the local build of R2 for development. 

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
need to do this before merging CP to develop

**Does this include changes that require a new SimplyE build for QA?**
not needed

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 