### PR TITLE
SIMPLY-3668 Refactor GET annotations api calls

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1087,6 +1087,10 @@
 		73CEF830252699CA006B2820 /* FirebaseCrashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73CEF82F252699C9006B2820 /* FirebaseCrashlytics.framework */; };
 		73CEF831252699DD006B2820 /* FirebaseCrashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73CEF82F252699C9006B2820 /* FirebaseCrashlytics.framework */; };
 		73CEF832252699DD006B2820 /* FirebaseCrashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73CEF82F252699C9006B2820 /* FirebaseCrashlytics.framework */; };
+		73D4DC192627A0C0005CAFFA /* NYPLAnnotationResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D4DC182627A0C0005CAFFA /* NYPLAnnotationResponseTests.swift */; };
+		73D4DC1A2627A0C0005CAFFA /* NYPLAnnotationResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D4DC182627A0C0005CAFFA /* NYPLAnnotationResponseTests.swift */; };
+		73D4DC212627B1DB005CAFFA /* annotation-response.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D4DC202627B1DA005CAFFA /* annotation-response.json */; };
+		73D4DC222627B1DB005CAFFA /* annotation-response.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D4DC202627B1DA005CAFFA /* annotation-response.json */; };
 		73D8D26825A68C6500DF5F69 /* NYPLR2Owner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A2299A240F3B9B006B9EAD /* NYPLR2Owner.swift */; };
 		73D8D26E25A68CA900DF5F69 /* LibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A2299E240F3BEA006B9EAD /* LibraryService.swift */; };
 		73D8D27025A68CC400DF5F69 /* NYPLReaderTOCCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7386C1F9245276CA004C78BD /* NYPLReaderTOCCell.swift */; };
@@ -2275,6 +2279,8 @@
 		73CEF8352526FE80006B2820 /* run */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = run; sourceTree = "<group>"; };
 		73CEF8362526FE80006B2820 /* upload-symbols */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = "upload-symbols"; sourceTree = "<group>"; };
 		73CEF83E25270F38006B2820 /* adobe-rmsdk-build.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = "adobe-rmsdk-build.sh"; path = "scripts/adobe-rmsdk-build.sh"; sourceTree = SOURCE_ROOT; };
+		73D4DC182627A0C0005CAFFA /* NYPLAnnotationResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NYPLAnnotationResponseTests.swift; path = Bookmarks/NYPLAnnotationResponseTests.swift; sourceTree = "<group>"; };
+		73D4DC202627B1DA005CAFFA /* annotation-response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "annotation-response.json"; path = "Bookmarks/annotation-response.json"; sourceTree = "<group>"; };
 		73DA43A12404B4A900985482 /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = SOURCE_ROOT; };
 		73DA43A32404B92E00985482 /* Cartfile.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = SOURCE_ROOT; };
 		73DA43A62404BA5600985482 /* build-carthage.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = "build-carthage.sh"; path = "scripts/build-carthage.sh"; sourceTree = SOURCE_ROOT; };
@@ -2950,10 +2956,12 @@
 				73F6BF9D261E511100A71AB8 /* valid-R1-bookmark-1.json */,
 				73F6BF97261E511100A71AB8 /* valid-R1-readingprogress-1.json */,
 				73F6BFA5261E60C400A71AB8 /* only-essential-info-bookmark.json */,
+				73D4DC202627B1DA005CAFFA /* annotation-response.json */,
 				730EF262260955EF008E1DC3 /* NYPLBookmarkSpecTests.swift */,
 				7340A8B526151FDA00B2D5FA /* NYPLBookmarkDeserializationTests.swift */,
 				73F6BFA2261E515E00A71AB8 /* NYPLR1BookmarkDeserializationTests.swift */,
 				733EE5992620D2F6006A735C /* NYPLBookmarkSerializationTests.swift */,
+				73D4DC182627A0C0005CAFFA /* NYPLAnnotationResponseTests.swift */,
 			);
 			name = Bookmarks;
 			sourceTree = "<group>";
@@ -4159,6 +4167,7 @@
 				B51C1E17229456E2003B49A5 /* acl_authentication_document.json in Resources */,
 				730EF24F26093E40008E1DC3 /* invalid-locator-4.json in Resources */,
 				219901FB24FD2E56001BC727 /* jwk_public in Resources */,
