### PR TITLE
SIMPLY-3607: Removes Adept and LCP from OpenEbooks

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -246,11 +246,26 @@
 		2DFAC8ED1CD8DDD1003D9EC0 /* NYPLOPDSCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DFAC8EC1CD8DDD1003D9EC0 /* NYPLOPDSCategory.m */; };
 		52545185217A76FF00BBC1B4 /* NYPLUserNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52545184217A76FF00BBC1B4 /* NYPLUserNotifications.swift */; };
 		52592BB821220A1100587288 /* NYPLLocalization.m in Sources */ = {isa = PBXBuildFile; fileRef = 52592BB721220A1100587288 /* NYPLLocalization.m */; };
+		5916E7D4262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7D3262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift */; };
+		5916E7D5262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7D3262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift */; };
+		5916E7D6262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7D3262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift */; };
+		5916E7D7262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7D3262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift */; };
+		5916E7D8262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7D3262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift */; };
+		5916E7DF2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */; };
+		5916E7E02627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */; };
+		5916E7E12627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */; };
+		5916E7E22627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */; };
+		5916E7E32627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */; };
 		598CDC02261D3B5E006A5AB3 /* NYPLAxisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A78B89261656C20038BCDC /* NYPLAxisService.swift */; };
 		598CDC03261D3B5F006A5AB3 /* NYPLAxisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A78B89261656C20038BCDC /* NYPLAxisService.swift */; };
 		598CDC04261D3B5F006A5AB3 /* NYPLAxisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A78B89261656C20038BCDC /* NYPLAxisService.swift */; };
 		598CDC05261D3B60006A5AB3 /* NYPLAxisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A78B89261656C20038BCDC /* NYPLAxisService.swift */; };
 		59A78B8A261656C20038BCDC /* NYPLAxisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A78B89261656C20038BCDC /* NYPLAxisService.swift */; };
+		59EEAFF3262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EEAFF2262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift */; };
+		59EEAFF4262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EEAFF2262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift */; };
+		59EEAFF5262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EEAFF2262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift */; };
+		59EEAFF6262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EEAFF2262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift */; };
+		59EEAFF7262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EEAFF2262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift */; };
 		5A5B901B1B946FAD002C53E9 /* NYPLReaderContainerDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5A5B901A1B946FAD002C53E9 /* NYPLReaderContainerDelegate.mm */; };
 		5A69290E1B95ACC600FB4C10 /* readium-shared-js_all.js in Resources */ = {isa = PBXBuildFile; fileRef = 5A69290D1B95ACC600FB4C10 /* readium-shared-js_all.js */; };
 		5A6929101B95ACD100FB4C10 /* sdk.css in Resources */ = {isa = PBXBuildFile; fileRef = 5A69290F1B95ACD100FB4C10 /* sdk.css */; };
@@ -2062,7 +2077,10 @@
 		52545184217A76FF00BBC1B4 /* NYPLUserNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserNotifications.swift; sourceTree = "<group>"; };
 		52592BB721220A1100587288 /* NYPLLocalization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NYPLLocalization.m; sourceTree = "<group>"; };
 		52592BBB21220A4F00587288 /* NYPLLocalization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NYPLLocalization.h; sourceTree = "<group>"; };
+		5916E7D3262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+Adept.swift"; sourceTree = "<group>"; };
+		5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+Axis.swift"; sourceTree = "<group>"; };
 		59A78B89261656C20038BCDC /* NYPLAxisService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAxisService.swift; sourceTree = "<group>"; };
+		59EEAFF2262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAxisDRMAuthorizer.swift; sourceTree = "<group>"; };
 		5A569A261B8351C6003B5B61 /* ADEPT.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ADEPT.xcodeproj; path = "adept-ios/ADEPT.xcodeproj"; sourceTree = "<group>"; };
 		5A5B90111B946763002C53E9 /* libc++.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.1.dylib"; path = "usr/lib/libc++.1.dylib"; sourceTree = SDKROOT; };
 		5A5B90141B946CBD002C53E9 /* libstdc++.6.0.9.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libstdc++.6.0.9.dylib"; path = "usr/lib/libstdc++.6.0.9.dylib"; sourceTree = SDKROOT; };
@@ -2834,6 +2852,7 @@
 			isa = PBXGroup;
 			children = (
 				59A78B89261656C20038BCDC /* NYPLAxisService.swift */,
