### PR TITLE
SIMPLY-3669 Ensure ability to read R1 bookmarks

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1400,6 +1400,14 @@
 		73F11E0F251945BE00FCD22B /* NYPLAppDelegate+SE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734731222514235900BE3D2C /* NYPLAppDelegate+SE.swift */; };
 		73F11E10251945E500FCD22B /* NYPLPresentationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73085E192502DE88008F6244 /* NYPLPresentationUtils.swift */; };
 		73F36BD825CC76C60057954C /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73F36BD325CC76C60057954C /* XCTest.framework */; };
+		73F6BF9E261E511200A71AB8 /* valid-R1-readingprogress-1.json in Resources */ = {isa = PBXBuildFile; fileRef = 73F6BF97261E511100A71AB8 /* valid-R1-readingprogress-1.json */; };
+		73F6BF9F261E511200A71AB8 /* valid-R1-readingprogress-1.json in Resources */ = {isa = PBXBuildFile; fileRef = 73F6BF97261E511100A71AB8 /* valid-R1-readingprogress-1.json */; };
+		73F6BFA0261E511200A71AB8 /* valid-R1-bookmark-1.json in Resources */ = {isa = PBXBuildFile; fileRef = 73F6BF9D261E511100A71AB8 /* valid-R1-bookmark-1.json */; };
+		73F6BFA1261E511200A71AB8 /* valid-R1-bookmark-1.json in Resources */ = {isa = PBXBuildFile; fileRef = 73F6BF9D261E511100A71AB8 /* valid-R1-bookmark-1.json */; };
+		73F6BFA3261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F6BFA2261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift */; };
+		73F6BFA4261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F6BFA2261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift */; };
+		73F6BFA6261E60C400A71AB8 /* only-essential-info-bookmark.json in Resources */ = {isa = PBXBuildFile; fileRef = 73F6BFA5261E60C400A71AB8 /* only-essential-info-bookmark.json */; };
+		73F6BFA7261E60C400A71AB8 /* only-essential-info-bookmark.json in Resources */ = {isa = PBXBuildFile; fileRef = 73F6BFA5261E60C400A71AB8 /* only-essential-info-bookmark.json */; };
 		73F713562417200F00C63B81 /* NYPLEPUBViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F713502417200F00C63B81 /* NYPLEPUBViewController.swift */; };
 		73F713572417200F00C63B81 /* NYPLBaseReaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F713552417200F00C63B81 /* NYPLBaseReaderViewController.swift */; };
 		73F713682417240100C63B81 /* UIViewController+NYPL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F713672417240100C63B81 /* UIViewController+NYPL.swift */; };
