### PR TITLE
SIMPLY-3670 Reconciliate old bookmark format with new format

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -398,8 +398,8 @@
 		733FF9BE2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */; };
 		733FF9BF2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */; };
 		733FF9C02530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */; };
-		7340A8B626151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340A8B526151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift */; };
-		7340A8B726151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340A8B526151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift */; };
+		7340A8B626151FDA00B2D5FA /* NYPLBookmarkDeserializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340A8B526151FDA00B2D5FA /* NYPLBookmarkDeserializationTests.swift */; };
+		7340A8B726151FDA00B2D5FA /* NYPLBookmarkDeserializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340A8B526151FDA00B2D5FA /* NYPLBookmarkDeserializationTests.swift */; };
 		7340DA6224B7E45C00361387 /* URLResponse+NYPL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */; };
 		7340DA6824B7F27900361387 /* NYPLBook+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340DA6724B7F27900361387 /* NYPLBook+Logging.swift */; };
 		73418F2B2616AAF000583569 /* valid-bookmark-3.json in Resources */ = {isa = PBXBuildFile; fileRef = 73418F252616AAF000583569 /* valid-bookmark-3.json */; };
@@ -1407,8 +1407,8 @@
 		73F6BF9F261E511200A71AB8 /* valid-R1-readingprogress-1.json in Resources */ = {isa = PBXBuildFile; fileRef = 73F6BF97261E511100A71AB8 /* valid-R1-readingprogress-1.json */; };
 		73F6BFA0261E511200A71AB8 /* valid-R1-bookmark-1.json in Resources */ = {isa = PBXBuildFile; fileRef = 73F6BF9D261E511100A71AB8 /* valid-R1-bookmark-1.json */; };
 		73F6BFA1261E511200A71AB8 /* valid-R1-bookmark-1.json in Resources */ = {isa = PBXBuildFile; fileRef = 73F6BF9D261E511100A71AB8 /* valid-R1-bookmark-1.json */; };
-		73F6BFA3261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F6BFA2261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift */; };
-		73F6BFA4261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F6BFA2261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift */; };
+		73F6BFA3261E515E00A71AB8 /* NYPLR1BookmarkDeserializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F6BFA2261E515E00A71AB8 /* NYPLR1BookmarkDeserializationTests.swift */; };
+		73F6BFA4261E515E00A71AB8 /* NYPLR1BookmarkDeserializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F6BFA2261E515E00A71AB8 /* NYPLR1BookmarkDeserializationTests.swift */; };
 		73F6BFA6261E60C400A71AB8 /* only-essential-info-bookmark.json in Resources */ = {isa = PBXBuildFile; fileRef = 73F6BFA5261E60C400A71AB8 /* only-essential-info-bookmark.json */; };
 		73F6BFA7261E60C400A71AB8 /* only-essential-info-bookmark.json in Resources */ = {isa = PBXBuildFile; fileRef = 73F6BFA5261E60C400A71AB8 /* only-essential-info-bookmark.json */; };
 		73F713562417200F00C63B81 /* NYPLEPUBViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F713502417200F00C63B81 /* NYPLEPUBViewController.swift */; };
@@ -2177,7 +2177,7 @@
 		733ED6E32617DEAA00ED8C8C /* invalid-bookmark-5.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "invalid-bookmark-5.json"; path = "Simplified-Bookmarks-Spec/invalid-bookmark-5.json"; sourceTree = SOURCE_ROOT; };
 		733EE5992620D2F6006A735C /* NYPLBookmarkSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NYPLBookmarkSerializationTests.swift; path = Bookmarks/NYPLBookmarkSerializationTests.swift; sourceTree = "<group>"; };
 		733FF9BD2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+OAuth.swift"; sourceTree = "<group>"; };
-		7340A8B526151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NYPLBookmarkDecodingTests.swift; path = Bookmarks/NYPLBookmarkDecodingTests.swift; sourceTree = "<group>"; };
+		7340A8B526151FDA00B2D5FA /* NYPLBookmarkDeserializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NYPLBookmarkDeserializationTests.swift; path = Bookmarks/NYPLBookmarkDeserializationTests.swift; sourceTree = "<group>"; };
 		7340DA6124B7E45C00361387 /* URLResponse+NYPL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLResponse+NYPL.swift"; sourceTree = "<group>"; };
 		7340DA6724B7F27900361387 /* NYPLBook+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLBook+Logging.swift"; sourceTree = "<group>"; };
 		73418F252616AAF000583569 /* valid-bookmark-3.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "valid-bookmark-3.json"; path = "Simplified-Bookmarks-Spec/valid-bookmark-3.json"; sourceTree = SOURCE_ROOT; };
@@ -2302,7 +2302,7 @@
 		73F36BD325CC76C60057954C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		73F6BF97261E511100A71AB8 /* valid-R1-readingprogress-1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "valid-R1-readingprogress-1.json"; path = "Bookmarks/valid-R1-readingprogress-1.json"; sourceTree = "<group>"; };
 		73F6BF9D261E511100A71AB8 /* valid-R1-bookmark-1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "valid-R1-bookmark-1.json"; path = "Bookmarks/valid-R1-bookmark-1.json"; sourceTree = "<group>"; };
-		73F6BFA2261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NYPLR1BookmarkDecodingTests.swift; path = Bookmarks/NYPLR1BookmarkDecodingTests.swift; sourceTree = "<group>"; };
+		73F6BFA2261E515E00A71AB8 /* NYPLR1BookmarkDeserializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NYPLR1BookmarkDeserializationTests.swift; path = Bookmarks/NYPLR1BookmarkDeserializationTests.swift; sourceTree = "<group>"; };
 		73F6BFA5261E60C400A71AB8 /* only-essential-info-bookmark.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "only-essential-info-bookmark.json"; path = "Bookmarks/only-essential-info-bookmark.json"; sourceTree = "<group>"; };
 		73F713502417200F00C63B81 /* NYPLEPUBViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NYPLEPUBViewController.swift; path = Simplified/Reader2/UI/NYPLEPUBViewController.swift; sourceTree = SOURCE_ROOT; };
 		73F713552417200F00C63B81 /* NYPLBaseReaderViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NYPLBaseReaderViewController.swift; path = Simplified/Reader2/UI/NYPLBaseReaderViewController.swift; sourceTree = SOURCE_ROOT; };
@@ -2951,8 +2951,8 @@
 				73F6BF97261E511100A71AB8 /* valid-R1-readingprogress-1.json */,
 				73F6BFA5261E60C400A71AB8 /* only-essential-info-bookmark.json */,
 				730EF262260955EF008E1DC3 /* NYPLBookmarkSpecTests.swift */,
-				7340A8B526151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift */,
-				73F6BFA2261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift */,
+				7340A8B526151FDA00B2D5FA /* NYPLBookmarkDeserializationTests.swift */,
+				73F6BFA2261E515E00A71AB8 /* NYPLR1BookmarkDeserializationTests.swift */,
 				733EE5992620D2F6006A735C /* NYPLBookmarkSerializationTests.swift */,
 			);
 			name = Bookmarks;
@@ -4755,7 +4755,7 @@
 				735771A02537635600067CEA /* NYPLSignInBusinessLogicTests.swift in Sources */,
 				17BE24DA25F85D2300AE707F /* NYPLAgeCheckTests.swift in Sources */,
 				17BE24E025FABA0900AE707F /* NYPLAgeCheckChoiceStorageMock.swift in Sources */,