+				59EEAFF2262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift */,
 			);
 			path = AxisService;
 			sourceTree = "<group>";
@@ -3028,6 +3047,8 @@
 				730D17CB25535954004CAC83 /* NYPLSignInBusinessLogic+BookmarkSyncing.swift */,
 				73B80BAA25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift */,
 				737F4A6A254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift */,
+				5916E7D3262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift */,
+				5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */,
 				733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */,
 				7314D13F2551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift */,
 				73A794A525477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift */,
@@ -4807,13 +4828,16 @@
 				7347F049245A4DE200558D7F /* NYPLNetworkQueue.swift in Sources */,
 				7347F04A245A4DE200558D7F /* NYPLMyBooksNavigationController.m in Sources */,
 				7347F04B245A4DE200558D7F /* NYPLBookCellCollectionViewController.m in Sources */,
+				59EEAFF5262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift in Sources */,
 				73B551092511748900D05B86 /* NYPLLoginCellTypes.swift in Sources */,
 				7342703324DCB30B00A4F605 /* Publication+NYPLAdditions.swift in Sources */,
 				730FC05225128225004D7C2D /* NYPLSettings.swift in Sources */,
+				5916E7D6262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift in Sources */,
 				73085E3625030D27008F6244 /* SEMigrations.swift in Sources */,
 				21C5047F2513C9FA0016A6C8 /* AudioBookVendorsHelper.swift in Sources */,
 				7347F04C245A4DE200558D7F /* NYPLXML.m in Sources */,
 				73B5510E2511750B00D05B86 /* NYPLSamlIDPCell.swift in Sources */,
+				5916E7E12627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */,
 				731A5B1324621F2B00B5E663 /* NYPLSignInBusinessLogic.swift in Sources */,
 				598CDC04261D3B5F006A5AB3 /* NYPLAxisService.swift in Sources */,
 				7347F04D245A4DE200558D7F /* NYPLBookCell.m in Sources */,
@@ -5050,13 +5074,16 @@
 				739E605A244A0D8600D00301 /* OPDS2Publication.swift in Sources */,
 				739E605B244A0D8600D00301 /* String+MD5.swift in Sources */,
 				739E605C244A0D8600D00301 /* NYPLNetworkQueue.swift in Sources */,
+				59EEAFF4262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift in Sources */,
 				73B551022511738A00D05B86 /* NYPLBasicAuth.swift in Sources */,
 				739E605D244A0D8600D00301 /* NYPLMyBooksNavigationController.m in Sources */,
 				739E605E244A0D8600D00301 /* NYPLBookCellCollectionViewController.m in Sources */,
+				5916E7D5262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift in Sources */,
 				73B5510D2511750A00D05B86 /* NYPLSamlIDPCell.swift in Sources */,
 				739E605F244A0D8600D00301 /* NYPLXML.m in Sources */,
 				739E6060244A0D8600D00301 /* NYPLBookCell.m in Sources */,
 				739E6061244A0D8600D00301 /* NSURL+NYPLURLAdditions.m in Sources */,
+				5916E7E02627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */,
 				739E6062244A0D8600D00301 /* NYPLAsync.m in Sources */,
 				598CDC03261D3B5F006A5AB3 /* NYPLAxisService.swift in Sources */,
 				739E6063244A0D8600D00301 /* NYPLReloadView.m in Sources */,
@@ -5319,6 +5346,7 @@
 				73EB0A8F25821DF4006BC997 /* NYPLReaderTOCViewController.m in Sources */,
 				73D8D27825A68D3B00DF5F69 /* NYPLUserSettingsVC.swift in Sources */,
 				73EB0A9025821DF4006BC997 /* OPDS2CatalogsFeed.swift in Sources */,
