### PR TITLE
SIMPLY-3655 New bookmark format deserialization

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -380,11 +380,19 @@
 		733875652423E1B0000FEB67 /* NYPLNetworkExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733875642423E1B0000FEB67 /* NYPLNetworkExecutor.swift */; };
 		733875672423E540000FEB67 /* NYPLCaching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733875662423E540000FEB67 /* NYPLCaching.swift */; };
 		733DEC92241090C7008C74BC /* NYPLRootTabBarController+R2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733DEC91241090C7008C74BC /* NYPLRootTabBarController+R2.swift */; };
+		733ED6E42617DEAA00ED8C8C /* invalid-bookmark-6.json in Resources */ = {isa = PBXBuildFile; fileRef = 733ED6E22617DEA900ED8C8C /* invalid-bookmark-6.json */; };
+		733ED6E52617DEAA00ED8C8C /* invalid-bookmark-6.json in Resources */ = {isa = PBXBuildFile; fileRef = 733ED6E22617DEA900ED8C8C /* invalid-bookmark-6.json */; };
+		733ED6E62617DEAA00ED8C8C /* invalid-bookmark-5.json in Resources */ = {isa = PBXBuildFile; fileRef = 733ED6E32617DEAA00ED8C8C /* invalid-bookmark-5.json */; };
+		733ED6E72617DEAA00ED8C8C /* invalid-bookmark-5.json in Resources */ = {isa = PBXBuildFile; fileRef = 733ED6E32617DEAA00ED8C8C /* invalid-bookmark-5.json */; };
 		733FF9BE2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */; };
 		733FF9BF2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */; };
 		733FF9C02530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */; };
+		7340A8B626151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340A8B526151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift */; };
+		7340A8B726151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340A8B526151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift */; };
 		7340DA6224B7E45C00361387 /* URLResponse+NYPL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */; };
 		7340DA6824B7F27900361387 /* NYPLBook+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340DA6724B7F27900361387 /* NYPLBook+Logging.swift */; };
+		73418F2B2616AAF000583569 /* valid-bookmark-3.json in Resources */ = {isa = PBXBuildFile; fileRef = 73418F252616AAF000583569 /* valid-bookmark-3.json */; };
+		73418F2C2616AAF000583569 /* valid-bookmark-3.json in Resources */ = {isa = PBXBuildFile; fileRef = 73418F252616AAF000583569 /* valid-bookmark-3.json */; };
 		73422119252FE4950053DA9E /* NYPLAccountSignInViewController+OESelectAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73422116252FE4950053DA9E /* NYPLAccountSignInViewController+OESelectAuth.swift */; };
 		7342701E24DCB23000A4F605 /* NSError+NYPLAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732327B12478504500A041E6 /* NSError+NYPLAdditions.swift */; };
 		7342702324DCB24600A4F605 /* NYPLUserFriendlyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7360D0D424BFCB9700C8AD16 /* NYPLUserFriendlyError.swift */; };
@@ -2154,9 +2162,13 @@
 		733E3E0B257ED52500BEBA32 /* exportOptions-appstore.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "exportOptions-appstore.plist"; sourceTree = "<group>"; };
 		733E3E0C257ED5DF00BEBA32 /* exportOptions-appstore.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "exportOptions-appstore.plist"; sourceTree = "<group>"; };
 		733E3E0D257ED5E000BEBA32 /* exportOptions-adhoc.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "exportOptions-adhoc.plist"; sourceTree = "<group>"; };
+		733ED6E22617DEA900ED8C8C /* invalid-bookmark-6.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "invalid-bookmark-6.json"; path = "Simplified-Bookmarks-Spec/invalid-bookmark-6.json"; sourceTree = SOURCE_ROOT; };
+		733ED6E32617DEAA00ED8C8C /* invalid-bookmark-5.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "invalid-bookmark-5.json"; path = "Simplified-Bookmarks-Spec/invalid-bookmark-5.json"; sourceTree = SOURCE_ROOT; };
 		733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+OAuth.swift"; sourceTree = "<group>"; };
+		7340A8B526151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NYPLBookmarkDecodingTests.swift; path = Bookmarks/NYPLBookmarkDecodingTests.swift; sourceTree = "<group>"; };
 		7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLResponse+NYPL.swift"; sourceTree = "<group>"; };
 		7340DA6724B7F27900361387 /* NYPLBook+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLBook+Logging.swift"; sourceTree = "<group>"; };
+		73418F252616AAF000583569 /* valid-bookmark-3.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "valid-bookmark-3.json"; path = "Simplified-Bookmarks-Spec/valid-bookmark-3.json"; sourceTree = SOURCE_ROOT; };
 		73422116252FE4950053DA9E /* NYPLAccountSignInViewController+OESelectAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLAccountSignInViewController+OESelectAuth.swift"; sourceTree = "<group>"; };
 		734731222514235900BE3D2C /* NYPLAppDelegate+SE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLAppDelegate+SE.swift"; sourceTree = "<group>"; };
 		734731252514236A00BE3D2C /* NYPLAppDelegate+OE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLAppDelegate+OE.swift"; sourceTree = "<group>"; };
@@ -2906,6 +2918,8 @@
 				730EF23B26093E3F008E1DC3 /* invalid-bookmark-2.json */,
 				730EF23A26093E3E008E1DC3 /* invalid-bookmark-3.json */,
 				730EF24026093E40008E1DC3 /* invalid-bookmark-4.json */,