-				7340A8B626151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift in Sources */,
+				7340A8B626151FDA00B2D5FA /* NYPLBookmarkDeserializationTests.swift in Sources */,
 				7375AE5A25382AC900C85211 /* NYPLUserAccountMock.swift in Sources */,
 				73C3CF5A25CB8D6100CA8166 /* NYPLNetworkExecutorMock.swift in Sources */,
 				735771AE2537687D00067CEA /* NYPLURLSettingsProviderMock.swift in Sources */,
@@ -4766,7 +4766,7 @@
 				5D73DA4322A080BA00162CB8 /* NYPLMyBooksDownloadCenterTests.swift in Sources */,
 				730D17C02552124B004CAC83 /* NYPLMyBooksDownloadsCenterMock.swift in Sources */,
 				735F41A3243E381D00046182 /* String+NYPLAdditionsTests.swift in Sources */,
-				73F6BFA3261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift in Sources */,
+				73F6BFA3261E515E00A71AB8 /* NYPLR1BookmarkDeserializationTests.swift in Sources */,
 				17BE24E725FABCDE00AE707F /* NYPLUserAccountProviderMock.swift in Sources */,
 				7311FD2B25CBD086004447CB /* NYPLSignInOutBusinessLogicUIDelegateMock.swift in Sources */,
 				173F0823241AAA4E00A64658 /* NYPLBookStateTests.swift in Sources */,
@@ -4792,7 +4792,7 @@
 				735DD0D02522A0730096D1F9 /* UserProfileDocumentTests.swift in Sources */,
 				735DD0AD252293580096D1F9 /* NYPLBookStateTests.swift in Sources */,
 				735DD0C92522A0590096D1F9 /* NYPLCatalogFacetTests.m in Sources */,
-				73F6BFA4261E515E00A71AB8 /* NYPLR1BookmarkDecodingTests.swift in Sources */,
+				73F6BFA4261E515E00A71AB8 /* NYPLR1BookmarkDeserializationTests.swift in Sources */,
 				735771A9253763E800067CEA /* NYPLBookRegistryMock.swift in Sources */,
 				737F4A542549D78100A3C34B /* NYPLBookCreationTestsObjc.m in Sources */,
 				735771A52537635D00067CEA /* NYPLSignInBusinessLogicTests.swift in Sources */,
@@ -4801,7 +4801,7 @@
 				730EF264260955EF008E1DC3 /* NYPLBookmarkSpecTests.swift in Sources */,
 				7375AE5B25382AC900C85211 /* NYPLUserAccountMock.swift in Sources */,
 				735771AF2537687D00067CEA /* NYPLURLSettingsProviderMock.swift in Sources */,
-				7340A8B726151FDA00B2D5FA /* NYPLBookmarkDecodingTests.swift in Sources */,
+				7340A8B726151FDA00B2D5FA /* NYPLBookmarkDeserializationTests.swift in Sources */,
 				733EE59B2620D2F6006A735C /* NYPLBookmarkSerializationTests.swift in Sources */,
 				735771B22537691800067CEA /* NYPLDRMAuthorizingMock.swift in Sources */,
 				73A794BE2548E36100C59CC1 /* NYPLBookCreationTests.swift in Sources */,

--- a/Simplified/Book/Models/NYPLBookRegistry.m
+++ b/Simplified/Book/Models/NYPLBookRegistry.m
@@ -584,11 +584,11 @@ genericBookmarks:(NSArray<NYPLBookLocation *> *)genericBookmarks
     NYPLBookRegistryRecord *const record = self.identifiersToRecords[identifier];
     
     NSArray<NYPLReadiumBookmark *> *sortedArray = [record.readiumBookmarks sortedArrayUsingComparator:^NSComparisonResult(NYPLReadiumBookmark *obj1, NYPLReadiumBookmark *obj2) {
-      if (obj1.progressWithinBook > obj2.progressWithinBook)
-        return NSOrderedDescending;
-      else if (obj1.progressWithinBook < obj2.progressWithinBook)
+      if ([obj1 lessThan:obj2]) {
         return NSOrderedAscending;
-      return NSOrderedSame;
+      } else {
+        return NSOrderedDescending;
+      }
     }];
       
     return sortedArray ?: [NSArray array];

--- a/Simplified/NYPLReaderReadiumView.m
+++ b/Simplified/NYPLReaderReadiumView.m
@@ -756,12 +756,13 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
   NYPLReadiumBookmark *bookmark = [[NYPLReadiumBookmark alloc]
                                   initWithAnnotationId:nil
                                   contentCFI:contentCFI
+                                  href:nil
                                   idref:idref
                                   chapter:chapter
                                   page:nil
                                   location:location.locationString
                                   progressWithinChapter:progressWithinChapter
-                                  progressWithinBook:self.progressWithinBook
+                                  progressWithinBook:[NSNumber numberWithFloat:self.progressWithinBook]
                                   creationTime:[[NSDate alloc] init]
                                   device:[[NYPLUserAccount sharedAccount] deviceID]];
   

--- a/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
@@ -212,10 +212,26 @@ import R2Shared
 
   // MARK: - Reading Position
 
+  /// _Deprecated_: for objc compatibility only.
+  ///
+  /// Use `syncReadingPosition(ofBook:publication:toURL:completion:)` instead.
+  ///
+  /// TODO: SIMPLY-2656 remove once we remove R1's code
+  class func syncReadingPosition(ofBook bookID: String?,
+                                 toURL url:URL?,
+                                 completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ()) {
+    syncReadingPosition(ofBook: bookID,
+                        publication: nil,
+                        toURL: url,
+                        completion: completion)
+  }
+
   /// Reads the current reading position from the server, parses the response
   /// and returns the result to the `completionHandler`.
-  class func syncReadingPosition(ofBook bookID: String?, toURL url:URL?,
   // TODO: SIMPLY-3668 Refactor with `syncReadingPosition(...)`
+  class func syncReadingPosition(ofBook bookID: String?,
+                                 publication: Publication?,
+                                 toURL url:URL?,
                                  completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ()) {
 
     guard syncIsPossibleAndPermitted() else {
@@ -262,7 +278,8 @@ import R2Shared
       let readPos = items
         .compactMap { NYPLBookmarkFactory.make(fromServerAnnotation: $0,
                                                annotationType: .readingProgress,
-                                               bookID: bookID) }
+                                               bookID: bookID,
+                                               publication: publication) }
         .first
       completion(readPos)
     }
@@ -370,9 +387,26 @@ import R2Shared
 
   // MARK: - Bookmarks
 
+  /// for OBJC / R1 compatibility only.
+  ///
+  /// - _Deprecated_: Use
+  /// `getServerBookmarks(forBook:publication:atURL:completion:)` instead.
+  ///
+  /// TODO: SIMPLY-2656 remove once we remove R1's code
+  class func getServerBookmarks(forBook bookID:String?,
+                                atURL annotationURL:URL?,
+                                completion: @escaping (_ bookmarks: [NYPLReadiumBookmark]?) -> ()) {
+    getServerBookmarks(forBook: bookID,
+                       publication: nil,
+                       atURL: annotationURL,
+                       completion: completion)
+  }
+
   // Completion handler will return a nil parameter if there are any failures with
   // the network request, deserialization, or sync permission is not allowed.
+  // TODO: SIMPLY-3668 Refactor with `getServerBookmarks(...)`
   class func getServerBookmarks(forBook bookID:String?,
+                                publication: Publication?,
                                 atURL annotationURL:URL?,
                                 completion: @escaping (_ bookmarks: [NYPLReadiumBookmark]?) -> ()) {
 
@@ -420,7 +454,8 @@ import R2Shared
       let bookmarks = items.compactMap {
         NYPLBookmarkFactory.make(fromServerAnnotation: $0,
                                  annotationType: .bookmark,
-                                 bookID: bookID)
+                                 bookID: bookID,
+                                 publication: publication)
       }
 
       completion(bookmarks)