+				5916E7D7262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift in Sources */,
 				73EB0A9125821DF4006BC997 /* BundledHTMLViewController.swift in Sources */,
 				73EB0A9225821DF4006BC997 /* NYPLBookDetailView.m in Sources */,
 				73DB56C925F769FF003788EE /* NYPLLastReadPositionSynchronizer.swift in Sources */,
@@ -5478,6 +5506,7 @@
 				73EB0B1625821DF4006BC997 /* AudioBookVendors+Extensions.swift in Sources */,
 				73EB0B1725821DF4006BC997 /* NYPLLibraryNavigationController.m in Sources */,
 				73D8D27725A68D3B00DF5F69 /* UIViewController+NYPL.swift in Sources */,
+				5916E7E22627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */,
 				73EB0B1825821DF4006BC997 /* RemoteHTMLViewController.swift in Sources */,
 				73EB0B1925821DF4006BC997 /* NYPLBookDetailsProblemDocumentViewController.swift in Sources */,
 				73EB0B1A25821DF4006BC997 /* NYPLCatalogGroupedFeed.m in Sources */,
@@ -5493,6 +5522,7 @@
 				73EB0B2325821DF4006BC997 /* NYPLBarcodeScanningViewController.m in Sources */,
 				73C3CF5825C8EB6B00CA8166 /* NYPLUserAccount.swift in Sources */,
 				73EB0B2425821DF4006BC997 /* NYPLBookDetailDownloadFailedView.m in Sources */,
+				59EEAFF6262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift in Sources */,
 				73EB0B2525821DF4006BC997 /* NYPLOPDSFeed.m in Sources */,
 				73EB0B2625821DF4006BC997 /* NYPLRoundedButton.m in Sources */,
 				73EB0B2725821DF4006BC997 /* NYPLOPDSLink.m in Sources */,
@@ -5552,6 +5582,7 @@
 				73FCA2C225005BA4001B0C5D /* NYPLSignInBusinessLogic.swift in Sources */,
 				7380E70B254B408C004613B1 /* NYPLEPUBViewController.swift in Sources */,
 				73FCA2C325005BA4001B0C5D /* NYPLBookCell.m in Sources */,
+				5916E7E32627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */,
 				73FCA2C425005BA4001B0C5D /* NSURL+NYPLURLAdditions.m in Sources */,
 				73FCA2C525005BA4001B0C5D /* NYPLAsync.m in Sources */,
 				73A794A825477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift in Sources */,
@@ -5683,6 +5714,7 @@
 				73FCA32925005BA4001B0C5D /* Data+Base64.swift in Sources */,
 				73FCA32A25005BA4001B0C5D /* NYPLAppDelegate.m in Sources */,
 				730FC05825128D64004D7C2D /* OETutorialEligibilityViewController.swift in Sources */,
+				5916E7D8262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift in Sources */,
 				73FCA32B25005BA4001B0C5D /* NYPLCatalogFacetGroup.m in Sources */,
 				73FCA32C25005BA4001B0C5D /* NYPLOPDSAcquisition.m in Sources */,
 				73FCA32D25005BA4001B0C5D /* NSURLRequest+NYPLURLRequestAdditions.m in Sources */,
@@ -5714,6 +5746,7 @@
 				730D17CE25535954004CAC83 /* NYPLSignInBusinessLogic+BookmarkSyncing.swift in Sources */,
 				73FCA34025005BA4001B0C5D /* NSString+JSONParse.swift in Sources */,
 				73FCA34125005BA4001B0C5D /* NYPLOPDSEntryGroupAttributes.m in Sources */,
+				59EEAFF7262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift in Sources */,
 				73FCA34225005BA4001B0C5D /* NYPLMyBooksDownloadCenter.m in Sources */,
 				73FCA34325005BA4001B0C5D /* NYPLProblemDocumentCacheManager.swift in Sources */,
 				73E64E6A252BB82600276953 /* NYPLWelcomeEULAViewController.swift in Sources */,
