### PR TITLE
SIMPLY-3671: Fixed user unable to sign in using beta libraries

### DIFF
--- a/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
@@ -29,10 +29,10 @@ extension NYPLConfiguration {
   private static let betaFeedFileUrl = URL(fileURLWithPath:
     Bundle.main.path(forResource: "OpenEBooks_OPDS2_Catalog_Feed-QA",
                      ofType: "json")!)
-  private static let betaFeedFileUrlHash = feedFileUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+  private static let betaFeedFileUrlHash = betaFeedFileUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
 
   static var betaUrl = betaFeedFileUrl
-  static var betaUrlHash = feedFileUrlHash
+  static var betaUrlHash = betaFeedFileUrlHash
 
   // MARK:-
 


### PR DESCRIPTION
**What's this do?**
Fixes user unable to sign in with beta libraries. Requires https://github.com/NYPL-Simplified/Simplified-iOS/pull/1360 to be merged in order to work.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3671

**How should this be tested? / Do these changes have associated tests?**
Follow the steps to reproduce in the ticket

**Dependencies for merging? Releasing to production?**
This will only work after https://github.com/NYPL-Simplified/Simplified-iOS/pull/1360 has been merged.

**Does this include changes that require a new SimplyE build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A
**Did someone actually run this code to verify it works?**
Raman Singh verified it