+				733ED6E32617DEAA00ED8C8C /* invalid-bookmark-5.json */,
+				733ED6E22617DEA900ED8C8C /* invalid-bookmark-6.json */,
 				730EF23826093E3E008E1DC3 /* invalid-locator-1.json */,
 				730EF23926093E3E008E1DC3 /* invalid-locator-2.json */,
 				730EF23E26093E3F008E1DC3 /* invalid-locator-3.json */,
@@ -2913,8 +2927,10 @@
 				730EF25426093E53008E1DC3 /* valid-bookmark-0.json */,
 				730EF25526093E53008E1DC3 /* valid-bookmark-1.json */,
 				730EF25726093E53008E1DC3 /* valid-bookmark-2.json */,
+				73418F252616AAF000583569 /* valid-bookmark-3.json */,
 				730EF25626093E53008E1DC3 /* valid-locator-0.json */,
 				730EF25326093E52008E1DC3 /* valid-locator-1.json */,
+				7340A8B526151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift */,
 				730EF262260955EF008E1DC3 /* NYPLBookmarkSpecTests.swift */,
 			);
 			name = Bookmarks;
@@ -4116,6 +4132,7 @@
 				B51C1E18229456E2003B49A5 /* gpl_authentication_document.json in Resources */,
 				B51C1E19229456E2003B49A5 /* nypl_authentication_document.json in Resources */,
 				730EF24926093E40008E1DC3 /* invalid-bookmark-1.json in Resources */,
+				733ED6E42617DEAA00ED8C8C /* invalid-bookmark-6.json in Resources */,
 				730EF24126093E40008E1DC3 /* invalid-locator-1.json in Resources */,
 				B51C1E17229456E2003B49A5 /* acl_authentication_document.json in Resources */,
 				730EF24F26093E40008E1DC3 /* invalid-locator-4.json in Resources */,
@@ -4129,10 +4146,12 @@
 				730EF24526093E40008E1DC3 /* invalid-bookmark-3.json in Resources */,
 				219901F524FD2DE9001BC727 /* jwk.json in Resources */,
 				730EF25C26093E53008E1DC3 /* valid-bookmark-1.json in Resources */,
+				733ED6E62617DEAA00ED8C8C /* invalid-bookmark-5.json in Resources */,
 				730EF24326093E40008E1DC3 /* invalid-locator-2.json in Resources */,
 				B51C1DFC22860513003B49A5 /* OPDS2CatalogsFeed.json in Resources */,
 				2D2B47841D08F8E2007F7764 /* UpdateCheckUpToDate.json in Resources */,
 				730EF24B26093E40008E1DC3 /* invalid-bookmark-0.json in Resources */,
+				73418F2B2616AAF000583569 /* valid-bookmark-3.json in Resources */,
 				17BE24EF25FB114900AE707F /* simplye_authentication_document.json in Resources */,
 				732F4748260AD76E00E2CB64 /* NYPLOPDSAcquisitionPathEntry.xml in Resources */,
 				73A794C72549098700C59CC1 /* NYPLOPDSAcquisitionPathEntryMinimal.xml in Resources */,
@@ -4143,6 +4162,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				733ED6E52617DEAA00ED8C8C /* invalid-bookmark-6.json in Resources */,
 				7320AB3A251EBC9900E3F04D /* NYPLOPDSAcquisitionPathEntry.xml in Resources */,
 				732F4749260B1AEF00E2CB64 /* NYPLOPDSAcquisitionPathEntryMinimal.xml in Resources */,
 				730EF24C26093E40008E1DC3 /* invalid-bookmark-0.json in Resources */,