@@ -5780,13 +5813,16 @@
 				5DD567AF22B95A30001F0C83 /* String+MD5.swift in Sources */,
 				E671FF7D1E3A7068002AB13F /* NYPLNetworkQueue.swift in Sources */,
 				116A5EAF194767B200491A21 /* NYPLMyBooksNavigationController.m in Sources */,
+				59EEAFF3262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift in Sources */,
 				739062D225358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift in Sources */,
 				1120749319D20BF9008203A4 /* NYPLBookCellCollectionViewController.m in Sources */,
 				0857A0FF247835FF00C7984E /* NYPLKeychainStoredVariable.swift in Sources */,
+				5916E7D4262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift in Sources */,
 				111559ED19B8FA590003BE94 /* NYPLXML.m in Sources */,
 				731A5B1224621F2B00B5E663 /* NYPLSignInBusinessLogic.swift in Sources */,
 				11580AC81986A77B00949A15 /* NYPLBookCell.m in Sources */,
 				738CB2062509A87700891F31 /* NYPLConfiguration+SE.swift in Sources */,
+				5916E7DF2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */,
 				085640CE1BB99FC30088BDBF /* NSURL+NYPLURLAdditions.m in Sources */,
 				598CDC02261D3B5E006A5AB3 /* NYPLAxisService.swift in Sources */,
 				1183F35B194F847100DC322F /* NYPLAsync.m in Sources */,
@@ -6590,10 +6626,8 @@
 					"$(inherited)",
 					"OPENEBOOKS=1",
 					"DEBUG=1",
-					"FEATURE_DRM_CONNECTOR=1",
 					"FEATURE_CRASH_REPORTING=1",
 					"FEATURE_OVERDRIVE=1",
-					"LCP=1",
 					"AXIS=1",
 				);
 				INFOPLIST_FILE = "OpenEbooks/Open-eBooks-Info.plist";
@@ -6608,7 +6642,7 @@
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "Open eBooks Development";
 				RUN_CLANG_STATIC_ANALYZER = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG OPENEBOOKS FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING FEATURE_OVERDRIVE LCP AXIS";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG OPENEBOOKS FEATURE_CRASH_REPORTING FEATURE_OVERDRIVE AXIS";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplified/AppInfrastructure/SimplyE-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "SimplyE-Swift.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -6650,10 +6684,8 @@
 					"$(inherited)",
 					"OPENEBOOKS=1",
 					"DEBUG=0",
-					"FEATURE_DRM_CONNECTOR=1",
 					"FEATURE_CRASH_REPORTING=1",
 					"FEATURE_OVERDRIVE=1",
-					"LCP=1",
 					"AXIS=1",
 				);
 				INFOPLIST_FILE = "OpenEbooks/Open-eBooks-Info.plist";
@@ -6668,7 +6700,7 @@
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "Open eBooks Distribution";
 				RUN_CLANG_STATIC_ANALYZER = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "OPENEBOOKS FEATURE_DRM_CONNECTOR FEATURE_CRASH_REPORTING FEATURE_OVERDRIVE LCP=1 AXIS";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "OPENEBOOKS FEATURE_CRASH_REPORTING FEATURE_OVERDRIVE AXIS";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplified/AppInfrastructure/SimplyE-Bridging-Header.h";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "SimplyE-Swift.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;