+				73D4DC212627B1DB005CAFFA /* annotation-response.json in Resources */,
 				B51C1E1A229456E2003B49A5 /* dpl_authentication_document.json in Resources */,
 				730EF24D26093E40008E1DC3 /* invalid-locator-3.json in Resources */,
 				730EF25A26093E53008E1DC3 /* valid-bookmark-0.json in Resources */,
@@ -4193,6 +4202,7 @@
 				730EF24C26093E40008E1DC3 /* invalid-bookmark-0.json in Resources */,
 				730EF24226093E40008E1DC3 /* invalid-locator-1.json in Resources */,
 				730EF24626093E40008E1DC3 /* invalid-bookmark-3.json in Resources */,
+				73D4DC222627B1DB005CAFFA /* annotation-response.json in Resources */,
 				730EF24A26093E40008E1DC3 /* invalid-bookmark-1.json in Resources */,
 				7320AB3B251EBC9900E3F04D /* UpdateCheckNeedsUpdate.json in Resources */,
 				730EF25F26093E53008E1DC3 /* valid-locator-0.json in Resources */,
@@ -4750,6 +4760,7 @@
 				7384C800242BB43400D5F960 /* NYPLCachingTests.swift in Sources */,
 				5D3A28D522D400D00042B3BD /* UserProfileDocumentTests.swift in Sources */,
 				7307A5ED23FF1A8500DE53DE /* NYPLOpenSearchDescriptionTests.swift in Sources */,
+				73D4DC192627A0C0005CAFFA /* NYPLAnnotationResponseTests.swift in Sources */,
 				735771A8253763E800067CEA /* NYPLBookRegistryMock.swift in Sources */,
 				737F4A532549D78100A3C34B /* NYPLBookCreationTestsObjc.m in Sources */,
 				735771A02537635600067CEA /* NYPLSignInBusinessLogicTests.swift in Sources */,
@@ -4808,6 +4819,7 @@
 				735DD0CD2522A0730096D1F9 /* String+NYPLAdditionsTests.swift in Sources */,
 				730D17C12552124B004CAC83 /* NYPLMyBooksDownloadsCenterMock.swift in Sources */,
 				735DD0AF252293700096D1F9 /* NYPLMyBooksDownloadCenterTests.swift in Sources */,
+				73D4DC1A2627A0C0005CAFFA /* NYPLAnnotationResponseTests.swift in Sources */,
 				7311FD2C25CBD086004447CB /* NYPLSignInOutBusinessLogicUIDelegateMock.swift in Sources */,
 				7320AB51251EC07300E3F04D /* NYPLOPDSAcquisitionPathTests.swift in Sources */,
 				735DD0D12522A0730096D1F9 /* URLRequest+NYPLTests.swift in Sources */,

--- a/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
@@ -228,7 +228,6 @@ import R2Shared
 
   /// Reads the current reading position from the server, parses the response
   /// and returns the result to the `completionHandler`.