@@ -4159,7 +4179,9 @@
 				7320AB3F251EBC9900E3F04D /* jwk_public in Resources */,
 				730EF24826093E40008E1DC3 /* invalid-bookmark-2.json in Resources */,
 				7320AB40251EBC9900E3F04D /* dpl_authentication_document.json in Resources */,
+				73418F2C2616AAF000583569 /* valid-bookmark-3.json in Resources */,
 				7320AB41251EBC9900E3F04D /* UpdateCheckUnknown.json in Resources */,
+				733ED6E72617DEAA00ED8C8C /* invalid-bookmark-5.json in Resources */,
 				7320AB42251EBC9900E3F04D /* jwk.json in Resources */,
 				7320AB43251EBC9900E3F04D /* OPDS2CatalogsFeed.json in Resources */,
 				7320AB44251EBC9900E3F04D /* UpdateCheckUpToDate.json in Resources */,
@@ -4701,6 +4723,7 @@
 				735771A02537635600067CEA /* NYPLSignInBusinessLogicTests.swift in Sources */,
 				17BE24DA25F85D2300AE707F /* NYPLAgeCheckTests.swift in Sources */,
 				17BE24E025FABA0900AE707F /* NYPLAgeCheckChoiceStorageMock.swift in Sources */,
+				7340A8B626151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift in Sources */,
 				7375AE5A25382AC900C85211 /* NYPLUserAccountMock.swift in Sources */,
 				73C3CF5A25CB8D6100CA8166 /* NYPLNetworkExecutorMock.swift in Sources */,
 				735771AE2537687D00067CEA /* NYPLURLSettingsProviderMock.swift in Sources */,
@@ -4743,6 +4766,7 @@
 				730EF264260955EF008E1DC3 /* NYPLBookmarkSpecTests.swift in Sources */,
 				7375AE5B25382AC900C85211 /* NYPLUserAccountMock.swift in Sources */,
 				735771AF2537687D00067CEA /* NYPLURLSettingsProviderMock.swift in Sources */,
+				7340A8B726151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift in Sources */,
 				735771B22537691800067CEA /* NYPLDRMAuthorizingMock.swift in Sources */,
 				73A794BE2548E36100C59CC1 /* NYPLBookCreationTests.swift in Sources */,
 				735DD0CD2522A0730096D1F9 /* String+NYPLAdditionsTests.swift in Sources */,