@@ -2182,6 +2190,7 @@
 		735350B624918432006021BD /* URLRequest+NYPLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+NYPLTests.swift"; sourceTree = "<group>"; };
 		735394012508161A0043C800 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		7353940B250854A90043C800 /* NYPLSettingsSplitViewController+OE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSettingsSplitViewController+OE.swift"; sourceTree = "<group>"; };
+		73542EDD261E862B006083DC /* Bookmarks.lhs */ = {isa = PBXFileReference; lastKnownFileType = file; name = Bookmarks.lhs; path = "Simplified-Bookmarks-Spec/Bookmarks.lhs"; sourceTree = SOURCE_ROOT; };
 		7357719F2537635600067CEA /* NYPLSignInBusinessLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSignInBusinessLogicTests.swift; sourceTree = "<group>"; };
 		735771A7253763E800067CEA /* NYPLBookRegistryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBookRegistryMock.swift; sourceTree = "<group>"; };
 		735771AA2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLLibraryAccountsProviderMock.swift; sourceTree = "<group>"; };
@@ -2288,6 +2297,10 @@
 		73EC8904258D8A2A00978955 /* xcode-build-nodrm.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xcode-build-nodrm.sh"; sourceTree = "<group>"; };
 		73EC8927258D905E00978955 /* archive-and-upload.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = "archive-and-upload.yml"; sourceTree = "<group>"; };
 		73F36BD325CC76C60057954C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		73F6BF97261E511100A71AB8 /* valid-R1-readingprogress-1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "valid-R1-readingprogress-1.json"; path = "Bookmarks/valid-R1-readingprogress-1.json"; sourceTree = "<group>"; };
+		73F6BF9D261E511100A71AB8 /* valid-R1-bookmark-1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "valid-R1-bookmark-1.json"; path = "Bookmarks/valid-R1-bookmark-1.json"; sourceTree = "<group>"; };
+		73F6BFA2261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NYPLR1BookmarkDecodingTests.swift; path = Bookmarks/NYPLR1BookmarkDecodingTests.swift; sourceTree = "<group>"; };
+		73F6BFA5261E60C400A71AB8 /* only-essential-info-bookmark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "only-essential-info-bookmark.json"; path = "Bookmarks/only-essential-info-bookmark.json"; sourceTree = "<group>"; };
 		73F713502417200F00C63B81 /* NYPLEPUBViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NYPLEPUBViewController.swift; path = Simplified/Reader2/UI/NYPLEPUBViewController.swift; sourceTree = SOURCE_ROOT; };
 		73F713552417200F00C63B81 /* NYPLBaseReaderViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NYPLBaseReaderViewController.swift; path = Simplified/Reader2/UI/NYPLBaseReaderViewController.swift; sourceTree = SOURCE_ROOT; };
 		73F713672417240100C63B81 /* UIViewController+NYPL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIViewController+NYPL.swift"; path = "Simplified/Reader2/UI/UIViewController+NYPL.swift"; sourceTree = SOURCE_ROOT; };
@@ -2913,6 +2926,7 @@
 		730EF23226093DE3008E1DC3 /* Bookmarks */ = {
 			isa = PBXGroup;
 			children = (
+				73542EDD261E862B006083DC /* Bookmarks.lhs */,
 				730EF23D26093E3F008E1DC3 /* invalid-bookmark-0.json */,
 				730EF23C26093E3F008E1DC3 /* invalid-bookmark-1.json */,
 				730EF23B26093E3F008E1DC3 /* invalid-bookmark-2.json */,
@@ -2930,8 +2944,12 @@
 				73418F252616AAF000583569 /* valid-bookmark-3.json */,
 				730EF25626093E53008E1DC3 /* valid-locator-0.json */,
 				730EF25326093E52008E1DC3 /* valid-locator-1.json */,
-				7340A8B526151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift */,
+				73F6BF9D261E511100A71AB8 /* valid-R1-bookmark-1.json */,
+				73F6BF97261E511100A71AB8 /* valid-R1-readingprogress-1.json */,
+				73F6BFA5261E60C400A71AB8 /* only-essential-info-bookmark.json */,
 				730EF262260955EF008E1DC3 /* NYPLBookmarkSpecTests.swift */,
+				7340A8B526151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift */,
+				73F6BFA2261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift */,
 			);
 			name = Bookmarks;
 			sourceTree = "<group>";
@@ -4126,6 +4144,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				730EF25E26093E53008E1DC3 /* valid-locator-0.json in Resources */,
+				73F6BFA0261E511200A71AB8 /* valid-R1-bookmark-1.json in Resources */,
 				730EF25126093E40008E1DC3 /* invalid-bookmark-4.json in Resources */,
 				730EF24726093E40008E1DC3 /* invalid-bookmark-2.json in Resources */,
 				2D2B478E1D08FDF5007F7764 /* UpdateCheckNeedsUpdate.json in Resources */,
@@ -4153,6 +4172,8 @@
 				730EF24B26093E40008E1DC3 /* invalid-bookmark-0.json in Resources */,
 				73418F2B2616AAF000583569 /* valid-bookmark-3.json in Resources */,
 				17BE24EF25FB114900AE707F /* simplye_authentication_document.json in Resources */,
+				73F6BFA6261E60C400A71AB8 /* only-essential-info-bookmark.json in Resources */,
+				73F6BF9E261E511200A71AB8 /* valid-R1-readingprogress-1.json in Resources */,
 				732F4748260AD76E00E2CB64 /* NYPLOPDSAcquisitionPathEntry.xml in Resources */,
 				73A794C72549098700C59CC1 /* NYPLOPDSAcquisitionPathEntryMinimal.xml in Resources */,
 			);
