### PR TITLE
SIMPLY-3618 Show spinner when tapping Read button

### DIFF
--- a/.github/workflows/check-build-number.yml
+++ b/.github/workflows/check-build-number.yml
@@ -1,4 +1,4 @@
-name: Check SimplyE Build Number
+name: Check Build Number
 on:
   push:
     branches:

--- a/Simplified/AppInfrastructure/NSNotification+NYPL.swift
+++ b/Simplified/AppInfrastructure/NSNotification+NYPL.swift
@@ -20,7 +20,14 @@ extension Notification.Name {
   static let NYPLIsSigningIn = Notification.Name("NYPLIsSigningIn")
   static let NYPLAppDelegateDidReceiveCleverRedirectURL = Notification.Name("NYPLAppDelegateDidReceiveCleverRedirectURL")
   static let NYPLBookRegistryDidChange = Notification.Name("NYPLBookRegistryDidChange")
+
+  /// The `userInfo` dictionary contains the following key-value pairs:
+  /// - an `bookProcessingBookIDKey` key whose value is a String indicating
+  /// the book identifier;
+  /// - a `bookProcessingValueKey` key whose value is a Bool indicating
+  /// if there's some processing going on for the book.
   static let NYPLBookProcessingDidChange = Notification.Name("NYPLBookProcessingDidChange")
+
   static let NYPLMyBooksDownloadCenterDidChange = Notification.Name("NYPLMyBooksDownloadCenterDidChange")
   static let NYPLBookDetailDidClose = Notification.Name("NYPLBookDetailDidClose")
 }
@@ -40,4 +47,9 @@ extension Notification.Name {
   public static let NYPLBookProcessingDidChange = Notification.Name.NYPLBookProcessingDidChange
   public static let NYPLMyBooksDownloadCenterDidChange = Notification.Name.NYPLMyBooksDownloadCenterDidChange
   public static let NYPLBookDetailDidClose = Notification.Name.NYPLBookDetailDidClose
+}
+
+class NYPLNotificationKeys: NSObject {
+  @objc public static let bookProcessingBookIDKey = "identifier"
+  @objc public static let bookProcessingValueKey = "value"
 }

--- a/Simplified/NYPLBookButtonsView.h
+++ b/Simplified/NYPLBookButtonsView.h
@@ -9,7 +9,7 @@ typedef NS_ENUM(NSInteger, NYPLBookButtonsState) {
   NYPLBookButtonsStateCanBorrow,
   NYPLBookButtonsStateCanHold,
   NYPLBookButtonsStateHolding,
-  NYPLBookButtonsStateHoldingFOQ, // Front Of Queue
+  NYPLBookButtonsStateHoldingFOQ, //Front Of Queue: a book that was Reserved and now it's Ready for borrow
   NYPLBookButtonsStateDownloadNeeded,
   NYPLBookButtonsStateDownloadSuccessful,
   NYPLBookButtonsStateUsed,

--- a/Simplified/NYPLBookButtonsView.m
+++ b/Simplified/NYPLBookButtonsView.m
@@ -281,6 +281,7 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
 
     button.type = NYPLRoundedButtonTypeNormal;
     if ([buttonInfo[AddIndicatorKey] isEqualToValue:@(YES)]) {
+      // TODO: SIMPLY-3621 integrate this logic in NYPLBookDetailButtonsView
       [self.book.defaultAcquisition.availability
        matchUnavailable:nil
        limited:^(NYPLOPDSAcquisitionAvailabilityLimited *const _Nonnull limited) {

--- a/Simplified/NYPLBookButtonsView.m
+++ b/Simplified/NYPLBookButtonsView.m
@@ -77,18 +77,20 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
   [self addSubview:self.readButton];
   
   self.activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+  self.activityIndicator.color = [NYPLConfiguration mainColor];
   self.activityIndicator.hidesWhenStopped = YES;
   [self addSubview:self.activityIndicator];
   
   self.observer = [[NSNotificationCenter defaultCenter]
-   addObserverForName:NSNotification.NYPLBookProcessingDidChange
-   object:nil
-   queue:[NSOperationQueue mainQueue]
-   usingBlock:^(NSNotification *note) {
-     if([note.userInfo[@"identifier"] isEqualToString:self.book.identifier]) {
-       [self updateProcessingState];
-     }
-   }];
+                   addObserverForName:NSNotification.NYPLBookProcessingDidChange
+                   object:nil
+                   queue:[NSOperationQueue mainQueue]
+                   usingBlock:^(NSNotification *note) {
+    if ([note.userInfo[NYPLNotificationKeys.bookProcessingBookIDKey] isEqualToString:self.book.identifier]) {
+      BOOL isProcessing = [note.userInfo[NYPLNotificationKeys.bookProcessingValueKey] boolValue];
+      [self updateProcessingState:isProcessing];
+    }
+  }];
   
   return self;
 }
@@ -113,8 +115,6 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
     lastButton = button;
     button.frame = frame;
   }
-  self.activityIndicator.center = CGPointMake(CGRectGetMaxX(lastButton.frame) + 5 + self.activityIndicator.frame.size.width / 2,
-                                              lastButton.center.y);
 }
 
 - (void)sizeToFit