--- a/Simplified/Reader2/Bookmarks/NYPLAnnotations+Deprecated.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLAnnotations+Deprecated.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// - Important: all these functions are deprecated. Do not use in new code.
 extension NYPLAnnotations {
-  /// Important: this is deprecated. Do not use in new code.
+  /// - Important: this is deprecated. Do not use in new code.
   class func postR1Bookmark(_ bookmark: NYPLReadiumBookmark,
                             forBookID bookID: String,
                             completion: @escaping (_ serverID: String?) -> ())

--- a/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
@@ -214,8 +214,8 @@ import R2Shared
 
   /// Reads the current reading position from the server, parses the response
   /// and returns the result to the `completionHandler`.
-  //TODO: SIMPLY-3655 Refactor with `getServerBookmarks(forBook:atURL:completion:)
   class func syncReadingPosition(ofBook bookID: String?, toURL url:URL?,
+  // TODO: SIMPLY-3668 Refactor with `syncReadingPosition(...)`
                                  completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ()) {
 
     guard syncIsPossibleAndPermitted() else {
@@ -525,7 +525,7 @@ import R2Shared
   class func postBookmark(_ bookmark: NYPLReadiumBookmark,
                           forBookID bookID: String,
                           completion: @escaping (_ serverID: String?) -> ()) {
-    // TODO: SIMPLY-3655 distinguish based on renderer (R1 / R2)
+    // TODO: SIMPLY-3645 distinguish based on renderer (R1 / R2)
     //                   or maybe just post R2 bookmarks?
     postR1Bookmark(bookmark, forBookID: bookID, completion: completion)
   }

--- a/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
@@ -68,7 +68,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
   /// - Parameter location: The Readium 2 location to be checked.
   /// - Returns: The bookmark at the given `location` if it exists,
   /// otherwise nil.
-  func isBookmarkExisting(at location: NYPLBookmarkR2Location?) -> NYPLReadiumBookmark? {
+  func bookmarkExisting(at location: NYPLBookmarkR2Location?) -> NYPLReadiumBookmark? {
     guard let currentLocator = location?.locator else {
       return nil
     }

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -227,7 +227,7 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
       return
     }
 
-    if let bookmark = bookmarksBusinessLogic.isBookmarkExisting(at: loc) {
+    if let bookmark = bookmarksBusinessLogic.bookmarkExisting(at: loc) {
       deleteBookmark(bookmark)
     } else {
       addBookmark(at: loc)
@@ -261,7 +261,7 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
     // in which case the bookmark icon will be lit up and should stay lit up.
     if
       let loc = bookmarksBusinessLogic.currentLocation(in: navigator),
-      bookmarksBusinessLogic.isBookmarkExisting(at: loc) == nil {
+      bookmarksBusinessLogic.bookmarkExisting(at: loc) == nil {
 
       updateBookmarkButton(withState: false)
     }
@@ -352,7 +352,7 @@ extension NYPLBaseReaderViewController: NavigatorDelegate {
     }()
     
     if let resourceIndex = publication.resourceIndex(forLocator: locator),
-      let _ = bookmarksBusinessLogic.isBookmarkExisting(at: NYPLBookmarkR2Location(resourceIndex: resourceIndex, locator: locator)) {
+      let _ = bookmarksBusinessLogic.bookmarkExisting(at: NYPLBookmarkR2Location(resourceIndex: resourceIndex, locator: locator)) {
       updateBookmarkButton(withState: true)
     } else {
       updateBookmarkButton(withState: false)

--- a/SimplifiedTests/Bookmarks/NYPLBookmarkDecodingTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLBookmarkDecodingTests.swift
@@ -1,0 +1,269 @@
+//
+//  NYPLBookmarkDecodingTests.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 3/31/21.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import XCTest
+@testable import SimplyE
+
+class NYPLBookmarkDecodingTests: XCTestCase {
+  var bundle: Bundle!
+
+  override func setUpWithError() throws {
+    bundle = Bundle(for: NYPLBookmarkSpecTests.self)
+  }
+
+  override func tearDownWithError() throws {
+    bundle = nil
+  }
+
+  // MARK:- Valid bookmarks tests
+
+  func testMakeBookmarkFromJSON() throws {
+    // preconditions: get expected values from manually reading from disk
+    let bookmarkURL = bundle.url(forResource: "valid-bookmark-3",
+                                 withExtension: "json")!
+    let bookmarkData = try Data(contentsOf: bookmarkURL)
+    let json = try JSONSerialization.jsonObject(with: bookmarkData) as! [String: Any]
+    let annotationID = json[NYPLBookmarkSpec.Id.key] as! String
+    let body = json[NYPLBookmarkSpec.Body.key] as! [String: Any]
+    let device = body[NYPLBookmarkSpec.Body.Device.key] as! String
+    let time = body[NYPLBookmarkSpec.Body.Time.key] as! String
+    let target = json[NYPLBookmarkSpec.Target.key] as! [String: Any]
+    let bookID = target[NYPLBookmarkSpec.Target.Source.key] as! String
+    let selector = target[NYPLBookmarkSpec.Target.Selector.key] as! [String: Any]
+    let locator = selector[NYPLBookmarkSpec.Target.Selector.Value.key] as! String
+
+    // test: make a bookmark with the data we manually read with the wrong book id
+    let wrong1 = NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                                          annotationType: .bookmark,
+                                          bookID: "ciccio")
+
+    // test: make a bookmark with the data we manually read
+    guard let madeBookmark =
+      NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                               annotationType: .bookmark,
+                               bookID: bookID) else {
+                                XCTFail("Failed to create bookmark from valid data")
+                                return
+    }
+    let madeLocatorData = madeBookmark.location.data(using: .utf8)!
+    let madeJSONObject: Any
+    do {
+      try madeJSONObject = JSONSerialization.jsonObject(with: madeLocatorData)
+    } catch {
+      XCTFail("Unable to convert created selector from created bookmark to JSON: \(error)")
+      return
+    }
+    guard let madeSelectorJSON = madeJSONObject as? [String: Any] else {
+      XCTFail("Cannot cast JSON object to [String: Any]")
+      return
+    }
+
+    // verify
+    XCTAssertNil(wrong1)
+    XCTAssertEqual(madeBookmark.annotationId, annotationID)
+    XCTAssertEqual(madeBookmark.location.trimmingCharacters(in: .whitespacesAndNewlines),
+                   locator.trimmingCharacters(in: .whitespacesAndNewlines))
+    XCTAssertEqual(madeBookmark.device, device)
+    XCTAssertEqual(madeBookmark.time, time)
+    let parsedType = madeSelectorJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey] as? String
+    let parsedChapterID = madeSelectorJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterIDKey] as? String
+    let parsedProgress = madeSelectorJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as? Float
+    XCTAssertEqual(parsedType, NYPLBookmarkSpec.Target.Selector.Value.locatorTypeValue)
+    XCTAssertEqual(parsedChapterID, "/xyz.html")
+    XCTAssertEqual(parsedProgress, 0.5)
+  }
+
+  func testMakeReadingProgressFromJSON() throws {
+    // preconditions: get expected values from manually reading from disk
+    let bookmarkURL = bundle.url(forResource: "valid-bookmark-0",
+                                 withExtension: "json")!
+    let bookmarkData = try Data(contentsOf: bookmarkURL)
+    let json = try JSONSerialization.jsonObject(with: bookmarkData) as! [String: Any]
+    let annotationID = json[NYPLBookmarkSpec.Id.key] as! String
+    let body = json[NYPLBookmarkSpec.Body.key] as! [String: Any]
+    let device = body[NYPLBookmarkSpec.Body.Device.key] as! String
+    let time = body[NYPLBookmarkSpec.Body.Time.key] as! String
+    let target = json[NYPLBookmarkSpec.Target.key] as! [String: Any]
+    let bookID = target[NYPLBookmarkSpec.Target.Source.key] as! String
+    let selector = target[NYPLBookmarkSpec.Target.Selector.key] as! [String: Any]
+    let locator = selector[NYPLBookmarkSpec.Target.Selector.Value.key] as! String
+
+    // test: make a bookmark with the data we manually read with the wrong book id
+    let wrong1 = NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                                          annotationType: .readingProgress,
+                                          bookID: "ciccio")
+
+    // test: make a bookmark with the data we manually read
+    guard let madeBookmark =
+      NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                               annotationType: .readingProgress,
+                               bookID: bookID) else {
+                                XCTFail("Failed to create bookmark from valid data")
+                                return
+    }
+    let madeLocatorData = madeBookmark.location.data(using: .utf8)!
+    let madeJSONObject: Any
+    do {
+      try madeJSONObject = JSONSerialization.jsonObject(with: madeLocatorData)
+    } catch {
+      XCTFail("Unable to convert created selector from created bookmark to JSON: \(error)")
+      return
+    }
+    guard let madeSelectorJSON = madeJSONObject as? [String: Any] else {
+      XCTFail("Cannot cast JSON object to [String: Any]")
+      return
+    }
+
+    // verify
+    XCTAssertNil(wrong1)
+    XCTAssertEqual(madeBookmark.annotationId, annotationID)
+    XCTAssertEqual(madeBookmark.location.trimmingCharacters(in: .whitespacesAndNewlines),
+                   locator.trimmingCharacters(in: .whitespacesAndNewlines))
+    XCTAssertEqual(madeBookmark.device, device)
+    XCTAssertEqual(madeBookmark.time, time)
+    let parsedType = madeSelectorJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey] as? String
+    let parsedChapterID = madeSelectorJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterIDKey] as? String
+    let parsedProgress = madeSelectorJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as? Float
+    XCTAssertEqual(parsedType, NYPLBookmarkSpec.Target.Selector.Value.locatorTypeValue)
+    XCTAssertEqual(parsedChapterID, "/xyz.html")
+    XCTAssertEqual(parsedProgress, 0.5)
+  }
+
+  // MARK:- Invalid bookmarks tests
+
+  func testInvalidNoBodyReadingProgressFromJSON() throws {
+    // preconditions: get expected values from manually reading from disk
+    let bookmarkURL = bundle.url(forResource: "invalid-bookmark-0",
+                                 withExtension: "json")!
+    let bookmarkData = try Data(contentsOf: bookmarkURL)
+    let json = try JSONSerialization.jsonObject(with: bookmarkData) as! [String: Any]
+    let target = json[NYPLBookmarkSpec.Target.key] as! [String: Any]
+    let bookID = target[NYPLBookmarkSpec.Target.Source.key] as! String
+    let motivation = json[NYPLBookmarkSpec.Motivation.key] as! String
+    XCTAssertEqual(motivation, NYPLBookmarkSpec.Motivation.readingProgress.rawValue)
+
+    // test: make a locator with the data we manually read
+    let bookmark = NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                                            annotationType: .readingProgress,
+                                            bookID: bookID)
+
+    // verify
+    XCTAssertNil(bookmark, "should not deserialize a Bookmark without a Body section")
+  }
+
+  func testInvalidNoMotivationBookmarkFromJSON() throws {
+    // preconditions: get expected values from manually reading from disk
+    let bookmarkURL = bundle.url(forResource: "invalid-bookmark-1",
+                                 withExtension: "json")!
+    let bookmarkData = try Data(contentsOf: bookmarkURL)
+    let json = try JSONSerialization.jsonObject(with: bookmarkData) as! [String: Any]
+    let target = json[NYPLBookmarkSpec.Target.key] as! [String: Any]
+    let bookID = target[NYPLBookmarkSpec.Target.Source.key] as! String
+
+    // test: make a locator with the data we manually read
+    let bookmark = NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                                            annotationType: .bookmark,
+                                            bookID: bookID)
+    let readingProgress = NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                                                   annotationType: .readingProgress,
+                                                   bookID: bookID)
+
+    // verify
+    XCTAssertNil(bookmark, "should not deserialize a Bookmark without a Motivation section")
+    XCTAssertNil(readingProgress, "should not deserialize a Reading Progress without a Motivation section")
+  }
+
+  func testInvalidNoTargetReadingProgressFromJSON() throws {
+    // preconditions: get expected values from manually reading from disk
+    let bookmarkURL = bundle.url(forResource: "invalid-bookmark-2",
+                                 withExtension: "json")!
+    let bookmarkData = try Data(contentsOf: bookmarkURL)
+    let json = try JSONSerialization.jsonObject(with: bookmarkData) as! [String: Any]
+    let target = json[NYPLBookmarkSpec.Target.key]
+    XCTAssertNil(target)
+    let motivation = json[NYPLBookmarkSpec.Motivation.key] as! String
+    XCTAssertEqual(motivation, NYPLBookmarkSpec.Motivation.readingProgress.rawValue)
+
+    // test: make a locator with the data we manually read
+    let readingProgress = NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                                                   annotationType: .readingProgress,
+                                                   bookID: "A book")
+
+    // verify
+    XCTAssertNil(readingProgress, "should not deserialize a Bookmark without a Target section")
+  }
+
+  func testInvalidNoSelectorValueReadingProgressFromJSON() throws {
+    // preconditions: get expected values from manually reading from disk
+    let bookmarkURL = bundle.url(forResource: "invalid-bookmark-4",
+                                 withExtension: "json")!
+    let bookmarkData = try Data(contentsOf: bookmarkURL)
+    let json = try JSONSerialization.jsonObject(with: bookmarkData) as! [String: Any]
+    let target = json[NYPLBookmarkSpec.Target.key] as! [String: Any]
+    let bookID = target[NYPLBookmarkSpec.Target.Source.key] as! String
+    let motivation = json[NYPLBookmarkSpec.Motivation.key] as! String
+    XCTAssertEqual(motivation, NYPLBookmarkSpec.Motivation.readingProgress.rawValue)
+    let selector = target[NYPLBookmarkSpec.Target.Selector.key] as! [String: Any]
+    let selectorValue = selector[NYPLBookmarkSpec.Target.Selector.Value.key] as? String
+    XCTAssertEqual(selectorValue?.trimmingCharacters(in: .whitespacesAndNewlines), "{\n [] }")
+
+    // test: make a locator with the data we manually read
+    let readingProgress = NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                                                   annotationType: .readingProgress,
+                                                   bookID: bookID)
+
+    // verify
+    XCTAssertNil(readingProgress, "should not deserialize a Bookmark without a Selector section")
+  }
+
+  func testInvalidNoDeviceReadingProgressFromJSON() throws {
+    // preconditions: get expected values from manually reading from disk
+    let bookmarkURL = bundle.url(forResource: "invalid-bookmark-5",
+                                 withExtension: "json")!
+    let bookmarkData = try Data(contentsOf: bookmarkURL)
+    let json = try JSONSerialization.jsonObject(with: bookmarkData) as! [String: Any]
+    let target = json[NYPLBookmarkSpec.Target.key] as! [String: Any]
+    let bookID = target[NYPLBookmarkSpec.Target.Source.key] as! String
+    let motivation = json[NYPLBookmarkSpec.Motivation.key] as! String
+    XCTAssertEqual(motivation, NYPLBookmarkSpec.Motivation.readingProgress.rawValue)
+    let body = json[NYPLBookmarkSpec.Body.key] as! [String: Any]
+    let device = body[NYPLBookmarkSpec.Body.Device.key]
+    XCTAssertNil(device)
+
+    // test: make a locator with the data we manually read
+    let bookmark = NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                                            annotationType: .readingProgress,
+                                            bookID: bookID)
+
+    // verify
+    XCTAssertNil(bookmark, "should not deserialize a Bookmark without a Body-device section")
+  }
+
+  func testInvalidNoBodyTimeReadingProgressFromJSON() throws {
+    // preconditions: get expected values from manually reading from disk
+    let bookmarkURL = bundle.url(forResource: "invalid-bookmark-6",
+                                 withExtension: "json")!
+    let bookmarkData = try Data(contentsOf: bookmarkURL)
+    let json = try JSONSerialization.jsonObject(with: bookmarkData) as! [String: Any]
+    let target = json[NYPLBookmarkSpec.Target.key] as! [String: Any]
+    let bookID = target[NYPLBookmarkSpec.Target.Source.key] as! String
+    let motivation = json[NYPLBookmarkSpec.Motivation.key] as! String
+    XCTAssertEqual(motivation, NYPLBookmarkSpec.Motivation.readingProgress.rawValue)
+    let body = json[NYPLBookmarkSpec.Body.key] as! [String: Any]
+    let time = body[NYPLBookmarkSpec.Body.Time.key]
+    XCTAssertNil(time)
+
+    // test: make a locator with the data we manually read
+    let bookmark = NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                                            annotationType: .readingProgress,
+                                            bookID: bookID)
+
+    // verify
+    XCTAssertNil(bookmark, "should not deserialize a Bookmark without a Body-time section")
+  }
+}