@@ -4162,6 +4183,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				73F6BFA1261E511200A71AB8 /* valid-R1-bookmark-1.json in Resources */,
 				733ED6E52617DEAA00ED8C8C /* invalid-bookmark-6.json in Resources */,
 				7320AB3A251EBC9900E3F04D /* NYPLOPDSAcquisitionPathEntry.xml in Resources */,
 				732F4749260B1AEF00E2CB64 /* NYPLOPDSAcquisitionPathEntryMinimal.xml in Resources */,
@@ -4181,8 +4203,10 @@
 				7320AB40251EBC9900E3F04D /* dpl_authentication_document.json in Resources */,
 				73418F2C2616AAF000583569 /* valid-bookmark-3.json in Resources */,
 				7320AB41251EBC9900E3F04D /* UpdateCheckUnknown.json in Resources */,
+				73F6BFA7261E60C400A71AB8 /* only-essential-info-bookmark.json in Resources */,
 				733ED6E72617DEAA00ED8C8C /* invalid-bookmark-5.json in Resources */,
 				7320AB42251EBC9900E3F04D /* jwk.json in Resources */,
+				73F6BF9F261E511200A71AB8 /* valid-R1-readingprogress-1.json in Resources */,
 				7320AB43251EBC9900E3F04D /* OPDS2CatalogsFeed.json in Resources */,
 				7320AB44251EBC9900E3F04D /* UpdateCheckUpToDate.json in Resources */,
 				730EF24426093E40008E1DC3 /* invalid-locator-2.json in Resources */,
@@ -4734,6 +4758,7 @@
 				5D73DA4322A080BA00162CB8 /* NYPLMyBooksDownloadCenterTests.swift in Sources */,
 				730D17C02552124B004CAC83 /* NYPLMyBooksDownloadsCenterMock.swift in Sources */,
 				735F41A3243E381D00046182 /* String+NYPLAdditionsTests.swift in Sources */,
+				73F6BFA3261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift in Sources */,
 				17BE24E725FABCDE00AE707F /* NYPLUserAccountProviderMock.swift in Sources */,
 				7311FD2B25CBD086004447CB /* NYPLSignInOutBusinessLogicUIDelegateMock.swift in Sources */,
 				173F0823241AAA4E00A64658 /* NYPLBookStateTests.swift in Sources */,
@@ -4758,6 +4783,7 @@
 				735DD0D02522A0730096D1F9 /* UserProfileDocumentTests.swift in Sources */,
 				735DD0AD252293580096D1F9 /* NYPLBookStateTests.swift in Sources */,
 				735DD0C92522A0590096D1F9 /* NYPLCatalogFacetTests.m in Sources */,
+				73F6BFA4261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift in Sources */,
 				735771A9253763E800067CEA /* NYPLBookRegistryMock.swift in Sources */,
 				737F4A542549D78100A3C34B /* NYPLBookCreationTestsObjc.m in Sources */,
 				735771A52537635D00067CEA /* NYPLSignInBusinessLogicTests.swift in Sources */,

--- a/Simplified/Book/Models/NYPLBookRegistry.h
+++ b/Simplified/Book/Models/NYPLBookRegistry.h
@@ -183,7 +183,8 @@ genericBookmarks:(nullable NSArray<NYPLBookLocation *> *)genericBookmarks;
                    with:(nonnull NYPLReadiumBookmark *)newBookmark
           forIdentifier:(nonnull NSString *)identifier;
 