@@ -125,16 +125,15 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
   self.frame = frame;
 }
 
-- (void)updateProcessingState
+- (void)updateProcessingState:(BOOL)isCurrentlyProcessing
 {
-  BOOL state = [[NYPLBookRegistry sharedRegistry] processingForIdentifier:self.book.identifier];
-  if(state) {
+  if (isCurrentlyProcessing) {
     [self.activityIndicator startAnimating];
   } else {
     [self.activityIndicator stopAnimating];
   }
   for(NYPLRoundedButton *button in @[self.downloadButton, self.deleteButton, self.readButton]) {
-    button.enabled = !state;
+    button.enabled = !isCurrentlyProcessing;
   }
 }
 
@@ -193,7 +192,6 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
                               @{ButtonKey: self.deleteButton,
                                 TitleKey: title,
                                 HintKey: hint}];
-
       }
       break;
     }
@@ -205,16 +203,16 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
       switch (self.book.defaultBookContentType) {
         case NYPLBookContentTypeAudiobook:
           buttonInfo = @{ButtonKey: self.readButton,
-                        TitleKey: NSLocalizedString(@"Listen", nil),
-                        HintKey: [NSString stringWithFormat:NSLocalizedString(@"Opens audiobook %@ for listening", nil), self.book.title],
-                        AddIndicatorKey: @(YES)};
+                         TitleKey: NSLocalizedString(@"Listen", nil),
+                         HintKey: [NSString stringWithFormat:NSLocalizedString(@"Opens audiobook %@ for listening", nil), self.book.title],
+                         AddIndicatorKey: @(YES)};
           break;
         case NYPLBookContentTypePDF:
         case NYPLBookContentTypeEPUB:
           buttonInfo = @{ButtonKey: self.readButton,
-                        TitleKey: NSLocalizedString(@"Read", nil),
-                        HintKey: [NSString stringWithFormat:NSLocalizedString(@"Opens %@ for reading", nil), self.book.title],
-                        AddIndicatorKey: @(YES)};
+                         TitleKey: NSLocalizedString(@"Read", nil),
+                         HintKey: [NSString stringWithFormat:NSLocalizedString(@"Opens %@ for reading", nil), self.book.title],
+                         AddIndicatorKey: @(YES)};
           break;
         case NYPLBookContentTypeUnsupported:
           @throw NSInternalInconsistencyException;
@@ -232,17 +230,16 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
                               @{ButtonKey: self.deleteButton,
                                 TitleKey: title,
                                 HintKey: hint}];
-
       }
       break;
     }
+    case NYPLBookButtonsStateDownloadInProgress:
+    case NYPLBookButtonsStateDownloadFailed:
+      break;
     case NYPLBookButtonsStateUnsupported:
       // The app should never show books it cannot support, but if it mistakenly does,
       // no actions will be available.
       visibleButtonInfo = @[];
-      break;
-    case NYPLBookButtonsStateDownloadInProgress:
-    case NYPLBookButtonsStateDownloadFailed:
       break;
   }
   
@@ -275,7 +272,7 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
     
     [button setTitle:buttonInfo[TitleKey] forState:UIControlStateNormal];
     [button setAccessibilityHint:buttonInfo[HintKey]];
-    
+
     // We need to lay things out here else animations will be back on before it happens.
     [button layoutIfNeeded];
     
@@ -312,7 +309,10 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
 {
   _book = book;
   [self updateButtons];
-  [self updateProcessingState];
+
+  BOOL isCurrentlyProcessing = [[NYPLBookRegistry sharedRegistry]
+                                processingForIdentifier:self.book.identifier];
+  [self updateProcessingState:isCurrentlyProcessing];
 }
 
 - (void)setState:(NYPLBookButtonsState const)state