--- a/SimplifiedTests/Bookmarks/NYPLBookmarkSpecTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLBookmarkSpecTests.swift
@@ -9,13 +9,20 @@
 import XCTest
 @testable import SimplyE
 
-// TODO: SIMPLY-3645
+/**
+ things to test:
+  - SIMPLY-3645: bookmark creation from R2 locator (new format)
+  - SIMPLY-3645: bookmark post request body (new format)
+ */
 class NYPLBookmarkSpecTests: XCTestCase {
+  var bundle: Bundle!
 
   override func setUpWithError() throws {
+    bundle = Bundle(for: NYPLBookmarkSpecTests.self)
   }
 
   override func tearDownWithError() throws {
+    bundle = nil
   }
 
   func testBookmarkMotivationKeyword() throws {
@@ -24,4 +31,131 @@ class NYPLBookmarkSpecTests: XCTestCase {
         .contains(NYPLBookmarkSpec.Motivation.bookmarkingKeyword)
     )
   }
+
+  // MARK:- Locators
+
+  func testMakeLocatorFromJSON() throws {
+    // preconditions: get expected values from manually reading locator on disk
+    let locatorURL = bundle.url(forResource: "valid-locator-0", withExtension: "json")!
+    let locatorData = try Data(contentsOf: locatorURL)
+    let json = try JSONSerialization.jsonObject(with: locatorData) as! [String: Any]
+    let typeValue = json[NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey] as! String
+    let chapterID = json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterIDKey] as! String
+    let progress = json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as! Float
+
+    // test: make a locator, encode it to binary, parse binary back to JSON
+    guard let madeLocatorString = NYPLBookmarkFactory
+      .makeLocatorString(chapterHref: chapterID, chapterProgression: progress) else {
+        XCTFail("Unable to create locator")
+        return
+    }
+    let madeLocatorData = madeLocatorString.data(using: .utf8)!
+    let madeJSONObject: Any
+    do {
+      try madeJSONObject = JSONSerialization.jsonObject(with: madeLocatorData)
+    } catch {
+      XCTFail("Unable to convert created locator to JSON: \(error)")
+      return
+    }
+    guard let madeJSON = madeJSONObject as? [String: Any] else {
+      XCTFail("Cannot cast JSON object to [String: Any]")
+      return
+    }
+
+    // verify: parsing manually created locator should reveal same info of locator on disk
+    let parsedType = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey] as? String
+    let parsedChapterID = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterIDKey] as? String
+    let parsedProgress = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as? Float
+    XCTAssertNotNil(parsedType)
+    XCTAssertNotNil(parsedChapterID)
+    XCTAssertNotNil(parsedProgress)
+    XCTAssertFalse(parsedType!.isEmpty)
+    XCTAssertFalse(parsedChapterID!.isEmpty)
+    XCTAssertNotEqual(parsedProgress, 0.0)
+    XCTAssertEqual(parsedType, typeValue)
+    XCTAssertEqual(parsedChapterID, chapterID)
+    XCTAssertEqual(parsedProgress, progress)
+  }
+
+  func testMakeOldFormatLocatorFromJSON() throws {
+    // preconditions: get expected values from manually reading locator on disk
+    let locatorURL = bundle.url(forResource: "valid-locator-1", withExtension: "json")!
+    let locatorData = try Data(contentsOf: locatorURL)
+    let json = try JSONSerialization.jsonObject(with: locatorData) as! [String: Any]
+    let typeValue = json[NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey] as! String
+    let chapterID = json[NYPLBookmarkR1Key.idref.rawValue] as! String
+    let progress = json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as! Float
+    let cfi = json[NYPLBookmarkSpec.Target.Selector.Value.legacyLocatorCFIKey] as! String
+
+    // test: make a locator, encode it to binary, parse binary back to JSON
+    let madeLocatorString = NYPLBookmarkFactory
+      .makeLegacyLocatorString(idref: chapterID,
+                               chapterProgression: progress,
+                               cfi: cfi)
+    let madeLocatorData = madeLocatorString.data(using: .utf8)!
+    let madeJSONObj: Any
+    do {
+      try madeJSONObj = JSONSerialization.jsonObject(with: madeLocatorData)
+    } catch {
+      XCTFail("Unable to convert created locator to JSON: \(error)")
+      return
+    }
+    guard let madeJSON = madeJSONObj as? [String: Any] else {
+      XCTFail("Cannot cast JSON object to [String: Any]")
+      return
+    }
+
+    // verify: parsing manually created locator should reveal same info of locator on disk
+    let parsedType = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey] as? String
+    let parsedChapterID = madeJSON[NYPLBookmarkR1Key.idref.rawValue] as? String
+    let parsedProgress = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as? Float
+    let parsedCFI = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.legacyLocatorCFIKey] as? String
+    XCTAssertNotNil(parsedType)
+    XCTAssertNotNil(parsedChapterID)
+    XCTAssertNotNil(parsedProgress)
+    XCTAssertNotNil(parsedCFI)
+    XCTAssertFalse(parsedType!.isEmpty)
+    XCTAssertFalse(parsedChapterID!.isEmpty)
+    XCTAssertNotEqual(parsedProgress, 0.0)
+    XCTAssertFalse(parsedCFI!.isEmpty)
+    XCTAssertEqual(parsedType!, typeValue)
+    XCTAssertEqual(parsedChapterID!, chapterID)
+    XCTAssertEqual(parsedProgress!, progress)
+    XCTAssertEqual(parsedCFI!, cfi)
+  }
+
+  func testInvalidLocatorNegativeProgressFromJSON() throws {
+    // preconditions: get expected values from manually reading locator on disk
+    let locatorURL = bundle.url(forResource: "invalid-locator-3", withExtension: "json")!
+    let locatorData = try Data(contentsOf: locatorURL)
+    let json = try JSONSerialization.jsonObject(with: locatorData) as! [String: Any]
+    let chapterID = json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterIDKey] as! String
+    let progress = json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as! Float
+    XCTAssertLessThan(progress, 0.0)
+
+    // test
+    let madeLocatorString = NYPLBookmarkFactory
+      .makeLocatorString(chapterHref: chapterID, chapterProgression: progress)
+
+    // verify
+    XCTAssertNil(madeLocatorString)
+  }
+
+  func testInvalidLocatorTooBigProgressFromJSON() throws {
+    // preconditions: get expected values from manually reading locator on disk
+    let locatorURL = bundle.url(forResource: "invalid-locator-4", withExtension: "json")!
+    let locatorData = try Data(contentsOf: locatorURL)
+    let json = try JSONSerialization.jsonObject(with: locatorData) as! [String: Any]
+    let chapterID = json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterIDKey] as! String
+    let progress = json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as! Float
+    XCTAssertGreaterThan(progress, 1.0)
+
+    // test
+    let madeLocatorString = NYPLBookmarkFactory
+      .makeLocatorString(chapterHref: chapterID, chapterProgression: progress)
+
+    // verify
+    XCTAssertNil(madeLocatorString)
+  }
+
 }


### PR DESCRIPTION
**What's this do?**
Adds unit tests for deserializing bookmarks in the new Spec format. 
Also adds the necessary changes in the bookmarks parsing/creation code. Since these are breaking changes with R1, I'm merging this in a feature branch until this refactor is complete.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3655

**How should this be tested? / Do these changes have associated tests?**
too early to test. This is just a subtask.

**Dependencies for merging? Releasing to production?**
no -- merging into feature branch

**Does this include changes that require a new SimplyE build for QA?**
not yet

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 