-// Returns the generic bookmarks for a any renderer's bookmarks given its identifier
+/// Returns the generic bookmarks for a any renderer's bookmarks given its identifier
+/// @note Generic bookmarks are used for PDF documents.
 - (nullable NSArray<NYPLBookLocation *> *)genericBookmarksForIdentifier:(nonnull NSString *)identifier;
 
 // Add a generic bookmark (book location) for a book given its identifier

--- a/Simplified/Reader2/Bookmarks/NYPLBookmarkFactory.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLBookmarkFactory.swift
@@ -112,11 +112,14 @@ class NYPLBookmarkFactory {
       return nil
     }
 
-    guard let device = body[NYPLBookmarkSpec.Body.Device.key] as? String,
-      let time = body[NYPLBookmarkSpec.Body.Time.key] as? String else {
-        Log.error(#file, "Error reading `device` info from `body`:\(body)")
-        return nil
+    guard let device = body[NYPLBookmarkSpec.Body.Device.key] as? String else {
+      Log.error(#file, "Error reading `device` info from `body`:\(body)")
+      return nil
     }
+
+    // while time is required by the Spec, we don't need to impact the user
+    // experience just because we are missing or can't parse the time
+    let time = (body[NYPLBookmarkSpec.Body.Time.key] as? String) ?? NSDate().rfc3339String()
 
     guard
       let selector = target[NYPLBookmarkSpec.Target.Selector.key] as? [String: Any],
@@ -143,13 +146,13 @@ class NYPLBookmarkFactory {
 
     let progress = selectorValueJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey]
     let legacyProgress = body["http://librarysimplified.org/terms/progressWithinChapter"]
-    let progressWithinChapter = ((progress as? Float) ?? legacyProgress as? Float) ?? 0.0
+    let progressWithinChapter = ((progress as? Double) ?? legacyProgress as? Double) ?? 0.0
 
     // non-essential info
     let serverCFI = selectorValueJSON[NYPLBookmarkSpec.Target.Selector.Value.legacyLocatorCFIKey] as? String
     let chapter = body["http://librarysimplified.org/terms/chapter"] as? String
     let bookProgress = body["http://librarysimplified.org/terms/progressWithinBook"]
-    let progressWithinBook = Float(bookProgress as? String ?? "") ?? 0.0
+    let progressWithinBook = Float(bookProgress as? Double ?? 0.0)
 
     return NYPLReadiumBookmark(annotationId: annotationID,
                                contentCFI: serverCFI,
@@ -157,7 +160,7 @@ class NYPLBookmarkFactory {
                                chapter: chapter,
                                page: nil,
                                location: selectorValueEscJSON,
-                               progressWithinChapter: progressWithinChapter,
+                               progressWithinChapter: Float(progressWithinChapter),
                                progressWithinBook: progressWithinBook,
                                time:time,
                                device:device)

--- a/Simplified/Reader2/Bookmarks/NYPLReadiumBookmark.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLReadiumBookmark.swift
@@ -10,16 +10,16 @@
 /// that a user won't be able to retrieve the bookmarks from disk anymore.
 ///
 @objc class NYPLBookmarkDictionaryRepresentation: NSObject {
-  fileprivate static let annotationIdKey = "annotationId"
+  static let annotationIdKey = "annotationId"
   @objc static let idrefKey = "idref"
   @objc static let locationKey = "location"
   @objc static let cfiKey = "contentCFI"
-  fileprivate static let timeKey = "time"
-  fileprivate static let chapterKey = "chapter"
-  fileprivate static let pageKey = "page"
-  fileprivate static let deviceKey = "device"
-  fileprivate static let chapterProgressKey = "progressWithinChapter"
-  fileprivate static let bookProgressKey = "progressWithinBook"
+  static let timeKey = "time"
+  static let chapterKey = "chapter"
+  static let pageKey = "page"
+  static let deviceKey = "device"
+  static let chapterProgressKey = "progressWithinChapter"
+  static let bookProgressKey = "progressWithinBook"
 }
 
 /// Internal representation of an annotation. This may represent an actual

--- a/SimplifiedTests/Bookmarks/NYPLBookmarkSpecTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLBookmarkSpecTests.swift
@@ -41,7 +41,7 @@ class NYPLBookmarkSpecTests: XCTestCase {
     let json = try JSONSerialization.jsonObject(with: locatorData) as! [String: Any]
     let typeValue = json[NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey] as! String
     let chapterID = json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterIDKey] as! String
-    let progress = json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as! Float
+    let progress = Float(json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as! Double)
 
     // test: make a locator, encode it to binary, parse binary back to JSON
     guard let madeLocatorString = NYPLBookmarkFactory
@@ -65,7 +65,7 @@ class NYPLBookmarkSpecTests: XCTestCase {
     // verify: parsing manually created locator should reveal same info of locator on disk
     let parsedType = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey] as? String
     let parsedChapterID = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterIDKey] as? String
-    let parsedProgress = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as? Float
+    let parsedProgress = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as? Double
     XCTAssertNotNil(parsedType)
     XCTAssertNotNil(parsedChapterID)
     XCTAssertNotNil(parsedProgress)
@@ -74,7 +74,7 @@ class NYPLBookmarkSpecTests: XCTestCase {
     XCTAssertNotEqual(parsedProgress, 0.0)
     XCTAssertEqual(parsedType, typeValue)
     XCTAssertEqual(parsedChapterID, chapterID)
-    XCTAssertEqual(parsedProgress, progress)
+    XCTAssertEqual(Float(parsedProgress!), progress)
   }
 
   func testMakeOldFormatLocatorFromJSON() throws {
@@ -84,7 +84,7 @@ class NYPLBookmarkSpecTests: XCTestCase {
     let json = try JSONSerialization.jsonObject(with: locatorData) as! [String: Any]
     let typeValue = json[NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey] as! String
     let chapterID = json[NYPLBookmarkR1Key.idref.rawValue] as! String
-    let progress = json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as! Float
+    let progress = Float(json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as! Double)
     let cfi = json[NYPLBookmarkSpec.Target.Selector.Value.legacyLocatorCFIKey] as! String
 
     // test: make a locator, encode it to binary, parse binary back to JSON
@@ -120,7 +120,7 @@ class NYPLBookmarkSpecTests: XCTestCase {
     XCTAssertFalse(parsedCFI!.isEmpty)
     XCTAssertEqual(parsedType!, typeValue)
     XCTAssertEqual(parsedChapterID!, chapterID)
-    XCTAssertEqual(parsedProgress!, progress)
+    XCTAssertEqual(Float(parsedProgress!), progress)
     XCTAssertEqual(parsedCFI!, cfi)
   }
 
@@ -130,7 +130,7 @@ class NYPLBookmarkSpecTests: XCTestCase {
     let locatorData = try Data(contentsOf: locatorURL)
     let json = try JSONSerialization.jsonObject(with: locatorData) as! [String: Any]
     let chapterID = json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterIDKey] as! String
-    let progress = json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as! Float
+    let progress = Float(json[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as! Double)
     XCTAssertLessThan(progress, 0.0)
 
     // test

--- a/SimplifiedTests/Bookmarks/NYPLR1BookmarkDecodingTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLR1BookmarkDecodingTests.swift
@@ -1,0 +1,158 @@
+//
+//  NYPLR1BookmarkDecodingTests.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 4/7/21.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import XCTest
+@testable import SimplyE
+
+class NYPLR1BookmarkDecodingTests: XCTestCase {
+  var bundle: Bundle!
+
+  override func setUpWithError() throws {
+    bundle = Bundle(for: NYPLBookmarkSpecTests.self)
+  }
+
+  override func tearDownWithError() throws {
+    bundle = nil
+  }
+
+  func testDecodeValidR1Bookmark() throws {
+    // preconditions: get expected values from manually reading from disk
+    let bookmarkURL = bundle.url(forResource: "valid-R1-bookmark-1",
+                                 withExtension: "json")!
+    let bookmarkData = try Data(contentsOf: bookmarkURL)
+    let json = try JSONSerialization.jsonObject(with: bookmarkData) as! [String: Any]
+    let annotationID = json[NYPLBookmarkSpec.Id.key] as! String
+    let body = json[NYPLBookmarkSpec.Body.key] as! [String: Any]
+    let device = body[NYPLBookmarkSpec.Body.Device.key] as! String
+    let time = body[NYPLBookmarkSpec.Body.Time.key] as! String
+    let target = json[NYPLBookmarkSpec.Target.key] as! [String: Any]
+    let bookID = target[NYPLBookmarkSpec.Target.Source.key] as! String
+    let selector = target[NYPLBookmarkSpec.Target.Selector.key] as! [String: Any]
+    let locator = selector[NYPLBookmarkSpec.Target.Selector.Value.key] as! String
+
+    // test: make bookmark with the wrong book id or annotation type
+    let wrong1 = NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                                          annotationType: .bookmark,
+                                          bookID: "ciccio")
+    let wrong2 = NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                                          annotationType: .readingProgress,
+                                          bookID: bookID)
+
+    // test: make a bookmark with the data we manually read
+    guard let madeBookmark =
+      NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                               annotationType: .bookmark,
+                               bookID: bookID) else {
+                                XCTFail("Failed to create bookmark from valid data")
+                                return
+    }
+
+    // verify
+    XCTAssertNil(wrong1)
+    XCTAssertNil(wrong2)
+    XCTAssertEqual(madeBookmark.annotationId, annotationID)
+    XCTAssertEqual(madeBookmark.location.trimmingCharacters(in: .whitespacesAndNewlines),
+                   locator.trimmingCharacters(in: .whitespacesAndNewlines))
+    XCTAssertEqual(madeBookmark.device, device)
+    XCTAssertEqual(madeBookmark.time, time)
+    XCTAssertEqual(madeBookmark.idref, "c001")
+    XCTAssertEqual(madeBookmark.progressWithinChapter, 0.7471264600753784)
+    XCTAssertEqual(madeBookmark.progressWithinBook, 0.6000000238418579)
+  }
+
+  func testDecodeValidR1ReadingProgress() throws {
+    // preconditions: get expected values from manually reading from disk
+    let bookmarkURL = bundle.url(forResource: "valid-R1-readingprogress-1",
+                                 withExtension: "json")!
+    let bookmarkData = try Data(contentsOf: bookmarkURL)
+    let json = try JSONSerialization.jsonObject(with: bookmarkData) as! [String: Any]
+    let annotationID = json[NYPLBookmarkSpec.Id.key] as! String
+    let body = json[NYPLBookmarkSpec.Body.key] as! [String: Any]
+    let device = body[NYPLBookmarkSpec.Body.Device.key] as! String
+    let time = body[NYPLBookmarkSpec.Body.Time.key] as! String
+    let target = json[NYPLBookmarkSpec.Target.key] as! [String: Any]
+    let bookID = target[NYPLBookmarkSpec.Target.Source.key] as! String
+    let selector = target[NYPLBookmarkSpec.Target.Selector.key] as! [String: Any]
+    let locator = selector[NYPLBookmarkSpec.Target.Selector.Value.key] as! String
+    let motivationRaw = json[NYPLBookmarkSpec.Motivation.key] as! String
+    let motivation = NYPLBookmarkSpec.Motivation(rawValue: motivationRaw)!
+
+    // test: make bookmark with the wrong book id or annotation type
+    let wrong1 = NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                                          annotationType: motivation,
+                                          bookID: "ciccio")
+    let wrong2 = NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                                          annotationType: .bookmark,
+                                          bookID: bookID)
+
+    // test: make a bookmark with the data we manually read
+    guard let madeBookmark =
+      NYPLBookmarkFactory.make(fromServerAnnotation: json,
+                               annotationType: motivation,
+                               bookID: bookID) else {
+                                XCTFail("Failed to create bookmark from valid data")
+                                return
+    }
+
+    // verify
+    XCTAssertNil(wrong1)
+    XCTAssertNil(wrong2)
+    XCTAssertEqual(madeBookmark.annotationId, annotationID)
+    XCTAssertEqual(madeBookmark.location.trimmingCharacters(in: .whitespacesAndNewlines),
+                   locator.trimmingCharacters(in: .whitespacesAndNewlines))
+    XCTAssertEqual(madeBookmark.device, device)
+    XCTAssertEqual(madeBookmark.time, time)
+    XCTAssertEqual(madeBookmark.idref, "c001")
+    XCTAssertEqual(madeBookmark.contentCFI, "/4/4/638/1:30")
+  }
+
+  // This covers the case of bookmarks retrieved from disk
+  func testRestoringFromDictionary() {
+    // preconditions
+    let bookProgress: Float = 0.3684210479259491
+    let chapterProgress: Float = 0.666
+    let diskRepresentation: [String: Any] = [
+      NYPLBookmarkDictionaryRepresentation.annotationIdKey: "https://circulation.librarysimplified.org/NYNYPL/annotations/3195762",
+      NYPLBookmarkDictionaryRepresentation.chapterKey: "Current Chapter",
+      NYPLBookmarkDictionaryRepresentation.cfiKey: "/4[mikhail_feminine_sign_text-12]/2/72/1:0",
+      NYPLBookmarkDictionaryRepresentation.deviceKey: "urn:uuid:789166c5-ed87-413a-8d9f-f306f6f02362",
+      NYPLBookmarkDictionaryRepresentation.idrefKey: "mikhail_feminine_sign_text-12",
+      NYPLBookmarkDictionaryRepresentation.locationKey: "{\"idref\":\"mikhail_feminine_sign_text-12\",\"contentCFI\":\"/4[mikhail_feminine_sign_text-12]/2/72/1:0\"}",
+      NYPLBookmarkDictionaryRepresentation.pageKey: "",
+      NYPLBookmarkDictionaryRepresentation.bookProgressKey: NSNumber(value: bookProgress),
+      NYPLBookmarkDictionaryRepresentation.chapterProgressKey: NSNumber(value: chapterProgress),
+      NYPLBookmarkDictionaryRepresentation.timeKey: "2021-04-07T23:49:14Z",
+    ]
+
+    // test
+    guard let bookmark = NYPLReadiumBookmark(dictionary: diskRepresentation as NSDictionary) else {
+      XCTFail("Failed to create bookmark from disk dictionary representation")
+      return
+    }
+
+    // verify
+    XCTAssertEqual(bookmark.annotationId!,
+                   diskRepresentation[NYPLBookmarkDictionaryRepresentation.annotationIdKey] as? String)
+    XCTAssertEqual(bookmark.chapter!,
+                   diskRepresentation[NYPLBookmarkDictionaryRepresentation.chapterKey] as? String)
+    XCTAssertEqual(bookmark.contentCFI!,
+                   diskRepresentation[NYPLBookmarkDictionaryRepresentation.cfiKey] as? String)
+    XCTAssertEqual(bookmark.device!,
+                   diskRepresentation[NYPLBookmarkDictionaryRepresentation.deviceKey] as? String)
+    XCTAssertEqual(bookmark.idref,
+                   diskRepresentation[NYPLBookmarkDictionaryRepresentation.idrefKey] as? String)
+    XCTAssertEqual(bookmark.location,
+                   diskRepresentation[NYPLBookmarkDictionaryRepresentation.locationKey] as? String)
+    XCTAssertEqual(bookmark.page!,
+                   diskRepresentation[NYPLBookmarkDictionaryRepresentation.pageKey] as? String)
+    XCTAssertEqual(bookmark.progressWithinBook, bookProgress)
+    XCTAssertEqual(bookmark.progressWithinChapter, chapterProgress)
+    XCTAssertEqual(bookmark.time,
+                   diskRepresentation[NYPLBookmarkDictionaryRepresentation.timeKey] as? String)
+  }
+}

--- a/SimplifiedTests/Bookmarks/only-essential-info-bookmark.json
+++ b/SimplifiedTests/Bookmarks/only-essential-info-bookmark.json
@@ -1,0 +1,13 @@
+{
+  "id": "urn:uuid:715885bc-23d3-4d7d-bd87-f5e7a042c4ba",
+  "body": {
+    "http://librarysimplified.org/terms/device": "urn:uuid:c83db5b1-9130-4b86-93ea-634b00235c7c"
+  },
+  "motivation": "http://www.w3.org/ns/oa#bookmarking",
+  "target": {
+    "selector": {
+      "value": "{\n  \"href\": \"/xyz.html\",\n  \"progressWithinChapter\": 0.888\n}\n"
+    },
+    "source": "urn:uuid:1daa8de6-94e8-4711-b7d1-e43b572aa6e0"
+  }
+}

--- a/SimplifiedTests/Bookmarks/valid-R1-bookmark-1.json
+++ b/SimplifiedTests/Bookmarks/valid-R1-bookmark-1.json
@@ -1,0 +1,19 @@
+{
+  "body": {
+    "http://librarysimplified.org/terms/progressWithinBook": 0.6000000238418579,
+    "http://librarysimplified.org/terms/progressWithinChapter": 0.7471264600753784,
+    "http://librarysimplified.org/terms/device": "urn:uuid:680f188b-b7bd-4b19-8379-f1dfeb491da8",
+    "http://librarysimplified.org/terms/time": "2021-03-31T23:59:20Z",
+    "http://librarysimplified.org/terms/chapter": "Current Chapter"
+  },
+  "motivation": "http://www.w3.org/ns/oa#bookmarking",
+  "type": "Annotation",
+  "id": "https://circulation.librarysimplified.org/NYNYPL/annotations/3173101",
+  "target": {
+    "selector": {
+      "type": "FragmentSelector",
+      "value": "{\"idref\":\"c001\",\"contentCFI\":\"/4/4/526/1:276\"}"
+    },
+    "source": "urn:librarysimplified.org/terms/id/Overdrive%20ID/365e31df-d292-44d6-98b6-20acd2542a28"
+  }
+}

--- a/SimplifiedTests/Bookmarks/valid-R1-readingprogress-1.json
+++ b/SimplifiedTests/Bookmarks/valid-R1-readingprogress-1.json
@@ -1,0 +1,16 @@
+{
+  "body": {
+    "http://librarysimplified.org/terms/time": "2021-04-01T01:20:05Z",
+    "http://librarysimplified.org/terms/device": "urn:uuid:680f188b-b7bd-4b19-8379-f1dfeb491da8"
+  },
+  "motivation": "http://librarysimplified.org/terms/annotation/idling",
+  "type": "Annotation",
+  "id": "https://circulation.librarysimplified.org/NYNYPL/annotations/3169837",
+  "target": {
+    "selector": {
+      "type": "FragmentSelector",
+      "value": "{\"idref\":\"c001\",\"contentCFI\":\"/4/4/638/1:30\"}"
+    },
+    "source": "urn:librarysimplified.org/terms/id/Overdrive%20ID/365e31df-d292-44d6-98b6-20acd2542a28"
+  }
+}


### PR DESCRIPTION
**What's this do?**
Ensures that despite the changes for the new bookmarks spec we can still read R1 bookmarks in the old format.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3669

**How should this be tested? / Do these changes have associated tests?**
not ready for QA, will be when the story is completed

**Dependencies for merging? Releasing to production?**
I'll need to update the commit reference for the Simplified-Bookmark-Spec repo once the PR https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec/pull/3 is merged.

**Does this include changes that require a new SimplyE build for QA?**
not yet

**Has the application documentation been updated for these changes?**
y

**Did someone actually run this code to verify it works?**
@ettore 