--- a/Simplified/AxisService/NYPLAxisDRMAuthorizer.swift
+++ b/Simplified/AxisService/NYPLAxisDRMAuthorizer.swift
@@ -1,0 +1,61 @@
+//
+//  NYPLAxisDRMAuthorizer.swift
+//  Simplified
+//
+//  Created by Raman Singh on 2021-04-13.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+#if AXIS
+@objcMembers
+class NYPLAxisDRMAuthorizer: NSObject, NYPLDRMAuthorizing {
+  
+  static let deviceIDKey = "NYPLAxisDRMAuthorizerKey"
+  
+  static let sharedInstance = NYPLAxisDRMAuthorizer()
+  
+  static var deviceID: String {
+    if
+      let id = UserDefaults.standard.string(forKey: NYPLAxisDRMAuthorizer.deviceIDKey) {
+      return id
+    }
+    
+    let id = UUID().uuidString
+    UserDefaults.standard.set(id, forKey: NYPLAxisDRMAuthorizer.deviceIDKey)
+    return id
+  }
+  
+  /// Not applicable for Axis
+  var workflowsInProgress: Bool {
+    return false
+  }
+  
+  /// We're always returning true since Axis does not deauthorize a user.
+  func isUserAuthorized(_ userID: String!,
+                        withDevice device: String!) -> Bool {
+   return true
+  }
+  
+  /// As of now, we're creating a deviceID which stays saved until the user uninstalls the app.
+  func authorize(withVendorID vendorID: String!,
+                 username: String!,
+                 password: String!,
+                 completion: ((Bool, Error?, String?, String?) -> Void)!) {
+    
+    completion(true, nil, NYPLAxisDRMAuthorizer.deviceID, username)
+  }
+  
+  /// There is no mechanism for deauthorizing the user in Axis. Returning succeeding completion.
+  func deauthorize(withUsername username: String!,
+                   password: String!,
+                   userID: String!,
+                   deviceID: String!,
+                   completion: ((Bool, Error?) -> Void)!) {
+    
+    completion(true, nil)
+  }
+
+}
+#endif

--- a/Simplified/Book/Models/NYPLBook.m
+++ b/Simplified/Book/Models/NYPLBook.m
@@ -534,19 +534,33 @@ static NSString *const UpdatedKey = @"updated";
     NYPLLOG(@"ERROR: No acquisitions found when computing a default. This is an OPDS violation.");
     return nil;
   }
-
+  
+  NYPLOPDSAcquisition *fallbackAcquisition;
+  
   for (NYPLOPDSAcquisition *const acquisition in self.acquisitions) {
     NSArray *const paths = [NYPLOPDSAcquisitionPath
                             supportedAcquisitionPathsForAllowedTypes:[NYPLOPDSAcquisitionPath supportedTypes]
                             allowedRelations:NYPLOPDSAcquisitionRelationSetAll
                             acquisitions:@[acquisition]];
-
+    
     if (paths.count >= 1) {
+#if defined(AXIS)
+      for (NYPLOPDSAcquisitionPath *path in paths) {
+        if ([path.types containsObject:ContentTypeAxis360]) {
+          return acquisition;
+        }
+      }
+      
+      if (!fallbackAcquisition) {
+        fallbackAcquisition = acquisition;
+      }
+#else
       return acquisition;
+#endif
     }
   }
-
-  return nil;
+  
+  return fallbackAcquisition;
 }
 
 - (NYPLOPDSAcquisition *)defaultAcquisitionIfBorrow

--- a/Simplified/Migrations/OEMigrations.swift
+++ b/Simplified/Migrations/OEMigrations.swift
@@ -15,10 +15,12 @@ extension NYPLMigrationManager {
     Log.info(#function, "AppVersion in UserDefaults: \(appVersionInUserDefaults) - Tokenized: \(versionComponents)")
 
     // Run through migration stages
+    #if FEATURE_DRM_CONNECTOR
     migrate_1_8_1(ifNeededFrom: versionComponents)
+    #endif
     migrate_1_9_0(ifNeededFrom: versionComponents)
   }
-
+  #if FEATURE_DRM_CONNECTOR
   /// v1.8.1
   /// Adept API changed to allow multiple accounts
   /// userID and deviceID will be nil
@@ -47,6 +49,7 @@ extension NYPLMigrationManager {
       }
     }
   }
