### PR TITLE
SIMPLY-3672: Get DeviceID and Client IP for AXIS license URL generation 

### DIFF
--- a/Simplified/AxisService/NYPLAxisDRMAuthorizer.swift
+++ b/Simplified/AxisService/NYPLAxisDRMAuthorizer.swift
@@ -9,14 +9,27 @@
 import Foundation
 
 #if AXIS
+
+@objc protocol NYPLDeviceInfoProviding {
+  var deviceID: String { get }
+  var clientIP: String { get }
+}
+
 @objcMembers
-class NYPLAxisDRMAuthorizer: NSObject, NYPLDRMAuthorizing {
+class NYPLAxisDRMAuthorizer: NSObject, NYPLDRMAuthorizing, NYPLDeviceInfoProviding {
   
-  static let deviceIDKey = "NYPLAxisDRMAuthorizerKey"
+  static private let deviceIDKey = "NYPLAxisDRMAuthorizerKey"
   
   static let sharedInstance = NYPLAxisDRMAuthorizer()
   
-  static var deviceID: String {
+  // MARK: - NYPLDeviceInfoProviding
+  
+  /// Device IP address is only needed when generating a url for downloading license. Generating actual
+  /// device IP address would be more costly and would provide a result no different than what the hard
+  /// coded IP address already provides. Also, this is consistent with what Android is doing.
+  let clientIP = "192.168.1.254"
+  
+  var deviceID: String {
     if
       let id = UserDefaults.standard.string(forKey: NYPLAxisDRMAuthorizer.deviceIDKey) {
       return id
@@ -26,6 +39,8 @@ class NYPLAxisDRMAuthorizer: NSObject, NYPLDRMAuthorizing {
     UserDefaults.standard.set(id, forKey: NYPLAxisDRMAuthorizer.deviceIDKey)
     return id
   }
+  
+  // MARK: - NYPLDRMAuthorizing
   
   /// Not applicable for Axis
   var workflowsInProgress: Bool {
@@ -44,7 +59,7 @@ class NYPLAxisDRMAuthorizer: NSObject, NYPLDRMAuthorizing {
                  password: String!,
                  completion: ((Bool, Error?, String?, String?) -> Void)!) {
     
-    completion(true, nil, NYPLAxisDRMAuthorizer.deviceID, username)
+    completion(true, nil, deviceID, username)
   }
   
   /// There is no mechanism for deauthorizing the user in Axis. Returning succeeding completion.

--- a/Simplified/AxisService/NYPLAxisService.swift
+++ b/Simplified/AxisService/NYPLAxisService.swift
@@ -35,15 +35,19 @@ class NYPLAxisService: NSObject {
   private let fileURL: URL
   private let baseURL: URL
   private let book: NYPLBook
+  private let deviceInfoProvider: NYPLDeviceInfoProviding
   
   /// Failable initializer that extracts `isbn` and `book_vault_id` from the downloaded file. Returns
   /// nil if keys are not present and notifies delegate.
   /// - Parameters:
   ///   - delegate: An object confirming to NYPLBookDownloadBroadcasting protocol.
   ///   - fileURL: Local url of the downloaded file.
+  ///   - deviceInfoProvider: An NYPLDeviceInfoProviding object to get deviceID and clientIP
+  ///   required for license URL generation
   ///   - book: NYPLBook object
   @objc init?(delegate: NYPLBookDownloadBroadcasting,
               fileURL: URL,
+              deviceInfoProvider: NYPLDeviceInfoProviding,
               forBook book: NYPLBook) {
     /*
      The downloaded file is supposed to have a key for isbn and
@@ -71,6 +75,7 @@ class NYPLAxisService: NSObject {
     self.dedicatedWriteURL = fileURL.deletingLastPathComponent().appendingPathComponent(isbn)
     self.baseURL = AxisHelper.baseURL.appendingPathComponent(AxisHelper.isbnKey)
     self.book = book
+    self.deviceInfoProvider = deviceInfoProvider
   }
   
   /// Fulfill AxisNow license. Notifies NYPLBookDownloadBroadcasting upon completion or failure.

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -348,11 +348,14 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
       }
       case NYPLMyBooksDownloadRightsManagementAxis: {
 #if defined(AXIS)
-        NYPLAxisService *axis = [[NYPLAxisService alloc]
-                                 initWithDelegate:self
-                                 fileURL:tmpSavedFileURL
-                                 forBook:book];
-        [axis fulfillAxisLicenseWithDownloadTask:downloadTask];
+        id<NYPLDeviceInfoProviding> deviceInfoProvider = NYPLAxisDRMAuthorizer.sharedInstance;
+        NYPLAxisService *axisService = [[NYPLAxisService alloc]
+                                        initWithDelegate:self
+                                        fileURL:tmpSavedFileURL
+                                        deviceInfoProvider:deviceInfoProvider
+                                        forBook:book];
+        
+        [axisService fulfillAxisLicenseWithDownloadTask:downloadTask];
 #endif
         break;
       }


### PR DESCRIPTION
**What's this do?**
Gets DeviceID and Client IP for AXIS license URL generation 

**Why are we doing this? (w/ JIRA link if applicable)**
We need deviceID and clientIP in order to generate a url for downloading the license file for AXIS books.
https://jira.nypl.org/browse/SIMPLY-3672

**How should this be tested? / Do these changes have associated tests?**
Too early to test

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Raman Singh verified it