@@ -325,6 +325,8 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
 
 - (void)didSelectReturn
 {
+  self.activityIndicator.center = self.deleteButton.center;
+
   NSString *title = nil;
   NSString *message = nil;
   NSString *confirmButtonTitle = nil;
@@ -378,16 +380,17 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
 
 - (void)didSelectRead
 {
+  self.activityIndicator.center = self.readButton.center;
+  [self updateProcessingState:YES];
   [self.delegate didSelectReadForBook:self.book];
 }
 
 - (void)didSelectDownload
 {
-  if (@available (iOS 10.0, *)) {
-    if (self.state == NYPLBookButtonsStateCanHold) {
-      [NYPLUserNotifications requestAuthorization];
-    }
+  if (self.state == NYPLBookButtonsStateCanHold) {
+    [NYPLUserNotifications requestAuthorization];
   }
+  self.activityIndicator.center = self.downloadButton.center;
   [self.delegate didSelectDownloadForBook:self.book];
 }
 

--- a/Simplified/NYPLBookButtonsView.m
+++ b/Simplified/NYPLBookButtonsView.m
@@ -284,14 +284,19 @@ NYPLBookButtonsViewStateWithAvailability(id<NYPLOPDSAcquisitionAvailability> con
       [self.book.defaultAcquisition.availability
        matchUnavailable:nil
        limited:^(NYPLOPDSAcquisitionAvailabilityLimited *const _Nonnull limited) {
-         if (limited.until && [limited.until timeIntervalSinceNow] > 0) {
+         if ([limited.until timeIntervalSinceNow] > 0) {
            button.type = NYPLRoundedButtonTypeClock;
            button.endDate = limited.until;
          }
        }
        unlimited:nil
        reserved:nil
-       ready:nil];
+       ready:^(NYPLOPDSAcquisitionAvailabilityReady *const _Nonnull limited) {
+        if ([limited.until timeIntervalSinceNow] > 0) {
+          button.type = NYPLRoundedButtonTypeClock;
+          button.endDate = limited.until;
+        }
+      }];
     }
 
     [visibleButtons addObject:button];

--- a/Simplified/NYPLBookDetailButtonsView.m
+++ b/Simplified/NYPLBookDetailButtonsView.m
@@ -15,9 +15,9 @@
 @property (nonatomic) NYPLRoundedButton *deleteButton;
 @property (nonatomic) NYPLRoundedButton *downloadButton;
 @property (nonatomic) NYPLRoundedButton *readButton;
-@property (nonatomic) NYPLRoundedButton *cancelButton;
+@property (nonatomic) NYPLRoundedButton *cancelButton;// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
 @property (nonatomic) NSArray *visibleButtons;
-@property (nonatomic) NSMutableArray *constraints;
+@property (nonatomic) NSMutableArray *constraints;// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
 @property (nonatomic) id observer;
 
 @end
@@ -34,28 +34,28 @@
   self.constraints = [[NSMutableArray alloc] init];
   
   self.deleteButton = [NYPLRoundedButton button];
-  self.deleteButton.fromDetailView = YES;
-  self.deleteButton.titleLabel.minimumScaleFactor = 0.8f;
+  self.deleteButton.fromDetailView = YES;// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
+  self.deleteButton.titleLabel.minimumScaleFactor = 0.8f;// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
   [self.deleteButton addTarget:self action:@selector(didSelectReturn) forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.deleteButton];
 
   self.downloadButton = [NYPLRoundedButton button];
-  self.downloadButton.fromDetailView = YES;
-  self.downloadButton.titleLabel.minimumScaleFactor = 0.8f;
+  self.downloadButton.fromDetailView = YES;// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
+  self.downloadButton.titleLabel.minimumScaleFactor = 0.8f;// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
   [self.downloadButton addTarget:self action:@selector(didSelectDownload) forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.downloadButton];
 
   self.readButton = [NYPLRoundedButton button];
-  self.readButton.fromDetailView = YES;
-  self.readButton.titleLabel.minimumScaleFactor = 0.8f;
+  self.readButton.fromDetailView = YES;// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
+  self.readButton.titleLabel.minimumScaleFactor = 0.8f;// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
   [self.readButton addTarget:self action:@selector(didSelectRead) forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.readButton];
   
-  self.cancelButton = [NYPLRoundedButton button];
-  self.cancelButton.fromDetailView = YES;
-  self.cancelButton.titleLabel.minimumScaleFactor = 0.8f;
-  [self.cancelButton addTarget:self action:@selector(didSelectCancel) forControlEvents:UIControlEventTouchUpInside];
-  [self addSubview:self.cancelButton];
+  self.cancelButton = [NYPLRoundedButton button];// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
+  self.cancelButton.fromDetailView = YES;// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
+  self.cancelButton.titleLabel.minimumScaleFactor = 0.8f;// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
+  [self.cancelButton addTarget:self action:@selector(didSelectCancel) forControlEvents:UIControlEventTouchUpInside];// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
+  [self addSubview:self.cancelButton];// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
   
   self.activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
   self.activityIndicator.color = [NYPLConfiguration mainColor];
@@ -216,7 +216,7 @@
       }
       break;
     }