-  // TODO: SIMPLY-3668 Refactor with `syncReadingPosition(...)`
   class func syncReadingPosition(ofBook bookID: String?,
                                  publication: Publication?,
                                  toURL url:URL?,
@@ -249,38 +248,15 @@ import R2Shared
     var request = URLRequest(url: url,
                              cachePolicy: .reloadIgnoringLocalCacheData,
                              timeoutInterval: NYPLDefaultRequestTimeout)
-    request.httpMethod = "GET"
     setDefaultAnnotationHeaders(forRequest: &request)
 
-    let dataTask = URLSession.shared.dataTask(with: request) { (data, response, error) in
-
-      if let error = error as NSError? {
-        Log.error(#file, "Request Error Code: \(error.code). Description: \(error.localizedDescription)")
-        completion(nil)
-        return
-      }
-
-      guard let data = data,
-        let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []),
-        let json = jsonObject as? [String: Any] else {
-          Log.error(#file, "Response from annotation server could not be serialized.")
-          completion(nil)
-          return
-      }
-
-      guard let first = json["first"] as? [String: Any],
-        let items = first["items"] as? [[String: Any]] else {
-          Log.error(#file, "Missing required key from Annotations response, or no items exist.")
-          completion(nil)
-          return
-      }
-
-      let readPos = items
-        .compactMap { NYPLBookmarkFactory.make(fromServerAnnotation: $0,
-                                               annotationType: .readingProgress,
-                                               bookID: bookID,
-                                               publication: publication) }
-        .first
+    let dataTask = URLSession.shared.dataTask(with: request) { (data, _, error) in
+      let bookmarks = parseAnnotationsResponse(data,
+                                               error: error,
+                                               motivation: .readingProgress,
+                                               publication: publication,
+                                               bookID: bookID)
+      let readPos = bookmarks?.first
       completion(readPos)
     }
     dataTask.resume()
@@ -310,81 +286,6 @@ import R2Shared
     }
   }
 
-  /// Serializes the `parameters` into JSON and POSTs them to the server.
-  class func postAnnotation(forBook bookID: String,
-                            withParameters parameters: [String: Any],
-                            timeout: TimeInterval = NYPLDefaultRequestTimeout,
-                            queueOffline: Bool,
-                            _ completionHandler: @escaping (_ success: Bool, _ annotationID: String?) -> ()) {
-
-    guard syncIsPossibleAndPermitted() else {
-      Log.debug(#file, "Account does not support sync or sync is disabled.")
-      completionHandler(false, nil)
-      return
-    }
-
-    guard let annotationsURL = NYPLAnnotations.annotationsURL else {
-      Log.error(#file, "Annotations URL was nil while attempting to post")
-      completionHandler(false, nil)
-      return
-    }
-
-    guard let jsonData = makeSubmissionData(fromRepresentation: parameters) else {
-      Log.error(#file, "Network request abandoned. Could not create JSON from given parameters.")
-      completionHandler(false, nil)
-      return
-    }
-    
-    var request = URLRequest(url: annotationsURL)
-    request.httpMethod = "POST"
-    request.httpBody = jsonData
-    setDefaultAnnotationHeaders(forRequest: &request)
-    request.timeoutInterval = timeout
-
-    let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
-      if let error = error as NSError? {
-        Log.error(#file, "Annotation POST error (nsCode: \(error.code) Description: \(error.localizedDescription))")
-        if (NetworkQueue.StatusCodes.contains(error.code)) && (queueOffline == true) {
-          self.addToOfflineQueue(bookID, annotationsURL, parameters)
-        }
-        completionHandler(false, nil)
-        return
-      }
-      guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {
-        Log.error(#file, "Annotation POST error: No response received from server")
-        completionHandler(false, nil)
-        return
-      }
-
-      if statusCode == 200 {
-        Log.debug(#file, "Annotation POST: Success 200.")
-        let serverAnnotationID = annotationID(fromNetworkData: data)
-        completionHandler(true, serverAnnotationID)
-      } else {
-        Log.error(#file, "Annotation POST: Response Error. Status Code: \(statusCode)")
-        completionHandler(false, nil)
-      }
-    }
-    task.resume()
-  }
-
-  private class func annotationID(fromNetworkData data: Data?) -> String? {
-    guard let data = data else {
-      Log.error(#file, "No Annotation ID saved: No data received from server.")
-      return nil
-    }
-    guard let json = try? JSONSerialization.jsonObject(with: data, options: []) as! [String:Any] else {
-      Log.error(#file, "No Annotation ID saved: JSON could not be created from data.")
-      return nil
-    }
-    if let annotationID = json[NYPLBookmarkSpec.Id.key] as? String {
-      return annotationID
-    } else {
-      Log.error(#file, "No Annotation ID saved: Key/Value not found in JSON response.")
-      return nil
-    }
-  }
-
   // MARK: - Bookmarks
 
   /// for OBJC / R1 compatibility only.
@@ -404,7 +305,6 @@ import R2Shared
 
   // Completion handler will return a nil parameter if there are any failures with
   // the network request, deserialization, or sync permission is not allowed.
-  // TODO: SIMPLY-3668 Refactor with `getServerBookmarks(...)`
   class func getServerBookmarks(forBook bookID:String?,
                                 publication: Publication?,
                                 atURL annotationURL:URL?,
@@ -425,39 +325,14 @@ import R2Shared
     var request = URLRequest(url: annotationURL,
                              cachePolicy: .reloadIgnoringLocalCacheData,
                              timeoutInterval: NYPLDefaultRequestTimeout)
-    request.httpMethod = "GET"
     setDefaultAnnotationHeaders(forRequest: &request)
-    
+
     let dataTask = URLSession.shared.dataTask(with: request) { (data, response, error) in
-      
-      if let error = error as NSError? {
-        Log.error(#file, "Request Error Code: \(error.code). Description: \(error.localizedDescription)")
-        completion(nil)
-        return
-      }
-
-      guard let data = data,
-        let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []),
-        let json = jsonObject as? [String: Any] else {
-          Log.error(#file, "Response from annotation server could not be serialized.")
-          completion(nil)
-          return
-      }
-
-      guard let first = json["first"] as? [String: Any],
-        let items = first["items"] as? [[String: Any]] else {
-          Log.error(#file, "Missing required key from Annotations response, or no items exist.")
-          completion(nil)
-          return
-      }
-
-      let bookmarks = items.compactMap {
-        NYPLBookmarkFactory.make(fromServerAnnotation: $0,
-                                 annotationType: .bookmark,
-                                 bookID: bookID,
-                                 publication: publication)
-      }
-
+      let bookmarks = parseAnnotationsResponse(data,
+                                               error: error,
+                                               motivation: .bookmark,
+                                               publication: publication,
+                                               bookID: bookID)
       completion(bookmarks)
     }
     dataTask.resume()
@@ -590,7 +465,116 @@ import R2Shared
     }
   }
 
-  // MARK: -
+  // MARK:- Helpers / Private methods
+
+  class func parseAnnotationsResponse(_ data: Data?,
+                                      error: Error?,
+                                      motivation: NYPLBookmarkSpec.Motivation,
+                                      publication: Publication?,
+                                      bookID: String) -> [NYPLReadiumBookmark]? {
+    if let error = error as NSError? {
+      Log.error(#file, "Request Error Code: \(error.code). Description: \(error.localizedDescription)")
+      return nil
+    }
+
+    guard let data = data,
+      let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []),
+      let json = jsonObject as? [String: Any] else {
+        Log.error(#file, "Response from annotation server could not be serialized.")
+        return nil
+    }
+
+    guard let first = json["first"] as? [String: Any],
+      let items = first["items"] as? [[String: Any]] else {
+        Log.error(#file, "Missing required key from Annotations response, or no items exist.")
+        return nil
+    }
+
+    let bookmarks = items.compactMap {
+      NYPLBookmarkFactory.make(fromServerAnnotation: $0,
+                               annotationType: motivation,
+                               bookID: bookID,
+                               publication: publication)
+    }
+
+    return bookmarks
+  }
+
+  /// Serializes the `parameters` into JSON and POSTs them to the server.
+  private class func postAnnotation(
+    forBook bookID: String,
+    withParameters parameters: [String: Any],
+    timeout: TimeInterval = NYPLDefaultRequestTimeout,
+    queueOffline: Bool,
+    _ completionHandler: @escaping (_ success: Bool, _ annotationID: String?) -> ()) {
+
+    guard syncIsPossibleAndPermitted() else {
+      Log.debug(#file, "Account does not support sync or sync is disabled.")
+      completionHandler(false, nil)
+      return
+    }
+
+    guard let annotationsURL = NYPLAnnotations.annotationsURL else {
+      Log.error(#file, "Annotations URL was nil while attempting to post")
+      completionHandler(false, nil)
+      return
+    }
+
+    guard let jsonData = makeSubmissionData(fromRepresentation: parameters) else {
+      Log.error(#file, "Network request abandoned. Could not create JSON from given parameters.")
+      completionHandler(false, nil)
+      return
+    }
+
+    var request = URLRequest(url: annotationsURL)
+    request.httpMethod = "POST"
+    request.httpBody = jsonData
+    setDefaultAnnotationHeaders(forRequest: &request)
+    request.timeoutInterval = timeout
+
+    let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+      if let error = error as NSError? {
+        Log.error(#file, "Annotation POST error (nsCode: \(error.code) Description: \(error.localizedDescription))")
+        if (NetworkQueue.StatusCodes.contains(error.code)) && (queueOffline == true) {
+          self.addToOfflineQueue(bookID, annotationsURL, parameters)
+        }
+        completionHandler(false, nil)
+        return
+      }
+      guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {
+        Log.error(#file, "Annotation POST error: No response received from server")
+        completionHandler(false, nil)
+        return
+      }
+
+      if statusCode == 200 {
+        Log.debug(#file, "Annotation POST: Success 200.")
+        let serverAnnotationID = annotationID(fromNetworkData: data)
+        completionHandler(true, serverAnnotationID)
+      } else {
+        Log.error(#file, "Annotation POST: Response Error. Status Code: \(statusCode)")
+        completionHandler(false, nil)
+      }
+    }
+    task.resume()
+  }
+
+  private class func annotationID(fromNetworkData data: Data?) -> String? {
+    guard let data = data else {
+      Log.error(#file, "No Annotation ID saved: No data received from server.")
+      return nil
+    }
+    guard let json = try? JSONSerialization.jsonObject(with: data, options: []) as! [String:Any] else {
+      Log.error(#file, "No Annotation ID saved: JSON could not be created from data.")
+      return nil
+    }
+    if let annotationID = json[NYPLBookmarkSpec.Id.key] as? String {
+      return annotationID
+    } else {
+      Log.error(#file, "No Annotation ID saved: Key/Value not found in JSON response.")
+      return nil
+    }
+  }
 
   /// Annotation-syncing is possible only if the given `account` is signed-in
   /// and if the currently selected library supports it.

--- a/Simplified/Reader2/Bookmarks/NYPLBookmarkFactory.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLBookmarkFactory.swift
@@ -87,7 +87,8 @@ class NYPLBookmarkFactory {
       return nil
     }
 
-    guard let target = annotation[NYPLBookmarkSpec.Target.key] as? [String: Any],
+    guard
+      let target = annotation[NYPLBookmarkSpec.Target.key] as? [String: Any],
       let source = target[NYPLBookmarkSpec.Target.Source.key] as? String,
       let motivation = annotation[NYPLBookmarkSpec.Motivation.key] as? String,
       let body = annotation[NYPLBookmarkSpec.Body.key] as? [String: Any]
@@ -143,6 +144,10 @@ class NYPLBookmarkFactory {
     let chapter = body["http://librarysimplified.org/terms/chapter"] as? String
     let progressWithinBook: NSNumber?
     if let bookProgress = body[NYPLBookmarkSpec.Body.BookProgress.key] as? Double {
+      progressWithinBook = NSNumber(value: bookProgress)
+    } else if let bookProgressStr = body[NYPLBookmarkSpec.Body.BookProgress.key] as? String,
+      let bookProgress = Double(bookProgressStr)
+    {
       progressWithinBook = NSNumber(value: bookProgress)
     } else {
       progressWithinBook = nil

--- a/SimplifiedTests/Bookmarks/NYPLAnnotationResponseTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLAnnotationResponseTests.swift
@@ -1,0 +1,80 @@
+//
+//  NYPLAnnotationResponseTests.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 4/14/21.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import XCTest
+import R2Shared
+@testable import SimplyE
+
+class NYPLAnnotationResponseTests: XCTestCase {
+  var bundle: Bundle!
+  var responseData: Data!
+  var publication: Publication!
+  let bookID = "urn:librarysimplified.org/terms/id/book1"
+
+  override func setUpWithError() throws {
+    // preconditions
+    bundle = Bundle(for: NYPLBookmarkSpecTests.self)
+    let annotationResponseURL = bundle.url(forResource: "annotation-response",
+                                           withExtension: "json")!
+    let annotationData = try Data(contentsOf: annotationResponseURL)
+    let json = try JSONSerialization.jsonObject(with: annotationData) as! [String: Any]
+    responseData = NYPLAnnotations.makeSubmissionData(fromRepresentation: json)
+    publication = NYPLFake.bookmarkSpecPublication
+  }
+
+  override func tearDownWithError() throws {
+    bundle = nil
+    responseData = nil
+    publication = nil
+  }
+
+  func testParseAnnotationsResponseForReadingProgress() throws {
+    // test
+    let annotations = NYPLAnnotations.parseAnnotationsResponse(responseData,
+                                                               error: nil,
+                                                               motivation: .readingProgress,
+                                                               publication: publication,
+                                                               bookID: bookID)
+
+    // verify
+    XCTAssertNotNil(annotations)
+    XCTAssertEqual(annotations!.count, 1)
+    let readingProgress = annotations!.first!
+    XCTAssertNotNil(readingProgress)
+    XCTAssertEqual(readingProgress.timestamp, "2021-04-14T22:49:41Z")
+    XCTAssertEqual(readingProgress.device!,
+                   "urn:uuid:789166c5-ed87-413a-8d9f-f306f6f02362")
+    XCTAssertEqual(readingProgress.annotationId!,
+                   "https://circulation.librarysimplified.org/NYNYPL/annotations/3217539")
+    XCTAssertEqual(readingProgress.progressWithinChapter, 0.666)
+    XCTAssertEqual(readingProgress.href!, "/xyz.html")
+  }
+
+  func testParseAnnotationsResponseForBookmarks() throws {
+    // test
+    let annotations = NYPLAnnotations.parseAnnotationsResponse(responseData,
+                                                               error: nil,
+                                                               motivation: .bookmark,
+                                                               publication: publication,
+                                                               bookID: bookID)
+
+    // verify
+    XCTAssertNotNil(annotations)
+    XCTAssertEqual(annotations!.count, 1)
+    let bookmark = annotations!.first!
+    XCTAssertNotNil(bookmark)
+    XCTAssertEqual(bookmark.timestamp, "2021-04-14T22:50:04Z")
+    XCTAssertEqual(bookmark.device!,
+                   "urn:uuid:789166c5-ed87-413a-8d9f-f306f6f02362")
+    XCTAssertEqual(bookmark.annotationId!,
+                   "https://circulation.librarysimplified.org/NYNYPL/annotations/3217569")
+    XCTAssertEqual(bookmark.progressWithinChapter, 0.09090909)
+    XCTAssertEqual(bookmark.progressWithinBook, 0.13910505)
+    XCTAssertEqual(bookmark.href!, "/xyz.html")
+  }
+}

--- a/SimplifiedTests/Bookmarks/NYPLBookmarkSpecTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLBookmarkSpecTests.swift
@@ -9,10 +9,6 @@
 import XCTest
 @testable import SimplyE
 
-/**
- things to test:
-  - SIMPLY-3668: bookmark post request body (new format)
- */
 class NYPLBookmarkSpecTests: XCTestCase {
   var bundle: Bundle!
 

--- a/SimplifiedTests/Bookmarks/annotation-response.json
+++ b/SimplifiedTests/Bookmarks/annotation-response.json
@@ -1,0 +1,43 @@
+{
+  "@context": ["http://www.w3.org/ns/anno.jsonld", "http://www.w3.org/ns/ldp.jsonld"],
+  "total": 2,
+  "type": ["BasicContainer", "AnnotationCollection"],
+  "id": "https://circulation.librarysimplified.org/NYNYPL/annotations/book1",
+  "first": {
+    "items": [{
+      "body": {
+        "http://librarysimplified.org/terms/time": "2021-04-14T22:50:04Z",
+        "http://librarysimplified.org/terms/progressWithinBook": "0.13910505",
+        "http://librarysimplified.org/terms/device": "urn:uuid:789166c5-ed87-413a-8d9f-f306f6f02362"
+      },
+      "motivation": "http://www.w3.org/ns/oa#bookmarking",
+      "type": "Annotation",
+      "id": "https://circulation.librarysimplified.org/NYNYPL/annotations/3217569",
+      "target": {
+        "selector": {
+          "type": "FragmentSelector",
+          "value": "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"href\": \"/xyz.html\",\n  \"progressWithinChapter\": 0.09090909\n}"
+        },
+        "source": "urn:librarysimplified.org/terms/id/book1"
+      }
+    }, {
+      "body": {
+        "http://librarysimplified.org/terms/time": "2021-04-14T22:49:41Z",
+        "http://librarysimplified.org/terms/device": "urn:uuid:789166c5-ed87-413a-8d9f-f306f6f02362"
+      },
+      "motivation": "http://librarysimplified.org/terms/annotation/idling",
+      "type": "Annotation",
+      "id": "https://circulation.librarysimplified.org/NYNYPL/annotations/3217539",
+      "target": {
+        "selector": {
+          "type": "FragmentSelector",
+          "value": "{\"@type\":\"LocatorHrefProgression\",\"href\":\"/xyz.html\",\"progressWithinChapter\":0.666}"
+        },
+        "source": "urn:librarysimplified.org/terms/id/book1"
+      }
+    }],
+    "type": "AnnotationPage",
+    "id": "https://circulation.librarysimplified.org/NYNYPL/annotations/book1"
+  }
+}
+


### PR DESCRIPTION
**What's this do?**
The `syncReadingPosition` and `getServerBookmarks` functions call the same api, so the parsing of the api response is identical. This PR moves the parsing code into its own function, so it can be reused by the two api call wrappers. Also adds related unit tests.

Minor: in NYPLAnnotations, `postAnnotation` and `annotationID(fromNetworkData:)` have been moved as-is.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3668

**How should this be tested? / Do these changes have associated tests?**
will be able to test once all story subtasks have been completed. 

**Dependencies for merging? Releasing to production?**
merging to feature branch

**Does this include changes that require a new SimplyE build for QA?**
not needed

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 