+  #endif
 
   private static func migrate_1_9_0(ifNeededFrom previousVersion: [Int]) -> Void {
     // we run this even if previous version is empty because this migration

--- a/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
@@ -153,6 +153,8 @@ Authenticating with any of those barcodes should work.
   id<NYPLDRMAuthorizing> drmAuthorizer = nil;
 #if defined(FEATURE_DRM_CONNECTOR)
   drmAuthorizer = [NYPLADEPT sharedInstance];
+#elif defined(AXIS)
+  drmAuthorizer = [NYPLAxisDRMAuthorizer sharedInstance];
 #endif
 
   self.businessLogic = [[NYPLSignInBusinessLogic alloc]

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.m
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.m
@@ -102,6 +102,8 @@ CGFloat const marginPadding = 2.0;
                         drmAuthorizer:
 #if FEATURE_DRM_CONNECTOR
                         [NYPLADEPT sharedInstance]
+#elif AXIS
+                        [NYPLAxisDRMAuthorizer sharedInstance]
 #else
                         nil
 #endif

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+Adept.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+Adept.swift
@@ -1,0 +1,125 @@
+//
+//  NYPLSignInBusinessLogic+Adept.swift
+//  Simplified
+//
+//  Created by Raman Singh on 2021-04-14.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+#if FEATURE_DRM_CONNECTOR
+
+extension NYPLSignInBusinessLogic {
+  
+  /// Extracts username and password from user profile's drm's client token and authorizes with Adept DRM
+  /// - Parameters:
+  ///   - profileDoc: UserProfile document from which client token is extracted
+  ///   - loggingContext: Information to report when logging errors.
+  func authorizeWithAdobe(userProfile profileDoc: UserProfileDocument,
+                          loggingContext: [String: Any]) {
+    
+    guard
+      let drm = profileDoc.drm?.first,
+      drm.vendor != nil,
+      let clientToken = drm.clientToken else {
+
+        let drm = profileDoc.drm?.first
+        Log.info(#file, "\nLicensor: \(drm?.licensor ?? ["N/A": "N/A"])")
+        
+        NYPLErrorLogger.logError(
+          withCode: .noLicensorToken,
+          summary: "SignIn: no licensor token in user profile doc",
+          metadata: loggingContext)
+        
+        finalizeSignIn(
+          forDRMAuthorization: false,
+          errorMessage: "No credentials were received to authorize access to books with DRM.")
+        return
+    }
+    
+    Log.info(#file, "\nLicensor: \(drm.licensor)")
+    userAccount.setLicensor(drm.licensor)
+    
+    var licensorItems = clientToken
+      .replacingOccurrences(of: "\n", with: "")
+      .components(separatedBy: "|")
+    
+    let tokenPassword = licensorItems.last
+    licensorItems.removeLast()
+    let tokenUsername = (licensorItems as NSArray).componentsJoined(by: "|")
+    
+    drmAuthorize(username: tokenUsername,
+                 password: tokenPassword,
+                 loggingContext: loggingContext)
+    
+  }
+  
+  /// Perform the DRM authorization request with the given credentials
+  ///
+  /// - Parameters:
+  ///   - username: Adobe DRM token username.
+  ///   - password: Adobe DRM token password. The only reason why this is
+  ///   optional is because ADEPT already handles `nil` values, so we don't
+  ///   have to do the same here.
+  ///   - loggingContext: Information to report when logging errors.
+  private func drmAuthorize(username: String,
+                            password: String?,
+                            loggingContext: [String: Any]) {
+
+    let vendor = userAccount.licensor?["vendor"] as? String
+
+    Log.info(#file, """
+      ***DRM Auth/Activation Attempt***
+      Token username: \(username)
+      Token password: \(password ?? "N/A")
+      VendorID: \(vendor ?? "N/A")
+      """)
+
+    drmAuthorizer?
+      .authorize(withVendorID: vendor,
+                 username: username,
+                 password: password) { success, error, deviceID, userID in
+
+                  // make sure to cancel the previously scheduled selector
+                  // from the same thread it was scheduled on
+                  NYPLMainThreadRun.asyncIfNeeded { [weak self] in
+                    if let self = self {
+                      NSObject.cancelPreviousPerformRequests(withTarget: self)
+                    }
+                  }
+
+                  Log.info(#file, """
+                    Activation success: \(success)
+                    Error: \(error?.localizedDescription ?? "N/A")
+                    DeviceID: \(deviceID ?? "N/A")
+                    UserID: \(userID ?? "N/A")
+                    ***DRM Auth/Activation completion***
+                    """)
+
+                  var success = success
+
+                  if success, let userID = userID, let deviceID = deviceID {
+                    NYPLMainThreadRun.asyncIfNeeded {
+                      self.userAccount.setUserID(userID)
+                      self.userAccount.setDeviceID(deviceID)
+                    }
+                  } else {
+                    success = false
+                    NYPLErrorLogger.logLocalAuthFailed(error: error as NSError?,
+                                                       library: self.libraryAccount,
+                                                       metadata: loggingContext)
+                  }
+
+                  self.finalizeSignIn(forDRMAuthorization: success,
+                                      error: error as NSError?)
+    }
+
+    NYPLMainThreadRun.asyncIfNeeded { [weak self] in
+      self?.perform(#selector(self?.dismissAfterUnexpectedDRMDelay), with: self, afterDelay: 25)
+    }
+  }
+  
+}
+
+#endif

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+Axis.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+Axis.swift
@@ -1,0 +1,70 @@
+//
+//  NYPLSignInBusinessLogic+Axis.swift
+//  Simplified
+//
+//  Created by Raman Singh on 2021-04-14.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+#if AXIS
+
+extension NYPLSignInBusinessLogic {
+  
+  /// Perform the DRM authorization request with the given credentials
+  ///
+  /// - Parameters:
+  ///   - username: DRM token username.
+  ///   - password: DRM token password.
+  ///   - loggingContext: Information to report when logging errors.
+  func drmAuthorize(username: String,
+                    password: String?,
+                    loggingContext: [String: Any]) {
+    
+    let vendor = userAccount.licensor?["vendor"] as? String
+    
+    Log.info(#file, """
+      ***DRM Auth/Activation Attempt***
+      Token username: \(username)
+      Token password: \(password ?? "N/A")
+      VendorID: \(vendor ?? "N/A")
+      """)
+    
+    drmAuthorizer?
+      .authorize(
+        withVendorID: vendor,
+        username: username,
+        password: password
+      ) { success, error, deviceID, userID in
+        
+        Log.info(#file, """
+          Activation success: \(success)
+          Error: \(error?.localizedDescription ?? "N/A")
+          DeviceID: \(deviceID ?? "N/A")
+          UserID: \(userID ?? "N/A")
+          ***DRM Auth/Activation completion***
+          """)
+        
+        var success = success
+        
+        if success, let userID = userID, let deviceID = deviceID {
+          NYPLMainThreadRun.asyncIfNeeded {
+            self.userAccount.setUserID(userID)
+            self.userAccount.setDeviceID(deviceID)
+          }
+        } else {
+          success = false
+          NYPLErrorLogger.logLocalAuthFailed(error: error as NSError?,
+                                             library: self.libraryAccount,
+                                             metadata: loggingContext)
+        }
+        
+        self.finalizeSignIn(forDRMAuthorization: success,
+                            error: error as NSError?)
+    }
+  }
+  
+}
+
+#endif

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
@@ -286,7 +286,7 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider, NYPLCurrentL
 
       switch result {
       case .success(let responseData, _):
-        #if FEATURE_DRM_CONNECTOR
+        #if FEATURE_DRM_CONNECTOR || AXIS
         self.drmAuthorizeUserData(responseData, loggingContext: loggingContext)
         #else
         self.finalizeSignIn(forDRMAuthorization: true)


### PR DESCRIPTION
**What's this do?**
Removes Adept and LCP from OpenEbooks and Makes Axis360 preferred acquisition for downloading books.
With this, we no longer need any hacks to present a custom feed to the user for testing Axis content download.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3607

**How should this be tested? / Do these changes have associated tests?**
Can not be QA tested by itself. For devs, when downloading a book on OpenEbooks, a link with Axis DRM will be preferred over any other link.

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Raman Singh verified it.