--- a/Simplified/Reader2/Bookmarks/NYPLBookLocation+Locator.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLBookLocation+Locator.swift
@@ -15,6 +15,7 @@ extension NYPLBookLocation {
   convenience init?(locator: Locator,
                     publication: Publication,
                     renderer: String = NYPLBookLocation.r2Renderer) {
+    // TODO: SIMPLY-3667 refactor creation of NYPLBookmarkSpec's `selector`
     // Store all required properties of a locator object in a dictionary
     // Create a json string from it and use it as the location string in NYPLBookLocation
     // There is no specific format to follow, the value of the keys can be change if needed

--- a/Simplified/Reader2/Bookmarks/NYPLBookmarkFactory.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLBookmarkFactory.swift
@@ -11,60 +11,43 @@ import R2Shared
 
 class NYPLBookmarkFactory {
 
-  private let book: NYPLBook
-  private let publication: Publication
+  private let publication: Publication?
   private let drmDeviceID: String?
 
-  init(book: NYPLBook, publication: Publication, drmDeviceID: String?) {
-    self.book = book
+  init(publication: Publication?, drmDeviceID: String?) {
     self.publication = publication
     self.drmDeviceID = drmDeviceID
   }
 
   // MARK:- Bookmarks creation
 
-  func make(fromR2Location bookmarkLoc: NYPLBookmarkR2Location,
-            usingBookRegistry bookRegistry: NYPLBookRegistryProvider) -> NYPLReadiumBookmark? {
+  func make(fromR2Location bookmarkLoc: NYPLBookmarkR2Location) -> NYPLReadiumBookmark? {
 
     guard let progression = bookmarkLoc.locator.locations.progression else {
       return nil
     }
     let chapterProgress = Float(progression)
 
-    guard let total = bookmarkLoc.locator.locations.totalProgression else {
-      return nil
-    }
-    let totalProgress = Float(total)
+    let href = bookmarkLoc.locator.href
 
-    var page: String? = nil
+    let progressWithinBook: NSNumber?
+    if let totalProgression = bookmarkLoc.locator.locations.totalProgression {
+      progressWithinBook = NSNumber(value: totalProgression)
+    } else {
+      progressWithinBook = nil
+    }
+
+    let page: String?
     if let position = bookmarkLoc.locator.locations.position {
       page = "\(position)"
-    }
-
-    let registryLoc = bookRegistry.location(forIdentifier: book.identifier)
-    var cfi: String? = nil
-    var idref: String? = nil
-    if registryLoc?.locationString != nil,
-      let data = registryLoc?.locationString.data(using: .utf8),
-      let registryLocationJSON = try? JSONSerialization.jsonObject(with: data),
-      let registryLocationDict = registryLocationJSON as? [String: Any] {
-
-      cfi = registryLocationDict[NYPLBookmarkSpec.Target.Selector.Value.legacyLocatorCFIKey] as? String
-
-      // backup idref from R1 in case parsing from R2 fails for some reason
-      idref = registryLocationDict[NYPLBookmarkR1Key.idref.rawValue] as? String
-    }
-
-    // get the idref from R2 data structures. Should be more reliable than R1's
-    // when working with R2 since it comes directly from a R2 Locator object.
-    if let idrefFromR2 = publication.idref(forHref: bookmarkLoc.locator.href) {
-      idref = idrefFromR2
+    } else {
+      page = nil
     }
 
     let chapter: String?
     if let locatorChapter = bookmarkLoc.locator.title {
       chapter = locatorChapter
-    } else if let tocLink = publication.tableOfContents.first(withHREF: bookmarkLoc.locator.href) {
+    } else if let tocLink = publication?.tableOfContents.first(withHREF: bookmarkLoc.locator.href) {
       chapter = tocLink.title
     } else {
       chapter = nil
@@ -72,20 +55,33 @@ class NYPLBookmarkFactory {
 
     return NYPLReadiumBookmark(
       annotationId: nil,
-      contentCFI: cfi,
-      idref: idref,
+      contentCFI: nil,
+      href: href,
+      idref: nil,
       chapter: chapter,
       page: page,
-      location: registryLoc?.locationString,
+      location: nil,
       progressWithinChapter: chapterProgress,
-      progressWithinBook: totalProgress,
+      progressWithinBook: progressWithinBook,
       creationTime: bookmarkLoc.creationDate,
       device: drmDeviceID)
   }
 
+  /// Factory method to create a new bookmark from a server annotation.
+  ///
+  /// - Parameters:
+  ///   - annotation: The annotation object coming from the server in a
+  ///   JSON-like structure.
+  ///   - annotationType: Whether it's an explicit bookmark or a reading progress.
+  ///   - bookID: The book the annotation is related to.
+  ///   - publication: R2 object only used to derive the `href` if that's
+  ///   missing from the annotation, e.g. if the annotation was created on an
+  ///   R1 client.
+  /// - Returns: a client-side representation of a bookmark.
   class func make(fromServerAnnotation annotation: [String: Any],
                   annotationType: NYPLBookmarkSpec.Motivation,
-                  bookID: String) -> NYPLReadiumBookmark? {
+                  bookID: String,
+                  publication: Publication? = nil) -> NYPLReadiumBookmark? {
 
     guard let annotationID = annotation[NYPLBookmarkSpec.Id.key] as? String else {
       Log.error(#file, "Missing AnnotationID:\(annotation)")
@@ -138,11 +134,19 @@ class NYPLBookmarkFactory {
         return nil
     }
 
-    let href = selectorValueJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterIDKey] as? String
+    // either the `href` or `idref` may be nil: e.g. if we retrieved a bookmark
+    // saved by R1, `href` will be nil, and viceversa for R2. However, they
+    // should not be nil at the same time
+    var href = selectorValueJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterIDKey] as? String
     let legacyIDref = selectorValueJSON[NYPLBookmarkR1Key.idref.rawValue] as? String
-    guard let chapterID = href ?? legacyIDref else {
-        Log.error(#file, "Error reading chapter ID from server annotation. SelectorValue=\(selectorValueEscJSON)")
-        return nil
+    if href == nil && legacyIDref != nil {
+      href = publication?.href(forIdref: legacyIDref)
+    }
+
+    // if we can't derive the href, we cannot use this bookmark in R2
+    guard href != nil else {
+      Log.error(#file, "Error reading chapter ID from server annotation. SelectorValue=\(selectorValueEscJSON)")
+      return nil
     }
 
     let progress = selectorValueJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey]
@@ -150,14 +154,18 @@ class NYPLBookmarkFactory {
     let progressWithinChapter = ((progress as? Double) ?? legacyProgress as? Double) ?? 0.0
 
     // non-essential info
-    let serverCFI = selectorValueJSON[NYPLBookmarkSpec.Target.Selector.Value.legacyLocatorCFIKey] as? String
     let chapter = body["http://librarysimplified.org/terms/chapter"] as? String
-    let bookProgress = body[NYPLBookmarkSpec.Body.BookProgress.key]
-    let progressWithinBook = Float(bookProgress as? Double ?? 0.0)
+    let progressWithinBook: NSNumber?
+    if let bookProgress = body[NYPLBookmarkSpec.Body.BookProgress.key] as? Double {
+      progressWithinBook = NSNumber(value: bookProgress)
+    } else {
+      progressWithinBook = nil
+    }
 
     return NYPLReadiumBookmark(annotationId: annotationID,
-                               contentCFI: serverCFI,
-                               idref: chapterID,
+                               contentCFI: nil,
+                               href: href,
+                               idref: legacyIDref,
                                chapter: chapter,
                                page: nil,
                                location: selectorValueEscJSON,
@@ -167,18 +175,42 @@ class NYPLBookmarkFactory {
                                device:device)
   }
 
+  func parseLocatorString(_ selectorValueEscJSON: String) -> (href: String?, idref: String?, progression: Double)? {
+    guard
+      let selectorValueData = selectorValueEscJSON.data(using: String.Encoding.utf8),
+      let selectorValueJSON = (try? JSONSerialization.jsonObject(with: selectorValueData)) as? [String: Any]
+      else {
+        Log.error(#file, "Error serializing `selector`. SelectorValue=\(selectorValueEscJSON)")
+        return nil
+    }
+
+    // either the `href` or `idref` may be nil: e.g. if we retrieved a bookmark
+    // saved by R1, `href` will be nil, and viceversa for R2. However, they
+    // should not be nil at the same time
+    let href = selectorValueJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterIDKey] as? String
+    let legacyIDref = selectorValueJSON[NYPLBookmarkR1Key.idref.rawValue] as? String
+    guard let progress = selectorValueJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey] as? Double else {
+      return nil
+    }
+
+    return (href: href, idref: legacyIDref, progression: progress)
+  }
+
   // MARK:- Locators
 
-  class func makeLocatorString(chapterHref: String, chapterProgression: Float) -> String? {
-    guard chapterProgression >= 0.0, chapterProgression <= 1.0 else {
-      return nil
+  class func makeLocatorString(chapterHref: String, chapterProgression: Float) -> String {
+    var progression = chapterProgression
+    if chapterProgression < 0.0 {
+      progression = 0.0
+    } else if chapterProgression > 1.0 {
+      progression = 1.0
     }
 
     return """
     {
       "\(NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey)": "\(NYPLBookmarkSpec.Target.Selector.Value.locatorTypeValue)",
       "\(NYPLBookmarkSpec.Target.Selector.Value.locatorChapterIDKey)": "\(chapterHref)",
-      "\(NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey)": \(chapterProgression)
+      "\(NYPLBookmarkSpec.Target.Selector.Value.locatorChapterProgressionKey)": \(progression)
     }
     """
   }

--- a/Simplified/Reader2/Bookmarks/NYPLBookmarkSpec.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLBookmarkSpec.swift
@@ -191,9 +191,13 @@ extension NYPLBookmarkSpec.Body {
     static let key = "http://librarysimplified.org/terms/progressWithinBook"
 
     /// The `BookProgress` value is a % value ranged [0...1]
-    let value: Float
+    let value: Float?
 
     var dictionaryValue: [String: String] {
+      guard let value = value else {
+        return [:]
+      }
+
       return [
         BookProgress.key: String(value)
       ]

--- a/Simplified/Reader2/Bookmarks/NYPLReadiumBookmark+R2.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLReadiumBookmark+R2.swift
@@ -17,8 +17,8 @@ extension NYPLReadiumBookmark {
   /// for this conversion: only what's strictly necessary to be able to point
   /// at the same location inside the `Publication`.
   ///
-  /// - Complexity: O(*n*) where *n* is the length of internal `Publication`
-  /// data structures, such as list of chapters, resources, links.
+  /// - Complexity: O(*n*) where *n* is the length of internal
+  /// `Publication.readingOrder` data structure.
   ///
   /// - Parameter publication: The R2 publication object where the bookmark is
   /// located.
@@ -26,7 +26,12 @@ extension NYPLReadiumBookmark {
   /// - Returns: An object with R2 location information pointing at the same
   /// position the bookmark model is pointing to.
   func convertToR2(from publication: Publication) -> NYPLBookmarkR2Location? {
-    guard let link = publication.link(withIDref: self.idref) else {
+    let href: String
+    if let r2href = self.href {
+      href = r2href
+    } else if let idref = self.idref, let r1href = publication.link(withIDref: idref)?.href {
+      href = r1href
+    } else {
       return nil
     }
 
@@ -34,11 +39,12 @@ extension NYPLReadiumBookmark {
     if let page = page, let pos = Int(page) {
       position = pos
     }
-    
+
+    let bookProgress = (progressWithinBook != nil) ? Double(progressWithinBook!) : nil
     let locations = Locator.Locations(progression: Double(progressWithinChapter),
-                                      totalProgression: Double(progressWithinBook),
+                                      totalProgression: bookProgress,
                                       position: position)
-    let locator = Locator(href: link.href,
+    let locator = Locator(href: href,
                           type: publication.metadata.type ?? MediaType.xhtml.string,
                           title: self.chapter,
                           locations: locations)
@@ -52,16 +58,10 @@ extension NYPLReadiumBookmark {
                                   creationDate: creationTime)
   }
 
-
   /// Determines if a given locator matches the location addressed by this
   /// bookmark.
   ///
-  /// This function converts a Readium 2 location into information compatible
-  /// with the pre-existing Readium 1 data stored in NYPLReadiumBookmark.
-  /// This conversion should be lossless minus some Float epsilon error.
-  ///
-  /// - Complexity: O(*n*) where *n* is the length of internal Publication
-  /// data structures, such as list of chapters, resources, links.
+  /// - Complexity: O(*1*).
   ///
   /// - Parameters:
   ///   - locator: The object representing the given location in `publication`.
@@ -70,34 +70,6 @@ extension NYPLReadiumBookmark {
   /// - Returns: `true` if the `locator`'s position matches the bookmark's.
   func locationMatches(_ locator: Locator,
                        inPublication publication: Publication) -> Bool {
-    let idref = publication.idref(forHref: locator.href)
-
-    return locationMatches(locator, withIDref: idref)
-  }
-
-  /// Determines if a given locator matches the location addressed by this
-  /// bookmark.
-  ///
-  /// This function converts a Readium 2 location into information compatible
-  /// with the pre-existing Readium 1 data stored in NYPLReadiumBookmark.
-  /// This conversion should be lossless minus some Float epsilon error.
-  ///
-  /// - Complexity: O(*1*).
-  ///
-  /// - Parameters:
-  ///   - locator: The object representing the given location in `publication`.
-  ///   - locatorIDref: The ID reference of the resource the `locator` is
-  ///   contained in.
-  ///
-  /// - Returns: `true` if the `locator`'s position matches the bookmark's.
-  func locationMatches(_ locator: Locator,
-                       withIDref locatorIDref: String?) -> Bool {
-    let locatorTotalProgress: Float?
-    if let totalProgress = locator.locations.totalProgression {
-      locatorTotalProgress = Float(totalProgress)
-    } else {
-      locatorTotalProgress = nil
-    }
 
     let locatorChapterProgress: Float?
     if let chapterProgress = locator.locations.progression {
@@ -106,20 +78,13 @@ extension NYPLReadiumBookmark {
       locatorChapterProgress = nil
     }
 
-    guard self.idref == locatorIDref else {
+    guard self.href == locator.href else {
       return false
     }
 
-    if self.progressWithinBook =~= locatorChapterProgress {
+    if self.progressWithinChapter =~= locatorChapterProgress {
       return true
     }
-
-    if self.progressWithinBook =~= locatorTotalProgress {
-      return true
-    }
-
-    // note: could perhaps another condition be?
-    //   currentLocator.locations.position == bookmark.<position-is-missing>
 
     return false
   }

--- a/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionPoster.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionPoster.swift
@@ -52,7 +52,6 @@ class NYPLLastReadPositionPoster {
       return
     }
 
-    // TODO: SIMPLY-3645 don't use old school location
     guard let location = NYPLBookLocation(locator: locator, publication: publication) else {
       return
     }

--- a/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionSynchronizer.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionSynchronizer.swift
@@ -40,7 +40,7 @@ class NYPLLastReadPositionSynchronizer {
             drmDeviceID: String?,
             completion: @escaping () -> Void) {
 
-    syncReadPosition(for: book, drmDeviceID: drmDeviceID) { serverLocator in
+    syncReadPosition(for: book, publication: publication, drmDeviceID: drmDeviceID) { serverLocator in
       NYPLMainThreadRun.asyncIfNeeded {
         if let serverLocator = serverLocator {
           self.presentNavigationAlert(for: serverLocator,
@@ -69,13 +69,14 @@ class NYPLLastReadPositionSynchronizer {
   ///   completion will return that position, and `nil` in all other case.
   ///   This closure is not retained by `self`.
   private func syncReadPosition(for book: NYPLBook,
+                                publication: Publication,
                                 drmDeviceID: String?,
                                 completion: @escaping (Locator?) -> ()) {
 
     let localLocation = bookRegistry.location(forIdentifier: book.identifier)
 
     NYPLAnnotations
-      .syncReadingPosition(ofBook: book.identifier, toURL: book.annotationsURL) { bookmark in
+      .syncReadingPosition(ofBook: book.identifier, publication: publication, toURL: book.annotationsURL) { bookmark in
 
         guard let bookmark = bookmark else {
           Log.info(#function, "No reading position annotation exists on the server for \(book.loggableShortString()).")

--- a/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
@@ -33,8 +33,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
     self.bookRegistry = bookRegistryProvider
     bookmarks = bookRegistryProvider.readiumBookmarks(forIdentifier: book.identifier)
     self.currentLibraryAccountProvider = currentLibraryAccountProvider
-    self.bookmarksFactory = NYPLBookmarkFactory(book: book,
-                                                publication: publication,
+    self.bookmarksFactory = NYPLBookmarkFactory(publication: publication,
                                                 drmDeviceID: drmDeviceID)
 
     super.init()
@@ -73,9 +72,8 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
       return nil
     }
 
-    let idref = publication.idref(forHref: currentLocator.href)
-    return bookmarks.first(where: { $0.locationMatches(currentLocator,
-                                                       withIDref: idref )})
+    return bookmarks.first { $0.locationMatches(currentLocator,
+                                                inPublication: publication)}
   }
 
   /// Creates a new bookmark at the given location for the publication.
@@ -88,15 +86,13 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
   /// - Returns: A newly created bookmark object, unless the input location
   /// lacked progress information.
   func addBookmark(_ bookmarkLoc: NYPLBookmarkR2Location) -> NYPLReadiumBookmark? {
-    guard let bookmark =
-      bookmarksFactory.make(fromR2Location: bookmarkLoc,
-                            usingBookRegistry: bookRegistry) else {
-                              //TODO: log error
-                              return nil
+    guard let bookmark = bookmarksFactory.make(fromR2Location: bookmarkLoc) else {
+      Log.error(#function, "Unable to add bookmark from R2 location: \(bookmarkLoc)")
+      return nil
     }
 
     bookmarks.append(bookmark)
-    bookmarks.sort { $0.progressWithinBook < $1.progressWithinBook }
+    bookmarks.sort { $0.lessThan($1) }
 
     postBookmark(bookmark)
 
@@ -201,7 +197,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
           }
         }
         
-        NYPLAnnotations.getServerBookmarks(forBook: self.book.identifier, atURL: self.book.annotationsURL) { serverBookmarks in
+        NYPLAnnotations.getServerBookmarks(forBook: self.book.identifier, publication: self.publication, atURL: self.book.annotationsURL) { serverBookmarks in
 
           guard let serverBookmarks = serverBookmarks else {
             self.handleBookmarksSyncFail(message: "Ending sync without running completion. Returning original list of bookmarks.",

--- a/Simplified/Reader2/Internal/Publication+NYPLAdditions.swift
+++ b/Simplified/Reader2/Internal/Publication+NYPLAdditions.swift
@@ -10,24 +10,42 @@ import Foundation
 import R2Shared
 
 extension Publication {
+  static let idrefKey = "id"
 
   /// Obtains a R2 Link object from a given ID reference.
   ///
   /// This for example can be used to get the link object related to a R1
   /// bookmark by passing in the NYPLReadiumBookmark::idref.
   ///
-  /// - Complexity: O(*n*), where *n* is the length of data structures
-  /// internal to this Publication, such as resources, links, readingOrder.
+  /// - Complexity: O(*n*), where *n* is the length of `readingOrder`
+  /// data structure internal to this Publication.
   ///
-  /// - Parameter idref: The ID for the given position in the publication.
+  /// - Parameter idref: The ID for the given chapter in the publication.
   ///
   /// - Returns: The Link object matching the given ID, if it exists in the
   /// publication.
   func link(withIDref idref: String) -> Link? {
     // The Publication stores all bookmarks (and TOC; positions in general) in
-    // the `readingOrder` list. Each `Link` stores its metadata in a
+    // the `readingOrder` list of Links. Each `Link` stores its metadata in a
     // `properties` dictionary.
-    return readingOrder.first { $0.properties["id"] as? String == idref }
+    return readingOrder.first { $0.properties[Publication.idrefKey] as? String == idref }
+  }
+
+  /// Obtains a R2 HREF from a given ID reference.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of `readingOrder`
+  /// data structure internal to this Publication.
+  ///
+  /// - Parameter idref: The ID for the given chapter in the publication.
+  ///
+  /// - Returns: The HREF matching the given ID, if it exists in the
+  /// publication.
+  func href(forIdref idref: String?) -> String? {
+    guard let idref = idref else {
+      return nil
+    }
+
+    return link(withIDref: idref)?.href
   }
 
   /// Derives the `idref` (often used in Readium 1) from a Readium 2 `href`.
@@ -36,16 +54,16 @@ extension Publication {
   /// resource URI (for example from a `Link` or a `Locator` object) and
   /// need to obtain the ID of the related resource.
   ///
-  /// - Complexity: O(*n*), where *n* is the length of data structures
-  /// internal to this Publication, such as resources, links, readingOrder.
+  /// - Complexity: O(*n*), where *n* is the length of `readingOrder`
+  /// data structure internal to this Publication.
   ///
   /// - Parameter href: The URI of a resource in R2.
   ///
-  /// - Returns: The `idref` related to the resource in question. This *should*
+  /// - Returns: The `idref` related to the resource in question. This *must*
   /// be usable in R1 contexts.
   func idref(forHref href: String) -> String? {
     let link = self.link(withHREF: href)
-    return link?.properties["id"] as? String
+    return link?.properties[Publication.idrefKey] as? String
   }
 
   /// Shortcut helper to get the publication ID.

--- a/SimplifiedTests/Bookmarks/NYPLBookmarkDeserializationTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLBookmarkDeserializationTests.swift
@@ -1,5 +1,5 @@
 //
-//  NYPLBookmarkDecodingTests.swift
+//  NYPLBookmarkDeserializationTests.swift
 //  Simplified
 //
 //  Created by Ettore Pasquini on 3/31/21.
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SimplyE
 
-class NYPLBookmarkDecodingTests: XCTestCase {
+class NYPLBookmarkDeserializationTests: XCTestCase {
   var bundle: Bundle!
 
   override func setUpWithError() throws {
@@ -40,13 +40,15 @@ class NYPLBookmarkDecodingTests: XCTestCase {
     // test: make a bookmark with the data we manually read with the wrong book id
     let wrong1 = NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                           annotationType: .bookmark,
-                                          bookID: "ciccio")
+                                          bookID: "ciccio",
+                                          publication: NYPLFake.bookmarkSpecPublication)
 
     // test: make a bookmark with the data we manually read
     guard let madeBookmark =
       NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                annotationType: .bookmark,
-                               bookID: bookID) else {
+                               bookID: bookID,
+                               publication: NYPLFake.bookmarkSpecPublication) else {
                                 XCTFail("Failed to create bookmark from valid data")
                                 return
     }
@@ -80,13 +82,15 @@ class NYPLBookmarkDecodingTests: XCTestCase {
     // test: make a bookmark with the data we manually read with the wrong book id
     let wrong1 = NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                           annotationType: .readingProgress,
-                                          bookID: "ciccio")
+                                          bookID: "ciccio",
+                                          publication: NYPLFake.bookmarkSpecPublication)
 
     // test: make a bookmark with the data we manually read
     guard let madeBookmark =
       NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                annotationType: .readingProgress,
-                               bookID: bookID) else {
+                               bookID: bookID,
+                               publication: NYPLFake.bookmarkSpecPublication) else {
                                 XCTFail("Failed to create bookmark from valid data")
                                 return
     }
@@ -118,7 +122,8 @@ class NYPLBookmarkDecodingTests: XCTestCase {
     // test: make a locator with the data we manually read
     let bookmark = NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                             annotationType: .readingProgress,
-                                            bookID: bookID)
+                                            bookID: bookID,
+                                            publication: NYPLFake.bookmarkSpecPublication)
 
     // verify
     XCTAssertNil(bookmark, "should not deserialize a Bookmark without a Body section")
@@ -136,10 +141,12 @@ class NYPLBookmarkDecodingTests: XCTestCase {
     // test: make a locator with the data we manually read
     let bookmark = NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                             annotationType: .bookmark,
-                                            bookID: bookID)
+                                            bookID: bookID,
+                                            publication: NYPLFake.bookmarkSpecPublication)
     let readingProgress = NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                                    annotationType: .readingProgress,
-                                                   bookID: bookID)
+                                                   bookID: bookID,
+                                                   publication: NYPLFake.bookmarkSpecPublication)
 
     // verify
     XCTAssertNil(bookmark, "should not deserialize a Bookmark without a Motivation section")
@@ -160,7 +167,8 @@ class NYPLBookmarkDecodingTests: XCTestCase {
     // test: make a locator with the data we manually read
     let readingProgress = NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                                    annotationType: .readingProgress,
-                                                   bookID: "A book")
+                                                   bookID: "A book",
+                                                   publication: NYPLFake.bookmarkSpecPublication)
 
     // verify
     XCTAssertNil(readingProgress, "should not deserialize a Bookmark without a Target section")
@@ -183,7 +191,8 @@ class NYPLBookmarkDecodingTests: XCTestCase {
     // test: make a locator with the data we manually read
     let readingProgress = NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                                    annotationType: .readingProgress,
-                                                   bookID: bookID)
+                                                   bookID: bookID,
+                                                   publication: NYPLFake.bookmarkSpecPublication)
 
     // verify
     XCTAssertNil(readingProgress, "should not deserialize a Bookmark without a Selector section")
@@ -206,7 +215,8 @@ class NYPLBookmarkDecodingTests: XCTestCase {
     // test: make a locator with the data we manually read
     let bookmark = NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                             annotationType: .readingProgress,
-                                            bookID: bookID)
+                                            bookID: bookID,
+                                            publication: NYPLFake.bookmarkSpecPublication)
 
     // verify
     XCTAssertNil(bookmark, "should not deserialize a Bookmark without a Body-device section")
@@ -223,8 +233,6 @@ class NYPLBookmarkDecodingTests: XCTestCase {
     let device = body[NYPLBookmarkSpec.Body.Device.key] as! String
     let target = json[NYPLBookmarkSpec.Target.key] as! [String: Any]
     let bookID = target[NYPLBookmarkSpec.Target.Source.key] as! String
-    let selector = target[NYPLBookmarkSpec.Target.Selector.key] as! [String: Any]
-    let locator = selector[NYPLBookmarkSpec.Target.Selector.Value.key] as! String
     XCTAssertNil(body[NYPLBookmarkSpec.Body.Time.key],
                  "Body.time not nil, defeating purpose of unit test")
 
@@ -232,17 +240,18 @@ class NYPLBookmarkDecodingTests: XCTestCase {
     guard let madeBookmark =
       NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                annotationType: .bookmark,
-                               bookID: bookID) else {
+                               bookID: bookID,
+                               publication: NYPLFake.bookmarkSpecPublication) else {
                                 XCTFail("Failed to create bookmark from valid data")
                                 return
     }
 
     // verify
     XCTAssertEqual(madeBookmark.annotationId, annotationID)
-    XCTAssertEqual(madeBookmark.location.trimmingCharacters(in: .whitespacesAndNewlines),
-                   locator.trimmingCharacters(in: .whitespacesAndNewlines))
+    XCTAssert(madeBookmark.location.contains("/xyz.html"))
+    XCTAssert(madeBookmark.location.contains("\(madeBookmark.progressWithinChapter)"))
     XCTAssertEqual(madeBookmark.device, device)
-    XCTAssertEqual(madeBookmark.idref, "/xyz.html")
+    XCTAssertEqual(madeBookmark.href, "/xyz.html")
     XCTAssertEqual(madeBookmark.progressWithinChapter, 0.888)
     verifyLocator(href: "/xyz.html", chapterProgress: 0.888, forBookmark: madeBookmark)
   }

--- a/SimplifiedTests/Bookmarks/NYPLBookmarkSerializationTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLBookmarkSerializationTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import R2Shared
 @testable import SimplyE
 
 class NYPLBookmarkSerializationTests: XCTestCase {
@@ -18,6 +19,25 @@ class NYPLBookmarkSerializationTests: XCTestCase {
 
   override func tearDownWithError() throws {
     bundle = nil
+  }
+
+  func testSerializeFromR2() throws {
+    let locations = Locator.Locations(progression: Double(0.666),
+                                      totalProgression: Double(0.33333),
+                                      position: 123)
+    let locator = Locator(href: "/xyz.html",
+                          type: MediaType.xhtml.string,
+                          locations: locations)
+    let r2Location = NYPLBookmarkR2Location(resourceIndex: 1,
+                                           locator: locator)
+    let factory = NYPLBookmarkFactory(publication: NYPLFake.dummyPublication,
+                                      drmDeviceID: "deviceID")
+    let bookmark = factory.make(fromR2Location: r2Location)
+    XCTAssertNotNil(bookmark)
+    XCTAssertEqual(bookmark?.progressWithinChapter, Float(locations.progression!))
+    XCTAssertEqual(bookmark?.progressWithinBook, Float(locations.totalProgression!))
+    XCTAssertEqual(bookmark?.href, locator.href)
+    XCTAssertEqual(Int(bookmark!.page!), locations.position!)
   }
 
   func testSerializeBookmarkRoundrip() throws {
@@ -57,7 +77,8 @@ class NYPLBookmarkSerializationTests: XCTestCase {
     guard let bookmark =
       NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                annotationType: motivation,
-                               bookID: bookID) else {
+                               bookID: bookID,
+                               publication: NYPLFake.dummyPublication) else {
                                 XCTFail("Failed to create bookmark from valid data")
                                 return
     }

--- a/SimplifiedTests/Bookmarks/NYPLR1BookmarkDeserializationTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLR1BookmarkDeserializationTests.swift
@@ -120,13 +120,15 @@ class NYPLR1BookmarkDeserializationTests: XCTestCase {
     // preconditions
     let bookProgress: Float = 0.3684210479259491
     let chapterProgress: Float = 0.666
+    let idref = "mikhail_feminine_sign_text-12"
+    let cfi = "/4[mikhail_feminine_sign_text-12]/2/72/1:0"
     let diskRepresentation: [String: Any] = [
       NYPLBookmarkDictionaryRepresentation.annotationIdKey: "https://circulation.librarysimplified.org/NYNYPL/annotations/3195762",
       NYPLBookmarkDictionaryRepresentation.chapterKey: "Current Chapter",
-      NYPLBookmarkDictionaryRepresentation.cfiKey: "/4[mikhail_feminine_sign_text-12]/2/72/1:0",
+      NYPLBookmarkDictionaryRepresentation.cfiKey: cfi,
       NYPLBookmarkDictionaryRepresentation.deviceKey: "urn:uuid:789166c5-ed87-413a-8d9f-f306f6f02362",
-      NYPLBookmarkDictionaryRepresentation.idrefKey: "mikhail_feminine_sign_text-12",
-      NYPLBookmarkDictionaryRepresentation.locationKey: "{\"idref\":\"mikhail_feminine_sign_text-12\",\"contentCFI\":\"/4[mikhail_feminine_sign_text-12]/2/72/1:0\"}",
+      NYPLBookmarkDictionaryRepresentation.idrefKey: idref,
+      NYPLBookmarkDictionaryRepresentation.locationKey: "{\"idref\":\"\(idref)\",\"contentCFI\":\"\(cfi)\"}",
       NYPLBookmarkDictionaryRepresentation.pageKey: "",
       NYPLBookmarkDictionaryRepresentation.bookProgressKey: NSNumber(value: bookProgress),
       NYPLBookmarkDictionaryRepresentation.chapterProgressKey: NSNumber(value: chapterProgress),
@@ -150,8 +152,8 @@ class NYPLR1BookmarkDeserializationTests: XCTestCase {
                    diskRepresentation[NYPLBookmarkDictionaryRepresentation.deviceKey] as? String)
     XCTAssertEqual(bookmark.idref,
                    diskRepresentation[NYPLBookmarkDictionaryRepresentation.idrefKey] as? String)
-    XCTAssertEqual(bookmark.location,
-                   diskRepresentation[NYPLBookmarkDictionaryRepresentation.locationKey] as? String)
+    XCTAssert(bookmark.location.contains("\"idref\": \"\(idref)\""))
+    XCTAssert(bookmark.location.contains("\"contentCFI\": \"\(cfi)\""))
     XCTAssertEqual(bookmark.page!,
                    diskRepresentation[NYPLBookmarkDictionaryRepresentation.pageKey] as? String)
     XCTAssertEqual(bookmark.progressWithinBook, bookProgress)

--- a/SimplifiedTests/Bookmarks/NYPLR1BookmarkDeserializationTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLR1BookmarkDeserializationTests.swift
@@ -1,5 +1,5 @@
 //
-//  NYPLR1BookmarkDecodingTests.swift
+//  NYPLR1BookmarkDeserializationTests.swift
 //  Simplified
 //
 //  Created by Ettore Pasquini on 4/7/21.
@@ -9,7 +9,7 @@
 import XCTest
 @testable import SimplyE
 
-class NYPLR1BookmarkDecodingTests: XCTestCase {
+class NYPLR1BookmarkDeserializationTests: XCTestCase {
   var bundle: Bundle!
 
   override func setUpWithError() throws {
@@ -32,22 +32,24 @@ class NYPLR1BookmarkDecodingTests: XCTestCase {
     let time = body[NYPLBookmarkSpec.Body.Time.key] as! String
     let target = json[NYPLBookmarkSpec.Target.key] as! [String: Any]
     let bookID = target[NYPLBookmarkSpec.Target.Source.key] as! String
-    let selector = target[NYPLBookmarkSpec.Target.Selector.key] as! [String: Any]
-    let locator = selector[NYPLBookmarkSpec.Target.Selector.Value.key] as! String
+    let publication = NYPLFake.bookmarkSpecPublication
 
     // test: make bookmark with the wrong book id or annotation type
     let wrong1 = NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                           annotationType: .bookmark,
-                                          bookID: "ciccio")
+                                          bookID: "ciccio",
+                                          publication: publication)
     let wrong2 = NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                           annotationType: .readingProgress,
-                                          bookID: bookID)
+                                          bookID: bookID,
+                                          publication: publication)
 
     // test: make a bookmark with the data we manually read
     guard let madeBookmark =
       NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                annotationType: .bookmark,
-                               bookID: bookID) else {
+                               bookID: bookID,
+                               publication: publication) else {
                                 XCTFail("Failed to create bookmark from valid data")
                                 return
     }
@@ -56,8 +58,9 @@ class NYPLR1BookmarkDecodingTests: XCTestCase {
     XCTAssertNil(wrong1)
     XCTAssertNil(wrong2)
     XCTAssertEqual(madeBookmark.annotationId, annotationID)
-    XCTAssertEqual(madeBookmark.location.trimmingCharacters(in: .whitespacesAndNewlines),
-                   locator.trimmingCharacters(in: .whitespacesAndNewlines))
+    XCTAssertEqual(madeBookmark.href, "/xyz.html")
+    XCTAssert(madeBookmark.location.contains(madeBookmark.href!))
+    XCTAssert(madeBookmark.location.contains("0.7471264"))
     XCTAssertEqual(madeBookmark.device, device)
     XCTAssertEqual(madeBookmark.timestamp, time)
     XCTAssertEqual(madeBookmark.idref, "c001")
@@ -77,24 +80,26 @@ class NYPLR1BookmarkDecodingTests: XCTestCase {
     let time = body[NYPLBookmarkSpec.Body.Time.key] as! String
     let target = json[NYPLBookmarkSpec.Target.key] as! [String: Any]
     let bookID = target[NYPLBookmarkSpec.Target.Source.key] as! String
-    let selector = target[NYPLBookmarkSpec.Target.Selector.key] as! [String: Any]
-    let locator = selector[NYPLBookmarkSpec.Target.Selector.Value.key] as! String
     let motivationRaw = json[NYPLBookmarkSpec.Motivation.key] as! String
     let motivation = NYPLBookmarkSpec.Motivation(rawValue: motivationRaw)!
+    let publication = NYPLFake.bookmarkSpecPublication
 
     // test: make bookmark with the wrong book id or annotation type
     let wrong1 = NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                           annotationType: motivation,
-                                          bookID: "ciccio")
+                                          bookID: "ciccio",
+                                          publication: publication)
     let wrong2 = NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                           annotationType: .bookmark,
-                                          bookID: bookID)
+                                          bookID: bookID,
+                                          publication: publication)
 
     // test: make a bookmark with the data we manually read
     guard let madeBookmark =
       NYPLBookmarkFactory.make(fromServerAnnotation: json,
                                annotationType: motivation,
-                               bookID: bookID) else {
+                               bookID: bookID,
+                               publication: publication) else {
                                 XCTFail("Failed to create bookmark from valid data")
                                 return
     }
@@ -103,12 +108,11 @@ class NYPLR1BookmarkDecodingTests: XCTestCase {
     XCTAssertNil(wrong1)
     XCTAssertNil(wrong2)
     XCTAssertEqual(madeBookmark.annotationId, annotationID)
-    XCTAssertEqual(madeBookmark.location.trimmingCharacters(in: .whitespacesAndNewlines),
-                   locator.trimmingCharacters(in: .whitespacesAndNewlines))
+    XCTAssertEqual(madeBookmark.href, "/xyz.html")
+    XCTAssert(madeBookmark.location.contains(madeBookmark.href!))
     XCTAssertEqual(madeBookmark.device, device)
     XCTAssertEqual(madeBookmark.timestamp, time)
     XCTAssertEqual(madeBookmark.idref, "c001")
-    XCTAssertEqual(madeBookmark.contentCFI, "/4/4/638/1:30")
   }
 
   // This covers the case of bookmarks retrieved from disk

--- a/SimplifiedTests/Mocks/NYPLBookRegistryMock.swift
+++ b/SimplifiedTests/Mocks/NYPLBookRegistryMock.swift
@@ -37,7 +37,7 @@ class NYPLBookRegistryMock: NSObject, NYPLBookRegistrySyncing, NYPLBookRegistryP
     
   func readiumBookmarks(forIdentifier identifier: String) -> [NYPLReadiumBookmark] {
     guard let record = identifiersToRecords[identifier] else { return [NYPLReadiumBookmark]() }
-    return record.readiumBookmarks.sorted{ $0.progressWithinBook > $1.progressWithinBook }
+    return record.readiumBookmarks.sorted { $0.lessThan($1) }
   }
   
   func location(forIdentifier identifier: String) -> NYPLBookLocation? {

--- a/SimplifiedTests/NYPLFake.swift
+++ b/SimplifiedTests/NYPLFake.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import R2Shared
 @testable import SimplyE
 
 class NYPLFake {
@@ -58,5 +59,37 @@ class NYPLFake {
     }
   }
   """
+
+  class var dummyPublication: Publication {
+    return Publication(
+      manifest: Manifest(
+        metadata: Metadata(title: "Title"),
+        readingOrder: [
+          Link(href: "chapter1", type: "text/html"),
+          Link(href: "chapter2", type: "text/html")
+        ]
+      )
+    )
+  }
+
+  class var bookmarkSpecPublication: Publication {
+    return Publication(
+      manifest: Manifest(
+        metadata: Metadata(title: "Title"),
+        readingOrder: [
+          Link(href: "/xyz.html",
+               type: "text/html",
+               properties: Properties([
+                Publication.idrefKey: "c001"
+               ])),
+          Link(href: "dos.html",
+               type: "text/html",
+               properties: Properties([
+                Publication.idrefKey: "c002"
+               ]))
+        ]
+      )
+    )
+  }
 
 }

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -203,12 +203,13 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       bookmarkCounter += 1
       return NYPLReadiumBookmark(annotationId: "fakeAnnotationID\(bookmarkCounter)",
                                  contentCFI: "",
+                                 href: nil,
                                  idref: idref,
                                  chapter: chapter,
                                  page: nil,
                                  location: nil,
                                  progressWithinChapter: progressWithinChapter,
-                                 progressWithinBook: progressWithinBook,
+                                 progressWithinBook: NSNumber(value: progressWithinBook),
                                  creationTime: Date(),
                                  device:device)
     }

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -82,10 +82,10 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       // Make sure BookRegistry contains no bookmark
       XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
       
-      guard let firstBookmark = newBookmark(idref: "Intro",
-                                          chapter: "1",
-                                          progressWithinChapter: 0.1,
-                                          progressWithinBook: 0.1) else {
+      guard let firstBookmark = newBookmark(href: "Intro",
+                                            chapter: "1",
+                                            progressWithinChapter: 0.1,
+                                            progressWithinBook: 0.1) else {
         XCTFail("Failed to create new bookmark")
         return
       }
@@ -104,11 +104,11 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       // Make sure BookRegistry contains no bookmark
       XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
       
-      guard let firstBookmark = newBookmark(idref: "Intro",
-                                          chapter: "1",
-                                          progressWithinChapter: 0.1,
-                                          progressWithinBook: 0.1),
-        let secondBookmark = newBookmark(idref: "Intro",
+      guard let firstBookmark = newBookmark(href: "Intro",
+                                            chapter: "1",
+                                            progressWithinChapter: 0.1,
+                                            progressWithinBook: 0.1),
+        let secondBookmark = newBookmark(href: "Intro",
                                          chapter: "1",
                                          progressWithinChapter: 0.2,
                                          progressWithinBook: 0.1) else {
@@ -135,11 +135,11 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       // Make sure BookRegistry contains no bookmark
       XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
       
-      guard let firstBookmark = newBookmark(idref: "Intro",
-                                          chapter: "1",
-                                          progressWithinChapter: 0.1,
-                                          progressWithinBook: 0.1),
-        let secondBookmark = newBookmark(idref: "Intro",
+      guard let firstBookmark = newBookmark(href: "Intro",
+                                            chapter: "1",
+                                            progressWithinChapter: 0.1,
+                                            progressWithinBook: 0.1),
+        let secondBookmark = newBookmark(href: "Intro",
                                          chapter: "1",
                                          progressWithinChapter: 0.2,
                                          progressWithinBook: 0.1) else {
@@ -167,11 +167,11 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       // Make sure BookRegistry contains no bookmark
       XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
       
-      guard let firstBookmark = newBookmark(idref: "Intro",
-                                          chapter: "1",
-                                          progressWithinChapter: 0.1,
-                                          progressWithinBook: 0.1),
-        let secondBookmark = newBookmark(idref: "Intro",
+      guard let firstBookmark = newBookmark(href: "Intro",
+                                            chapter: "1",
+                                            progressWithinChapter: 0.1,
+                                            progressWithinBook: 0.1),
+        let secondBookmark = newBookmark(href: "Intro",
                                          chapter: "1",
                                          progressWithinChapter: 0.2,
                                          progressWithinBook: 0.1) else {
@@ -193,18 +193,18 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
 
     // MARK: Helper
     
-    func newBookmark(idref: String,
-                     chapter: String,
-                     progressWithinChapter: Float,
-                     progressWithinBook: Float,
-                     device: String? = nil) -> NYPLReadiumBookmark? {
+    private func newBookmark(href: String,
+                             chapter: String,
+                             progressWithinChapter: Float,
+                             progressWithinBook: Float,
+                             device: String? = nil) -> NYPLReadiumBookmark? {
       // Annotation id needs to be unique
       // contentCFI should be empty string for R2 bookmark
       bookmarkCounter += 1
       return NYPLReadiumBookmark(annotationId: "fakeAnnotationID\(bookmarkCounter)",
                                  contentCFI: "",
-                                 href: nil,
-                                 idref: idref,
+                                 href: href,
+                                 idref: nil,
                                  chapter: chapter,
                                  page: nil,
                                  location: nil,


### PR DESCRIPTION
**What's this do?**
Enforces creation of new bookmarks following the spec. This now includes:
- when creating a bookmark in a ereader context, we use the R2 Publication object to derive the `href` upfront and store it in the bookmark, instead of doing it later. 
- when creating a bookmark from the dictionary representation, the `href` may be nil if the bookmark was created in R1. In this case the `href` can be derived only when we open the book. However in this case the `idref` MUST be not nil. This is now expressed at compile time via the `ChapterID` enum.
- when creating a dictionary representation, always save all fields required by the spec, and not old ones
- mark the total progression as non-optional, per bookmark spec.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3670

**How should this be tested? / Do these changes have associated tests?**
too early to test, this is just a subtask. 

**Dependencies for merging? Releasing to production?**
merging to feature branch.

**Does this include changes that require a new SimplyE build for QA?**
not yet

**Has the application documentation been updated for these changes?**
yes, expanded existing docs.

**Did someone actually run this code to verify it works?**
@ettore 