-    case NYPLBookButtonsStateDownloadInProgress:
+    case NYPLBookButtonsStateDownloadInProgress:// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
     {
       if (self.showReturnButtonIfApplicable)
       {
@@ -227,7 +227,7 @@
       }
       break;
     }
-    case NYPLBookButtonsStateDownloadFailed:
+    case NYPLBookButtonsStateDownloadFailed:// TODO: SIMPLY-3621 difference with NYPLBookButtonsView
     {
       if (self.showReturnButtonIfApplicable)
       {
@@ -287,6 +287,7 @@
 
     // Provide End-Date for checked out loans
     if ([buttonInfo[AddIndicatorKey] isEqualToValue:@(YES)]) {
+      // TODO: SIMPLY-3621 difference with NYPLBookButtonsView
       if ([self.book.defaultAcquisition.availability.until timeIntervalSinceNow] > 0
           && self.state != NYPLBookButtonsStateHolding) {
         button.type = NYPLRoundedButtonTypeClock;

--- a/Simplified/NYPLBookDetailButtonsView.m
+++ b/Simplified/NYPLBookDetailButtonsView.m
@@ -253,7 +253,7 @@
   
   BOOL fulfillmentIdRequired = NO;
   NYPLBookState state = [[NYPLBookRegistry sharedRegistry] stateForIdentifier:self.book.identifier];
-  BOOL hasRevokeLink = (self.book.revokeURL && state && (state == NYPLBookStateDownloadSuccessful || state == NYPLBookStateUsed));
+  BOOL hasRevokeLink = (self.book.revokeURL && (state == NYPLBookStateDownloadSuccessful || state == NYPLBookStateUsed));
 
   #if defined(FEATURE_DRM_CONNECTOR)
   
@@ -287,7 +287,8 @@
 
     // Provide End-Date for checked out loans
     if ([buttonInfo[AddIndicatorKey] isEqualToValue:@(YES)]) {
-      if (self.book.defaultAcquisition.availability.until && [self.book.defaultAcquisition.availability.until timeIntervalSinceNow] > 0 && self.state != NYPLBookButtonsStateHolding) {
+      if ([self.book.defaultAcquisition.availability.until timeIntervalSinceNow] > 0
+          && self.state != NYPLBookButtonsStateHolding) {
         button.type = NYPLRoundedButtonTypeClock;
         button.endDate = self.book.defaultAcquisition.availability.until;
       } else {

--- a/Simplified/NYPLBookRegistry.m
+++ b/Simplified/NYPLBookRegistry.m
@@ -144,8 +144,8 @@ static NSString *const RecordsKey = @"records";
     [[NSNotificationCenter defaultCenter]
      postNotificationName:NSNotification.NYPLBookProcessingDidChange
      object:self
-     userInfo:@{@"identifier": identifier,
-                @"value": @(value)}];
+     userInfo:@{NYPLNotificationKeys.bookProcessingBookIDKey: identifier,
+                NYPLNotificationKeys.bookProcessingValueKey: @(value)}];
   }];
 }
 

--- a/Simplified/NYPLOPDSAcquisitionAvailability.h
+++ b/Simplified/NYPLOPDSAcquisitionAvailability.h
@@ -17,12 +17,12 @@ extern NYPLOPDSAcquisitionAvailabilityCopies const NYPLOPDSAcquisitionAvailabili
 /// @c YES for limited, unlimited, and ready states, else @c NO.
 @property (nonatomic, readonly) BOOL available;
 
-/// When this availability state began. Always @c nil unless @c Limited
-/// or @c Reserved.
+/// When this availability state began.
+/// See https://git.io/JmCQT for full semantics.
 @property (nonatomic, readonly, nullable) NSDate *since;
 
-/// When this availability state will end. Always @c nil unless @c Limited
-/// or @c Reserved.
+/// When this availability state will end.
+/// See https://git.io/JmCQT for full semantics.
 @property (nonatomic, readonly, nullable) NSDate *until;
 
 - (void)


### PR DESCRIPTION
**What's this do?**
Shows a spinning indicator in My Books or other book table view cells when the user taps on the Read button. This provides a visual indicator for the delay caused by syncing the reading position and opening R2.

While working on this I saw that NYPLBookButtonsView and NYPLBookDetailButtonsView share 90% of the code. I plan to refactor these in SIMPLY-3621 but here I highlighted the differences to make that more obvious.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3618
(https://jira.nypl.org/browse/SIMPLY-3621)

**How should this be tested? / Do these changes have associated tests?**
I will add steps in the ticket.

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE build for QA?**
No because there's a visual glitch in NYPLBookButtonsView that will be resolved by SIMPLY-3621.

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 