### PR TITLE
SIMPLY-3511: Use Network Executor for reporting errors with a book

### DIFF
--- a/Simplified/NYPLBookDetailViewController.m
+++ b/Simplified/NYPLBookDetailViewController.m
@@ -19,6 +19,7 @@
 
 @property (nonatomic) NYPLBook *book;
 @property (nonatomic) NYPLBookDetailView *bookDetailView;
+@property (nonatomic) NYPLNetworkExecutor *executor;
 
 -(void)didCacheProblemDocument;
 
@@ -36,6 +37,11 @@
   }
 
   self.book = book;
+    
+  self.executor = [[NYPLNetworkExecutor alloc]
+                   initWithCredentialsProvider:nil
+                   cachingStrategy:NYPLCachingStrategyEphemeral
+                   delegateQueue:nil];
 
   self.title = book.title;
   UILabel *label = [[UILabel alloc] init];
@@ -193,8 +199,11 @@
 {
   NSURL *reportURL = problemReportViewController.book.reportURL;
   if (reportURL) {
-    NSURLRequest *r = [NSURLRequest postRequestWithProblemDocument:@{@"type":type} url:reportURL];
-    [[NYPLSession sharedSession] uploadWithRequest:r completionHandler:nil];
+    NSURLRequest *request = [NSURLRequest
+                             postRequestWithProblemDocument:@{@"type":type}
+                             url:reportURL];
+    
+    [self.executor POST:request completion:nil];
   }
   if (problemReportViewController.navigationController) {
     [problemReportViewController.navigationController popViewControllerAnimated:YES];

--- a/Simplified/Network/NYPLCaching.swift
+++ b/Simplified/Network/NYPLCaching.swift
@@ -181,7 +181,7 @@ extension HTTPURLResponse {
 /// responses even when these would not be cached by URLSession despite having a
 /// sufficient set of caching headers per https://tools.ietf.org/html/rfc7234 --
 /// see `HTTPURLResponse::modifyingCacheHeaders()`.
-enum NYPLCachingStrategy: NSInteger {
+@objc enum NYPLCachingStrategy: NSInteger {
   case ephemeral
   case `default`
   case fallback

--- a/Simplified/Network/NYPLNetworkExecutor.swift
+++ b/Simplified/Network/NYPLNetworkExecutor.swift
@@ -46,7 +46,7 @@ protocol NYPLRequestExecuting {
   /// - Parameter credentialsProvider: The object responsible with providing cretdentials
   /// - Parameter cachingStrategy: The strategy to cache responses with.
   /// - Parameter delegateQueue: The queue where callbacks will be called.
-  init(credentialsProvider: NYPLBasicAuthCredentialsProvider? = nil,
+  @objc init(credentialsProvider: NYPLBasicAuthCredentialsProvider? = nil,
        cachingStrategy: NYPLCachingStrategy,
        delegateQueue: OperationQueue? = nil) {
     self.responder = NYPLNetworkResponder(credentialsProvider: credentialsProvider,
@@ -219,4 +219,30 @@ extension NYPLNetworkExecutor {
     }
     return executeRequest(req, completion: completionWrapper)
   }
+    
+  /// Performs a POST request using the specified request
+  /// - Parameters:
+  ///   - request: Request to be posted..
+  ///   - completion: Always called when the api call either returns or times out
+  @discardableResult
+  @objc
+  func POST(_ request: URLRequest,
+            completion: ((_ result: Data?, _ response: URLResponse?,  _ error: Error?) -> Void)?) -> URLSessionDataTask {
+      
+    if (request.httpMethod != "POST") {
+      var newRequest = request
+      newRequest.httpMethod = "POST"
+      return POST(newRequest, completion: completion)
+    }
+      
+    let completionWrapper: (_ result: NYPLResult<Data>) -> Void = { result in
+      switch result {
+        case let .success(data, response): completion?(data, response, nil)
+        case let .failure(error, response): completion?(nil, response, error)
+      }
+    }
+    
+    return executeRequest(request, completion: completionWrapper)
+    }
+    
 }


### PR DESCRIPTION
**What's this do?**
Uses Network Executor for reporting errors with a book

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3511

**How should this be tested? / Do these changes have associated tests?**
Cannot be QA tested

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE build for QA?**
No

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
Raman Singh verified it