### PR TITLE
OE-16: Move downloaded content for AXIS books to books directory

### DIFF
--- a/Simplified/AxisService/NYPLAxisService.swift
+++ b/Simplified/AxisService/NYPLAxisService.swift
@@ -51,7 +51,7 @@ class NYPLAxisService: NSObject {
               forBook book: NYPLBook) {
     /*
      The downloaded file is supposed to have a key for isbn and
-     book_vauld_uuid. Those keys are needed to download license.json,
+     book_vault_uuid. Those keys are needed to download license.json,
      encryption.xml, container.xml, package.opf, and assets enclosed in
      package.opf.
      */
@@ -72,10 +72,12 @@ class NYPLAxisService: NSObject {
     self.fileURL = fileURL
     self.delegate = delegate
     self.bookVaultId = bookVaultId
-    self.dedicatedWriteURL = fileURL.deletingLastPathComponent().appendingPathComponent(isbn)
-    self.baseURL = AxisHelper.baseURL.appendingPathComponent(AxisHelper.isbnKey)
+    self.baseURL = AxisHelper.baseURL.appendingPathComponent(isbn)
     self.book = book
     self.deviceInfoProvider = deviceInfoProvider
+    self.dedicatedWriteURL = fileURL
+      .deletingLastPathComponent()
+      .appendingPathComponent(book.identifier.sha256())
   }
   
   /// Fulfill AxisNow license. Notifies NYPLBookDownloadBroadcasting upon completion or failure.

--- a/Simplified/Book/Models/NYPLBookContentType.h
+++ b/Simplified/Book/Models/NYPLBookContentType.h
@@ -2,6 +2,7 @@ typedef NS_ENUM(NSInteger, NYPLBookContentType) {
   NYPLBookContentTypeEPUB,
   NYPLBookContentTypeAudiobook,
   NYPLBookContentTypePDF,
+  NYPLBookContentTypeAxis,
   NYPLBookContentTypeUnsupported
 };
 

--- a/Simplified/Book/Models/NYPLBookContentType.m
+++ b/Simplified/Book/Models/NYPLBookContentType.m
@@ -9,6 +9,8 @@ NYPLBookContentType NYPLBookContentTypeFromMIMEType(NSString *const string)
     return NYPLBookContentTypeEPUB;
   } else if ([string isEqualToString:ContentTypeOpenAccessPDF]) {
     return NYPLBookContentTypePDF;
+  } else if ([string isEqualToString:ContentTypeAxis360]) {
+    return NYPLBookContentTypeAxis;
   }
   return NYPLBookContentTypeUnsupported;
 }

--- a/Simplified/Book/UI/NYPLBookButtonsView.m
+++ b/Simplified/Book/UI/NYPLBookButtonsView.m
@@ -204,6 +204,7 @@
           break;
         case NYPLBookContentTypePDF:
         case NYPLBookContentTypeEPUB:
+        case NYPLBookContentTypeAxis:
           buttonInfo = @{ButtonKey: self.readButton,
                          TitleKey: NSLocalizedString(@"Read", nil),
                          HintKey: [NSString stringWithFormat:NSLocalizedString(@"Opens %@ for reading", nil), self.book.title],


### PR DESCRIPTION
**What's this do?**
Moves downloaded book content from downloads to content directory.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-16

**How should this be tested? / Do these changes have associated tests?**
Too early to test.

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Raman Singh verified it.