### PR TITLE
OE-19: Download required files for books with AXIS DRM

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -256,10 +256,45 @@
 		5916E7E12627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */; };
 		5916E7E22627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */; };
 		5916E7E32627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */; };
+		596D953F26308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596D953E26308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift */; };
+		596D954026308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596D953E26308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift */; };
+		596D954126308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596D953E26308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift */; };
+		596D954226308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596D953E26308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift */; };
+		596D954326308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596D953E26308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift */; };
+		5982E10F26309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5982E10E26309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift */; };
+		5982E11026309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5982E10E26309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift */; };
+		5982E11126309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5982E10E26309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift */; };
+		5982E11226309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5982E10E26309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift */; };
+		5982E11326309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5982E10E26309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift */; };
 		598CDC02261D3B5E006A5AB3 /* NYPLAxisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A78B89261656C20038BCDC /* NYPLAxisService.swift */; };
 		598CDC03261D3B5F006A5AB3 /* NYPLAxisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A78B89261656C20038BCDC /* NYPLAxisService.swift */; };
 		598CDC04261D3B5F006A5AB3 /* NYPLAxisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A78B89261656C20038BCDC /* NYPLAxisService.swift */; };
 		598CDC05261D3B60006A5AB3 /* NYPLAxisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A78B89261656C20038BCDC /* NYPLAxisService.swift */; };
+		598CDC44261D6F62006A5AB3 /* NYPLAssetWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC43261D6F62006A5AB3 /* NYPLAssetWriter.swift */; };
+		598CDC45261D6F62006A5AB3 /* NYPLAssetWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC43261D6F62006A5AB3 /* NYPLAssetWriter.swift */; };
+		598CDC46261D6F62006A5AB3 /* NYPLAssetWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC43261D6F62006A5AB3 /* NYPLAssetWriter.swift */; };
+		598CDC47261D6F62006A5AB3 /* NYPLAssetWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC43261D6F62006A5AB3 /* NYPLAssetWriter.swift */; };
+		598CDC48261D6F62006A5AB3 /* NYPLAssetWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC43261D6F62006A5AB3 /* NYPLAssetWriter.swift */; };
+		598CDC55261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC54261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift */; };
+		598CDC56261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC54261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift */; };
+		598CDC57261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC54261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift */; };
+		598CDC58261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC54261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift */; };
+		598CDC59261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC54261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift */; };
+		598CDC5B261D72DC006A5AB3 /* NYPLRSACypher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC5A261D72DC006A5AB3 /* NYPLRSACypher.swift */; };
+		598CDC5C261D72DC006A5AB3 /* NYPLRSACypher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC5A261D72DC006A5AB3 /* NYPLRSACypher.swift */; };
+		598CDC5D261D72DC006A5AB3 /* NYPLRSACypher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC5A261D72DC006A5AB3 /* NYPLRSACypher.swift */; };
+		598CDC5E261D72DC006A5AB3 /* NYPLRSACypher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC5A261D72DC006A5AB3 /* NYPLRSACypher.swift */; };
+		598CDC5F261D72DC006A5AB3 /* NYPLRSACypher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC5A261D72DC006A5AB3 /* NYPLRSACypher.swift */; };
+		598CDC61261D7FE4006A5AB3 /* NYPLAxisXML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC60261D7FE4006A5AB3 /* NYPLAxisXML.swift */; };
+		598CDC62261D7FE4006A5AB3 /* NYPLAxisXML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC60261D7FE4006A5AB3 /* NYPLAxisXML.swift */; };
+		598CDC63261D7FE4006A5AB3 /* NYPLAxisXML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC60261D7FE4006A5AB3 /* NYPLAxisXML.swift */; };
+		598CDC64261D7FE4006A5AB3 /* NYPLAxisXML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC60261D7FE4006A5AB3 /* NYPLAxisXML.swift */; };
+		598CDC65261D7FE4006A5AB3 /* NYPLAxisXML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598CDC60261D7FE4006A5AB3 /* NYPLAxisXML.swift */; };
+		599CB7982631EC140024B5F1 /* NYPLAxisKeysProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599CB7972631EC140024B5F1 /* NYPLAxisKeysProvider.swift */; };
+		599CB7992631EC140024B5F1 /* NYPLAxisKeysProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599CB7972631EC140024B5F1 /* NYPLAxisKeysProvider.swift */; };
+		599CB79A2631EC140024B5F1 /* NYPLAxisKeysProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599CB7972631EC140024B5F1 /* NYPLAxisKeysProvider.swift */; };
+		599CB79B2631EC140024B5F1 /* NYPLAxisKeysProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599CB7972631EC140024B5F1 /* NYPLAxisKeysProvider.swift */; };
+		599CB79C2631EC140024B5F1 /* NYPLAxisKeysProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599CB7972631EC140024B5F1 /* NYPLAxisKeysProvider.swift */; };
 		59A78B8A261656C20038BCDC /* NYPLAxisService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A78B89261656C20038BCDC /* NYPLAxisService.swift */; };
 		59EEAFF3262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EEAFF2262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift */; };
 		59EEAFF4262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EEAFF2262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift */; };
@@ -2079,6 +2114,13 @@
 		52592BBB21220A4F00587288 /* NYPLLocalization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NYPLLocalization.h; sourceTree = "<group>"; };
 		5916E7D3262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+Adept.swift"; sourceTree = "<group>"; };
 		5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+Axis.swift"; sourceTree = "<group>"; };
+		596D953E26308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAxisPackageEndpointProvider.swift; sourceTree = "<group>"; };
+		5982E10E26309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAxisPackagePathPrefixProvider.swift; sourceTree = "<group>"; };
+		598CDC43261D6F62006A5AB3 /* NYPLAssetWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAssetWriter.swift; sourceTree = "<group>"; };
+		598CDC54261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAxisLicenseURLGenerator.swift; sourceTree = "<group>"; };
+		598CDC5A261D72DC006A5AB3 /* NYPLRSACypher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLRSACypher.swift; sourceTree = "<group>"; };
+		598CDC60261D7FE4006A5AB3 /* NYPLAxisXML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAxisXML.swift; sourceTree = "<group>"; };
+		599CB7972631EC140024B5F1 /* NYPLAxisKeysProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAxisKeysProvider.swift; sourceTree = "<group>"; };
 		59A78B89261656C20038BCDC /* NYPLAxisService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAxisService.swift; sourceTree = "<group>"; };
 		59EEAFF2262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAxisDRMAuthorizer.swift; sourceTree = "<group>"; };
 		5A569A261B8351C6003B5B61 /* ADEPT.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ADEPT.xcodeproj; path = "adept-ios/ADEPT.xcodeproj"; sourceTree = "<group>"; };
@@ -2852,7 +2894,14 @@
 			isa = PBXGroup;
 			children = (
 				59A78B89261656C20038BCDC /* NYPLAxisService.swift */,
+				596D953E26308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift */,
+				5982E10E26309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift */,
+				599CB7972631EC140024B5F1 /* NYPLAxisKeysProvider.swift */,
 				59EEAFF2262624BD00944CE0 /* NYPLAxisDRMAuthorizer.swift */,
+				598CDC43261D6F62006A5AB3 /* NYPLAssetWriter.swift */,
+				598CDC54261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift */,
+				598CDC5A261D72DC006A5AB3 /* NYPLRSACypher.swift */,
+				598CDC60261D7FE4006A5AB3 /* NYPLAxisXML.swift */,
 			);
 			path = AxisService;
 			sourceTree = "<group>";
@@ -4804,6 +4853,7 @@
 			files = (
 				7347F038245A4DE200558D7F /* NYPLCirculationAnalytics.swift in Sources */,
 				7342703424DCB31800A4F605 /* NYPLBaseReaderViewController.swift in Sources */,
+				599CB79A2631EC140024B5F1 /* NYPLAxisKeysProvider.swift in Sources */,
 				7347F039245A4DE200558D7F /* NYPLBookState.swift in Sources */,
 				7347F03B245A4DE200558D7F /* APIKeys.swift in Sources */,
 				7347F03C245A4DE200558D7F /* NYPLAttributedString.m in Sources */,
@@ -4842,9 +4892,11 @@
 				598CDC04261D3B5F006A5AB3 /* NYPLAxisService.swift in Sources */,
 				7347F04D245A4DE200558D7F /* NYPLBookCell.m in Sources */,
 				7347F04E245A4DE200558D7F /* NSURL+NYPLURLAdditions.m in Sources */,
+				598CDC46261D6F62006A5AB3 /* NYPLAssetWriter.swift in Sources */,
 				7347F04F245A4DE200558D7F /* NYPLAsync.m in Sources */,
 				7342702524DCB26700A4F605 /* URLResponse+NYPL.swift in Sources */,
 				730EDFEF251537AF0038DD9F /* NYPLCredentials.swift in Sources */,
+				598CDC63261D7FE4006A5AB3 /* NYPLAxisXML.swift in Sources */,
 				7347F050245A4DE200558D7F /* NYPLReloadView.m in Sources */,
 				1798538D255A4092009F94D9 /* NYPLBookLocation+Locator.swift in Sources */,
 				7347F051245A4DE200558D7F /* NYPLReachabilityManager.m in Sources */,
@@ -4854,6 +4906,7 @@
 				21C5047C2513C9F60016A6C8 /* AudioBookVendors+Extensions.swift in Sources */,
 				7347F055245A4DE200558D7F /* NYPLProblemDocument.swift in Sources */,
 				730EDFF12515383B0038DD9F /* NYPLAnnouncementViewController.swift in Sources */,
+				598CDC5D261D72DC006A5AB3 /* NYPLRSACypher.swift in Sources */,
 				7347F056245A4DE200558D7F /* NYPLReturnPromptHelper.swift in Sources */,
 				7347F057245A4DE200558D7F /* NYPLReaderBookmarkCell.swift in Sources */,
 				21DDE32A25D2CEFC002CBCE3 /* AdobeDRMContentProtection.swift in Sources */,
@@ -4866,6 +4919,7 @@
 				7347F05C245A4DE200558D7F /* OPDS2CatalogsFeed.swift in Sources */,
 				7347F05D245A4DE200558D7F /* BundledHTMLViewController.swift in Sources */,
 				73B80BAC25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift in Sources */,
+				598CDC57261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift in Sources */,
 				7347F05E245A4DE200558D7F /* NYPLBookDetailView.m in Sources */,
 				7347F05F245A4DE200558D7F /* UIButton+NYPLAppearanceAdditions.m in Sources */,
 				7347F060245A4DE200558D7F /* NYPLBookCoverRegistry.m in Sources */,
@@ -5005,8 +5059,10 @@
 				7347F0C1245A4DE200558D7F /* NSString+NYPLStringAdditions.m in Sources */,
 				7347F0C2245A4DE200558D7F /* NYPLKeychainManager.swift in Sources */,
 				7347F0C3245A4DE200558D7F /* NYPLErrorLogger.swift in Sources */,
+				596D954126308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift in Sources */,
 				73CC48AC260C07C300F1E2C3 /* NYPLReadiumBookmark+R2.swift in Sources */,
 				730EE002251567820038DD9F /* NYPLLibraryNavigationController.m in Sources */,
+				5982E11126309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift in Sources */,
 				730EF268260967FF008E1DC3 /* NYPLBookmarkFactory.swift in Sources */,
 				7360D0D624BFCB9700C8AD16 /* NYPLUserFriendlyError.swift in Sources */,
 				7347F0C4245A4DE200558D7F /* NYPLOPDSEntryGroupAttributes.m in Sources */,
@@ -5050,6 +5106,7 @@
 			files = (
 				739E6046244A0D8600D00301 /* NYPLCirculationAnalytics.swift in Sources */,
 				739E6047244A0D8600D00301 /* NYPLBookState.swift in Sources */,
+				599CB7992631EC140024B5F1 /* NYPLAxisKeysProvider.swift in Sources */,
 				739E6049244A0D8600D00301 /* APIKeys.swift in Sources */,
 				739E604C244A0D8600D00301 /* NYPLBaseReaderViewController.swift in Sources */,
 				739E604D244A0D8600D00301 /* NYPLAttributedString.m in Sources */,
@@ -5088,9 +5145,11 @@
 				598CDC03261D3B5F006A5AB3 /* NYPLAxisService.swift in Sources */,
 				739E6063244A0D8600D00301 /* NYPLReloadView.m in Sources */,
 				739E6064244A0D8600D00301 /* NYPLReachabilityManager.m in Sources */,
+				598CDC45261D6F62006A5AB3 /* NYPLAssetWriter.swift in Sources */,
 				739E6066244A0D8600D00301 /* NYPLReadiumViewSyncManager.m in Sources */,
 				739E6067244A0D8600D00301 /* NYPLCatalogGroupedFeedViewController.m in Sources */,
 				73B551012511737B00D05B86 /* SEMigrations.swift in Sources */,
+				598CDC62261D7FE4006A5AB3 /* NYPLAxisXML.swift in Sources */,
 				739E6068244A0D8600D00301 /* NYPLBackgroundExecutor.swift in Sources */,
 				739E6069244A0D8600D00301 /* NYPLProblemDocument.swift in Sources */,
 				739E606A244A0D8600D00301 /* NYPLReturnPromptHelper.swift in Sources */,
@@ -5100,6 +5159,7 @@
 				739E606D244A0D8600D00301 /* NYPLReaderTOCElement.m in Sources */,
 				7327528E2578D69300A073E2 /* URLResponse+NYPLAuthentication.swift in Sources */,
 				739E606F244A0D8600D00301 /* NYPLReaderTOCViewController.m in Sources */,
+				598CDC5C261D72DC006A5AB3 /* NYPLRSACypher.swift in Sources */,
 				739E6070244A0D8600D00301 /* OPDS2CatalogsFeed.swift in Sources */,
 				739E6071244A0D8600D00301 /* BundledHTMLViewController.swift in Sources */,
 				739E6072244A0D8600D00301 /* NYPLBookDetailView.m in Sources */,
@@ -5112,6 +5172,7 @@
 				739E6076244A0D8600D00301 /* NYPLOPDSCategory.m in Sources */,
 				739E6077244A0D8600D00301 /* NYPLNull.m in Sources */,
 				739E6078244A0D8600D00301 /* NYPLLinearView.m in Sources */,
+				598CDC56261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift in Sources */,
 				73B550FB2511725C00D05B86 /* NSNotification+NYPL.swift in Sources */,
 				739E607A244A0D8600D00301 /* NSDate+NYPLDateAdditions.m in Sources */,
 				739E607B244A0D8600D00301 /* NYPLBook.m in Sources */,
@@ -5251,8 +5312,10 @@
 				73F11E0B251941FD00FCD22B /* DPLAAudiobooks.swift in Sources */,
 				2126FE2F25C059250095C45C /* ReaderError.swift in Sources */,
 				739E60E1244A0D8600D00301 /* NYPLIndeterminateProgressView.m in Sources */,
+				596D954026308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift in Sources */,
 				73CC48AB260C07C200F1E2C3 /* NYPLReadiumBookmark+R2.swift in Sources */,
 				739E60E2244A0D8600D00301 /* NSString+NYPLStringAdditions.m in Sources */,
+				5982E11026309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift in Sources */,
 				730EF267260967FF008E1DC3 /* NYPLBookmarkFactory.swift in Sources */,
 				739E60E3244A0D8600D00301 /* NYPLKeychainManager.swift in Sources */,
 				739E60E4244A0D8600D00301 /* NYPLErrorLogger.swift in Sources */,
@@ -5324,6 +5387,7 @@
 				73EB0A7C25821DF4006BC997 /* NYPLBookCellCollectionViewController.m in Sources */,
 				73EB0A7D25821DF4006BC997 /* NYPLKeychainStoredVariable.swift in Sources */,
 				73EB0A7E25821DF4006BC997 /* NYPLXML.m in Sources */,
+				598CDC5E261D72DC006A5AB3 /* NYPLRSACypher.swift in Sources */,
 				73EB0A7F25821DF4006BC997 /* NYPLSignInBusinessLogic.swift in Sources */,
 				73EB0A8025821DF4006BC997 /* NYPLBookCell.m in Sources */,
 				73EB0A8125821DF4006BC997 /* NYPLConfiguration+SE.swift in Sources */,
@@ -5360,6 +5424,7 @@
 				73EB0A9825821DF4006BC997 /* NYPLWelcomeScreenViewController.swift in Sources */,
 				73EB0A9925821DF4006BC997 /* NYPLOPDSCategory.m in Sources */,
 				73EB0A9A25821DF4006BC997 /* NYPLUserFriendlyError.swift in Sources */,
+				598CDC58261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift in Sources */,
 				73EB0A9B25821DF4006BC997 /* NYPLNull.m in Sources */,
 				73EB0A9C25821DF4006BC997 /* NYPLLinearView.m in Sources */,
 				73D8D27E25A68D4300DF5F69 /* NYPLReaderBookmarksBusinessLogic.swift in Sources */,
@@ -5376,6 +5441,7 @@
 				73EB0AA425821DF4006BC997 /* NYPLCatalogNavigationController.m in Sources */,
 				73EB0AA525821DF4006BC997 /* NYPLEntryPointView.swift in Sources */,
 				73EB0AA625821DF4006BC997 /* NYPLOPDSGroup.m in Sources */,
+				596D954226308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift in Sources */,
 				73EB0AA825821DF4006BC997 /* NYPLAppReviewPrompt.swift in Sources */,
 				73EB0AA925821DF4006BC997 /* NYPLFacetBarView.swift in Sources */,
 				73EB0AAA25821DF4006BC997 /* NYPLDismissibleViewController.m in Sources */,
@@ -5415,6 +5481,7 @@
 				73D8D28025A68D4300DF5F69 /* NYPLBookLocation+Locator.swift in Sources */,
 				73EB0AC925821DF4006BC997 /* NYPLBarcode.swift in Sources */,
 				73EB0ACA25821DF4006BC997 /* NYPLSession.m in Sources */,
+				599CB79B2631EC140024B5F1 /* NYPLAxisKeysProvider.swift in Sources */,
 				73EB0ACB25821DF4006BC997 /* NYPLSettingsEULAViewController.m in Sources */,
 				73EB0ACC25821DF4006BC997 /* NYPLPresentationUtils.swift in Sources */,
 				73EB0ACD25821DF4006BC997 /* NYPLMyBooksDownloadInfo.m in Sources */,
@@ -5448,6 +5515,7 @@
 				73EB0AE325821DF4006BC997 /* NYPLReauthenticator.swift in Sources */,
 				73EB0AE425821DF4006BC997 /* NYPLAnnouncementBusinessLogic.swift in Sources */,
 				73EB0AE525821DF4006BC997 /* Account.swift in Sources */,
+				598CDC64261D7FE4006A5AB3 /* NYPLAxisXML.swift in Sources */,
 				73EB0AE625821DF4006BC997 /* NYPLBookDownloadFailedCell.m in Sources */,
 				73EB0AE725821DF4006BC997 /* NYPLBookDetailViewController.m in Sources */,
 				73EB0AE925821DF4006BC997 /* NYPLBookContentMetadataFilesHelper.swift in Sources */,
@@ -5505,12 +5573,14 @@
 				73EB0B1525821DF4006BC997 /* NYPLAnnotations.swift in Sources */,
 				73EB0B1625821DF4006BC997 /* AudioBookVendors+Extensions.swift in Sources */,
 				73EB0B1725821DF4006BC997 /* NYPLLibraryNavigationController.m in Sources */,
+				598CDC47261D6F62006A5AB3 /* NYPLAssetWriter.swift in Sources */,
 				73D8D27725A68D3B00DF5F69 /* UIViewController+NYPL.swift in Sources */,
 				5916E7E22627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */,
 				73EB0B1825821DF4006BC997 /* RemoteHTMLViewController.swift in Sources */,
 				73EB0B1925821DF4006BC997 /* NYPLBookDetailsProblemDocumentViewController.swift in Sources */,
 				73EB0B1A25821DF4006BC997 /* NYPLCatalogGroupedFeed.m in Sources */,
 				73EB0B1B25821DF4006BC997 /* NYPLCatalogFacet.m in Sources */,
+				5982E11226309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift in Sources */,
 				73EB0B1C25821DF4006BC997 /* NYPLBook+DistributorChecks.swift in Sources */,
 				73EB0B1D25821DF4006BC997 /* NYPLLoginCellTypes.swift in Sources */,
 				73EB0B1E25821DF4006BC997 /* NYPLAccountSignInViewController.m in Sources */,
@@ -5539,6 +5609,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				73FCA2A925005BA4001B0C5D /* NYPLLibraryDescriptionCell.swift in Sources */,
+				5982E11326309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift in Sources */,
 				73FCA2AA25005BA4001B0C5D /* NYPLCirculationAnalytics.swift in Sources */,
 				73085E2E250308A3008F6244 /* NYPLSettingsPrimaryTableItem.swift in Sources */,
 				73FCA2AB25005BA4001B0C5D /* NYPLBookState.swift in Sources */,
@@ -5569,6 +5640,7 @@
 				735F559525A63EBF00AC6582 /* NYPLR2Owner.swift in Sources */,
 				7384C759252D20AA0012C2DD /* NYPLBook+DistributorChecks.swift in Sources */,
 				73FCA2BF25005BA4001B0C5D /* NYPLBookCellCollectionViewController.m in Sources */,
+				599CB79C2631EC140024B5F1 /* NYPLAxisKeysProvider.swift in Sources */,
 				7380E720254B4169004613B1 /* NYPLBookContentMetadataFilesHelper.swift in Sources */,
 				73FCA2C025005BA4001B0C5D /* NYPLKeychainStoredVariable.swift in Sources */,
 				73DB56CA25F769FF003788EE /* NYPLLastReadPositionSynchronizer.swift in Sources */,
@@ -5583,6 +5655,7 @@
 				7380E70B254B408C004613B1 /* NYPLEPUBViewController.swift in Sources */,
 				73FCA2C325005BA4001B0C5D /* NYPLBookCell.m in Sources */,
 				5916E7E32627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */,
+				598CDC59261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift in Sources */,
 				73FCA2C425005BA4001B0C5D /* NSURL+NYPLURLAdditions.m in Sources */,
 				73FCA2C525005BA4001B0C5D /* NYPLAsync.m in Sources */,
 				73A794A825477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift in Sources */,
@@ -5624,8 +5697,10 @@
 				73FCA2DF25005BA4001B0C5D /* NYPLCatalogLane.m in Sources */,
 				73FCA2E025005BA4001B0C5D /* NYPLBookNormalCell.m in Sources */,
 				73FCA2E125005BA4001B0C5D /* NYPLCatalogNavigationController.m in Sources */,
+				598CDC48261D6F62006A5AB3 /* NYPLAssetWriter.swift in Sources */,
 				73FCA2E225005BA4001B0C5D /* NYPLEntryPointView.swift in Sources */,
 				73FCA2E325005BA4001B0C5D /* NYPLOPDSGroup.m in Sources */,
+				598CDC5F261D72DC006A5AB3 /* NYPLRSACypher.swift in Sources */,
 				73FCA2E525005BA4001B0C5D /* NYPLAppReviewPrompt.swift in Sources */,
 				73DE53312525A386003E2C56 /* NYPLLibraryAccountURLsProvider.swift in Sources */,
 				73FCA2E625005BA4001B0C5D /* NYPLFacetBarView.swift in Sources */,
@@ -5646,11 +5721,13 @@
 				73FCA2F225005BA4001B0C5D /* NYPLCredentials.swift in Sources */,
 				737F4A6D254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift in Sources */,
 				73FCA2F325005BA4001B0C5D /* NYPLCatalogFeedViewController.m in Sources */,
+				598CDC65261D7FE4006A5AB3 /* NYPLAxisXML.swift in Sources */,
 				73FCA2F425005BA4001B0C5D /* NYPLBookDownloadingCell.m in Sources */,
 				73FCA2F525005BA4001B0C5D /* NYPLTenPrintCoverView+NYPLImageAdditions.m in Sources */,
 				73FCA2F625005BA4001B0C5D /* NYPLNetworkExecutor.swift in Sources */,
 				73FCA2F725005BA4001B0C5D /* NYPLOPDSAcquisitionPath.m in Sources */,
 				73FCA2F825005BA4001B0C5D /* NYPLOPDSAcquisitionAvailability.m in Sources */,
+				596D954326308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift in Sources */,
 				73FCA2F925005BA4001B0C5D /* NSError+NYPLAdditions.swift in Sources */,
 				73FCA2FA25005BA4001B0C5D /* NYPLReachability.m in Sources */,
 				73FCA2FB25005BA4001B0C5D /* NYPLReaderViewController.m in Sources */,
@@ -5789,6 +5866,7 @@
 			files = (
 				0826CD2F24AA2801000F4030 /* NYPLLibraryDescriptionCell.swift in Sources */,
 				2DE514351DC3F0BE005A58BD /* NYPLCirculationAnalytics.swift in Sources */,
+				599CB7982631EC140024B5F1 /* NYPLAxisKeysProvider.swift in Sources */,
 				171966A924170819007BB87E /* NYPLBookState.swift in Sources */,
 				0345BFE81DBF027200398B6F /* APIKeys.swift in Sources */,
 				73F713572417200F00C63B81 /* NYPLBaseReaderViewController.swift in Sources */,
@@ -5827,9 +5905,11 @@
 				598CDC02261D3B5E006A5AB3 /* NYPLAxisService.swift in Sources */,
 				1183F35B194F847100DC322F /* NYPLAsync.m in Sources */,
 				11B20E6E19D9F6DD00877A23 /* NYPLReloadView.m in Sources */,
+				598CDC44261D6F62006A5AB3 /* NYPLAssetWriter.swift in Sources */,
 				E694040A1E4A789800E566ED /* NYPLReachabilityManager.m in Sources */,
 				E6845D971FB38D1300EBF69A /* NYPLReadiumViewSyncManager.m in Sources */,
 				A4BA1D0E1B430341006F83DF /* NYPLCatalogGroupedFeedViewController.m in Sources */,
+				598CDC61261D7FE4006A5AB3 /* NYPLAxisXML.swift in Sources */,
 				732F929323ECB51F0099244C /* NYPLBackgroundExecutor.swift in Sources */,
 				5D1B141522CBE3570006C964 /* NYPLProblemDocument.swift in Sources */,
 				A92FB0F921CDCE3D004740F4 /* NYPLReturnPromptHelper.swift in Sources */,
@@ -5839,6 +5919,7 @@
 				11BFDB36199C08E900378691 /* NYPLReaderTOCElement.m in Sources */,
 				73A794A625477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift in Sources */,
 				11BFDB33199C01F700378691 /* NYPLReaderTOCViewController.m in Sources */,
+				598CDC5B261D72DC006A5AB3 /* NYPLRSACypher.swift in Sources */,
 				B51C1DFA2285FDF9003B49A5 /* OPDS2CatalogsFeed.swift in Sources */,
 				2D62568B1D412BCB0080A81F /* BundledHTMLViewController.swift in Sources */,
 				110AF8961961D94D004887C3 /* NYPLBookDetailView.m in Sources */,
@@ -5851,6 +5932,7 @@
 				73085E3525030D27008F6244 /* SEMigrations.swift in Sources */,
 				11119742198827850014462F /* NYPLBookDetailDownloadingView.m in Sources */,
 				730FC05B2512911E004D7C2D /* NYPLWelcomeScreenViewController.swift in Sources */,
+				598CDC55261D729C006A5AB3 /* NYPLAxisLicenseURLGenerator.swift in Sources */,
 				2DFAC8ED1CD8DDD1003D9EC0 /* NYPLOPDSCategory.m in Sources */,
 				7360D0D524BFCB9700C8AD16 /* NYPLUserFriendlyError.swift in Sources */,
 				11068C55196DD37900E8A94B /* NYPLNull.m in Sources */,
@@ -5990,8 +6072,10 @@
 				2126FE2E25C059250095C45C /* ReaderError.swift in Sources */,
 				5D7CF8B922C3FC06007CAA34 /* NYPLErrorLogger.swift in Sources */,
 				0824D44E24B8DFE400C85A7E /* NSString+JSONParse.swift in Sources */,
+				596D953F26308ADA002F7572 /* NYPLAxisPackageEndpointProvider.swift in Sources */,
 				73CC48AA260C07C200F1E2C3 /* NYPLReadiumBookmark+R2.swift in Sources */,
 				A499BF261B39EFC7002F8B8B /* NYPLOPDSEntryGroupAttributes.m in Sources */,
+				5982E10F26309778002B379B /* NYPLAxisPackagePathPrefixProvider.swift in Sources */,
 				730EF266260967FF008E1DC3 /* NYPLBookmarkFactory.swift in Sources */,
 				1196F75B1970727C00F62670 /* NYPLMyBooksDownloadCenter.m in Sources */,
 				8C40D6A72375FF8B006EA63B /* NYPLProblemDocumentCacheManager.swift in Sources */,

--- a/Simplified/AxisService/NYPLAssetWriter.swift
+++ b/Simplified/AxisService/NYPLAssetWriter.swift
@@ -1,0 +1,38 @@
+//
+//  NYPLAssetWriter.swift
+//  Simplified
+//
+//  Created by Raman Singh on 2021-04-06.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+#if AXIS
+
+protocol NYPLAssetWriting {
+  func writeAsset(_ data: Data, atURL url: URL) throws
+}
+
+struct NYPLAssetWriter: NYPLAssetWriting {
+  
+  /// writes asset at provided url while creating intermediate directories if not present.
+  /// - Parameters:
+  ///   - data: Data to be written
+  ///   - url: Desired location of asset to be written
+  /// - Throws: Throws an error if failure to create directories or write data occurs.
+  func writeAsset(_ data: Data, atURL url: URL) throws {
+    let folderURL = url.deletingLastPathComponent()
+    let dirExists = FileManager.default.fileExists(atPath: folderURL.path)
+    if (!dirExists) {
+      try FileManager.default.createDirectory(at: folderURL,
+                                              withIntermediateDirectories: true,
+                                              attributes: nil)
+    }
+    
+    try data.write(to: url)
+  }
+  
+}
+
+#endif

--- a/Simplified/AxisService/NYPLAxisKeysProvider.swift
+++ b/Simplified/AxisService/NYPLAxisKeysProvider.swift
@@ -1,0 +1,41 @@
+//
+//  NYPLAxisKeysProvider.swift
+//  Simplified
+//
+//  Created by Raman Singh on 2021-04-22.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+#if AXIS
+
+protocol NYPLAxisKeysProviding {
+  var isbnKey: String { get }
+  var bookVaultKey: String { get }
+  var baseURL: URL { get }
+  var licenseBaseURL: URL { get }
+  var desiredNameForLicenseFile: String { get }
+  var containerDownloadEndpoint: String { get }
+  var containerFileName: String { get }
+  var encryptionDownloadEndpoint: String { get }
+  var hrefKey: String { get }
+  var fullPathKey: String { get }
+}
+
+struct NYPLAxisKeysProvider: NYPLAxisKeysProviding {
+  let isbnKey = "isbn"
+  let bookVaultKey = "book_vault_uuid"
+  /// This is the url for downloading content for a given book with axis drm.
+  let baseURL = URL(string: "https://node.axisnow.com/content/stream/")!
+  /// Default base URL for downloading license for a book from Axis
+  let licenseBaseURL = URL(string: "https://node.axisnow.com/license")!
+  let desiredNameForLicenseFile = "license.json"
+  let containerDownloadEndpoint = "META-INF/container.xml"
+  let containerFileName = "container.xml"
+  let encryptionDownloadEndpoint = "META-INF/encryption.xml"
+  let hrefKey = "href"
+  let fullPathKey = "full-path"
+}
+
+#endif

--- a/Simplified/AxisService/NYPLAxisLicenseURLGenerator.swift
+++ b/Simplified/AxisService/NYPLAxisLicenseURLGenerator.swift
@@ -1,0 +1,47 @@
+//
+//  AxisLicenseURLGenerator.swift
+//  Simplified
+//
+//  Created by Raman Singh on 2021-04-06.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+#if AXIS
+
+/// Generates license URL for a given book with Axis DRM using the bookVaultId, isbn, clientId, deviceId, and
+/// a NYPLRSACryptographing object.
+///
+/// Note: The isbn and bookVauldId are received from the very first file that gets downloaded when we
+/// download a book with Axis DRM.
+///
+/// For generating license for a book with AxisDRM, we need `bookVaultId`, `isbn`, `deviceID`,
+/// `IP address`of the client, `modulus` of public key, and `exponent` from rsa client. The url should
+/// look this - baseURL/bookVaultId/deviceID/ipAddress/isbn/modulus/exponent
+struct NYPLAxisLicenseURLGenerator {
+  let baseURL: URL
+  let bookVaultId: String
+  let clientIP: String
+  let cypher: NYPLRSACryptographing
+  let deviceID: String
+  let isbn: String
+  
+  func generateLicenseURL() -> URL {
+    let modulus = cypher.modulus
+    let exponent = cypher.exponent
+    
+    let licenseURL = baseURL
+      .appendingPathComponent(bookVaultId)
+      .appendingPathComponent(deviceID)
+      .appendingPathComponent(clientIP)
+      .appendingPathComponent(isbn)
+      .appendingPathComponent(modulus)
+      .appendingPathComponent(exponent)
+    
+    return licenseURL
+  }
+  
+}
+
+#endif

--- a/Simplified/AxisService/NYPLAxisPackageEndpointProvider.swift
+++ b/Simplified/AxisService/NYPLAxisPackageEndpointProvider.swift
@@ -1,0 +1,73 @@
+//
+//  NYPLPackageEndpointProvider.swift
+//  Simplified
+//
+//  Created by Raman Singh on 2021-04-21.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+#if AXIS
+
+protocol NYPLAxisPackageEndpointProviding {
+  func getPackageEndpoint() -> String?
+}
+
+class NYPLAxisPackageEndpointProvider: NYPLAxisPackageEndpointProviding {
+  
+  private let containerURL: URL
+  private let fullPathKey: String
+  private var packageEndpoint: String?
+  
+  // MARK: - Static Constants
+  static private let summary = "AXIS: Failed to generate package endpoint"
+  
+  
+  /// Creates an instance of NYPLAxisPackageEndpointProvider for extracting the endpoint for package.opf
+  /// file from the Container.xml file using the given key.
+  /// - Parameters:
+  ///   - containerURL: URL for Container.xml file
+  ///   - fullPathKey: Name of the key
+  init(containerURL: URL, fullPathKey: String) {
+    self.containerURL = containerURL
+    self.fullPathKey = fullPathKey
+  }
+  
+  /// Generates, stores, and returns package endpoint from the container.xml file. Returns stored value on
+  /// subsequent calls.
+  /// - Returns: Generated or stored (if already generated on previous call) package endpoint (optional).
+  func getPackageEndpoint() -> String? {
+    if let endpoint = packageEndpoint {
+      return endpoint
+    }
+    
+    let data = try? Data(contentsOf: containerURL)
+    guard let axisXML = NYPLAxisXML(data: data) else {
+      NYPLErrorLogger.logError(
+        withCode: .axisDRMFulfillmentFail,
+        summary: NYPLAxisPackageEndpointProvider.summary,
+        metadata: [
+          NYPLAxisService.reason: NYPLAxisXML.NYPLXMLGenerationFailure
+      ])
+      
+      return nil
+    }
+    
+    packageEndpoint = axisXML.findFirstRecursivelyInAttributes(fullPathKey)
+    
+    if (packageEndpoint == nil) {
+      NYPLErrorLogger.logError(
+        withCode: .axisDRMFulfillmentFail,
+        summary: NYPLAxisPackageEndpointProvider.summary,
+        metadata: [
+          NYPLAxisService.reason: "Failed to find element with key \(fullPathKey)"
+      ])
+    }
+    
+    return packageEndpoint
+  }
+  
+}
+
+#endif

--- a/Simplified/AxisService/NYPLAxisPackagePathPrefixProvider.swift
+++ b/Simplified/AxisService/NYPLAxisPackagePathPrefixProvider.swift
@@ -1,0 +1,45 @@
+//
+//  NYPLAxisPackagePathPrefixProvider.swift
+//  Simplified
+//
+//  Created by Raman Singh on 2021-04-21.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+#if AXIS
+
+protocol NYPLAxisPackagePathPrefixProviding {
+  func getPackagePathPrefix(packageEndpoint: String?) -> String?
+}
+
+class NYPLAxisPackagePathPrefixProvider: NYPLAxisPackagePathPrefixProviding {
+  
+  private var packagePathPrefix: String?
+  
+  /// Generates, stores, and returns path prefix for downloadable content from the package endpoint
+  /// extracted from the package.opf file. Returns stored value on subsequent calls.
+  /// - Parameter packageEndpoint: Package endpoint
+  /// - Returns: Generated or stored (if already generated in a previous call) path prefix (optional)
+  func getPackagePathPrefix(packageEndpoint: String?) -> String? {
+    if let pathPrefix = packagePathPrefix {
+      return pathPrefix
+    }
+    
+    guard let packageEndpoint = packageEndpoint else {
+      // No need to log error here since an error is already logged when
+      // pacakgeEndpoint generation returns nil
+      return nil
+    }
+    
+    packagePathPrefix = URL(string: packageEndpoint)?
+      .deletingLastPathComponent()
+      .absoluteString
+    
+    return packagePathPrefix
+  }
+  
+}
+
+#endif

--- a/Simplified/AxisService/NYPLAxisService.swift
+++ b/Simplified/AxisService/NYPLAxisService.swift
@@ -19,13 +19,6 @@ import Foundation
                    forDownloadTask downloadtask: URLSessionDownloadTask) -> Bool
 }
 
-private struct AxisHelper {
-  static let isbnKey = "isbn"
-  static let bookVaultKey = "book_vault_uuid"
-  /// This is the url for downloading content for a given book with axis drm.
-  static let baseURL = URL(string: "https://node.axisnow.com/content/stream/")!
-}
-
 @objc
 class NYPLAxisService: NSObject {
   private weak var delegate: NYPLBookDownloadBroadcasting?
@@ -35,7 +28,239 @@ class NYPLAxisService: NSObject {
   private let fileURL: URL
   private let baseURL: URL
   private let book: NYPLBook
-  private let deviceInfoProvider: NYPLDeviceInfoProviding
+  private let deviceInfoProviding: NYPLDeviceInfoProviding
+  private var packageEndpointproviding: NYPLAxisPackageEndpointProviding
+  private let packagePathProviding: NYPLAxisPackagePathPrefixProviding
+  private let axisKeysProviding: NYPLAxisKeysProviding
+  private let dispatchGroup: DispatchGroup
+  private let assetWriter: NYPLAssetWriting
+  
+  // MARK: - Static Constants
+  static let reason = "reason"
+  
+  // Initialization constants
+  static private let initializationFailureSummary = "AXIS: Failed instantiating AxisService"
+  static let nilDataFromFileURLFailure = "Failed to get data from fileURL"
+  static private let jsonSerializationFailure = "Failed to get json object from data"
+  static private let requiredKeysFailure = "Failed to get required keys from downloaded file"
+  static private let jsonContent = "jsonContent"
+  
+  // Content Downloading constants
+  static private let writeFailureSummary = "AXIS: Failed writing item to specified write URL"
+  static private let failedDownloadingItemSummary = "AXIS: Failed downloading item"
+  static private let failedDownloadingAssetsFromPackageSummary = "AXIS: Failed downloading content from pacakge.opf"
+  
+  // MARK: - Initialization
+  init(delegate: NYPLBookDownloadBroadcasting?,
+       isbn: String,
+       bookVaultId: String,
+       fileURL: URL,
+       book: NYPLBook,
+       deviceInfoProviding: NYPLDeviceInfoProviding,
+       packageEndpointproviding: NYPLAxisPackageEndpointProviding,
+       packagePathProviding: NYPLAxisPackagePathPrefixProviding,
+       axisKeysProviding: NYPLAxisKeysProviding,
+       assetWriter: NYPLAssetWriting) {
+    
+    self.axisKeysProviding = axisKeysProviding
+    self.isbn = isbn
+    self.fileURL = fileURL
+    self.delegate = delegate
+    self.bookVaultId = bookVaultId
+    self.baseURL = axisKeysProviding.baseURL.appendingPathComponent(isbn)
+    self.book = book
+    self.deviceInfoProviding = deviceInfoProviding
+    self.packagePathProviding = NYPLAxisPackagePathPrefixProvider()
+    self.dispatchGroup = DispatchGroup()
+    self.assetWriter = NYPLAssetWriter()
+    self.packageEndpointproviding = packageEndpointproviding
+    self.dedicatedWriteURL = fileURL
+      .deletingLastPathComponent()
+      .appendingPathComponent(book.identifier.sha256())
+  }
+  
+  /// Fulfill AxisNow license. Notifies NYPLBookDownloadBroadcasting upon completion or failure.
+  
+  /// - Parameters:
+  ///   - downloadTask: downloadTask download task
+  @objc func fulfillAxisLicense(downloadTask: URLSessionDownloadTask) {
+    DispatchQueue.global(qos: .utility).async {
+      
+      // TODO: OE-63: As soon as we experience a failure we should stop the
+      // download process and delete all downloaded files.
+      
+      self.downloadLicense(forBook: self.book)
+      self.downloadEncryption(forBook: self.book)
+      self.downloadContainer(forBook: self.book)
+      self.downloadPackage(forBook: self.book)
+      self.downloadAssetsFromPackage(forBook: self.book)
+      
+      self.dispatchGroup.notify(queue: .global(qos: .utility)) {
+        _ = self.delegate?.replaceBook(self.book,
+                                       withFileAtURL: self.dedicatedWriteURL,
+                                       forDownloadTask: downloadTask)
+      }
+    }
+  }
+  
+  // MARK: - Download License
+  private func downloadLicense(forBook book: NYPLBook) {
+    dispatchGroup.wait()
+    dispatchGroup.enter()
+    let writeURL = dedicatedWriteURL
+      .appendingPathComponent(axisKeysProviding.desiredNameForLicenseFile)
+    
+    guard let cypher = NYPLRSACypher() else {
+      // No need to log error here since NYPLRSACypher takes care of that.
+      return
+    }
+    
+    let licenseURL = NYPLAxisLicenseURLGenerator(
+      baseURL: axisKeysProviding.licenseBaseURL,
+      bookVaultId: bookVaultId,
+      clientIP: deviceInfoProviding.clientIP,
+      cypher: cypher,
+      deviceID: deviceInfoProviding.deviceID,
+      isbn: isbn
+    ).generateLicenseURL()
+    
+    downloadItem(from: licenseURL, at: writeURL)
+  }
+  
+  // MARK: - Download Encryption
+  private func downloadEncryption(forBook book: NYPLBook) {
+    dispatchGroup.wait()
+    dispatchGroup.enter()
+    
+    let encryptionURL = baseURL
+      .appendingPathComponent(axisKeysProviding.encryptionDownloadEndpoint)
+    
+    let writeURL = self.dedicatedWriteURL
+      .appendingPathComponent(encryptionURL.lastPathComponent)
+    
+    downloadItem(from: encryptionURL, at: writeURL)
+  }
+  
+  // MARK: - Download Container
+  private func downloadContainer(forBook book: NYPLBook) {
+    dispatchGroup.wait()
+    dispatchGroup.enter()
+    
+    let containerURL = baseURL
+      .appendingPathComponent(axisKeysProviding.containerDownloadEndpoint)
+    
+    let writeURL = self.dedicatedWriteURL
+      .appendingPathComponent(containerURL.lastPathComponent)
+    
+    downloadItem(from: containerURL, at: writeURL)
+  }
+  
+  // MARK: - Download Package
+  private func downloadPackage(forBook book: NYPLBook) {
+    dispatchGroup.wait()
+    dispatchGroup.enter()
+    guard let endpoint = packageEndpoint else {
+      dispatchGroup.leave()
+      return
+    }
+    
+    let packageURL = baseURL.appendingPathComponent(endpoint)
+    let writeURL = self.dedicatedWriteURL.appendingPathComponent(endpoint)
+    downloadItem(from: packageURL, at: writeURL)
+  }
+  
+  // MARK: - Download assets listed in package
+  private func downloadAssetsFromPackage(forBook book: NYPLBook) {
+    dispatchGroup.wait()
+    guard let packageEndpoint = packageEndpoint else {
+      // No need to log error here since an error is already logged when
+      // pacakgeEndpoint generation returns nil
+      delegate?.failDownloadWithAlert(forBook: self.book)
+      return
+    }
+    
+    let packageURL = dedicatedWriteURL.appendingPathComponent(packageEndpoint)
+    let data = try? Data(contentsOf: packageURL)
+    guard let axisXML = NYPLAxisXML(data: data) else {
+      NYPLErrorLogger.logError(
+        withCode: .axisDRMFulfillmentFail,
+        summary: NYPLAxisService.failedDownloadingAssetsFromPackageSummary,
+        metadata: [
+          NYPLAxisService.reason: NYPLAxisXML.NYPLXMLGenerationFailure
+      ])
+      
+      return
+    }
+    
+    let hrefs = axisXML.findRecursivelyInAttributes(axisKeysProviding.hrefKey)
+    
+    for href in hrefs {
+      let endpath: String
+      if let pathPrefix = packagePathPrefix {
+        endpath = "\(pathPrefix)\(href)"
+      } else {
+        endpath = href
+      }
+      
+      let linkURL = baseURL
+        .appendingPathComponent(endpath)
+      
+      let writeURL = self.dedicatedWriteURL
+        .appendingPathComponent(endpath)
+      
+      dispatchGroup.enter()
+      downloadItem(from: linkURL, at: writeURL)
+    }
+  }
+  
+  // MARK: - Helper Methods
+  private func downloadItem(from url: URL, at writeURL: URL) {
+    
+    // TODO: OE-62: Axis code might need specific requirements for caching and
+    // using the shared network executor will result in whatever we choose to
+    // user there.
+    
+    NYPLNetworkExecutor.shared.GET(url) { (result) in
+      switch result {
+      case .success(let data, _):
+        do {
+          try self.assetWriter.writeAsset(data, atURL: writeURL)
+          self.dispatchGroup.leave()
+        } catch {
+          
+          NYPLErrorLogger.logError(
+            error,
+            summary: NYPLAxisService.writeFailureSummary,
+            metadata: ["writeURL": writeURL.path,
+                       "itemURL": url.absoluteString])
+          
+          self.dispatchGroup.leave()
+          self.delegate?.failDownloadWithAlert(forBook: self.book)
+        }
+      case .failure(let error, _):
+        NYPLErrorLogger.logError(
+          error,
+          summary: NYPLAxisService.failedDownloadingItemSummary,
+          metadata: ["itemURL": url.absoluteString])
+        
+        self.dispatchGroup.leave()
+        self.delegate?.failDownloadWithAlert(forBook: self.book)
+      }
+    }
+  }
+  
+  private var packageEndpoint: String? {
+    return self.packageEndpointproviding.getPackageEndpoint()
+  }
+  
+  private var packagePathPrefix: String? {
+    return packagePathProviding
+      .getPackagePathPrefix(packageEndpoint: packageEndpoint)
+  }
+  
+}
+
+extension NYPLAxisService {
   
   /// Failable initializer that extracts `isbn` and `book_vault_id` from the downloaded file. Returns
   /// nil if keys are not present and notifies delegate.
@@ -45,46 +270,90 @@ class NYPLAxisService: NSObject {
   ///   - deviceInfoProvider: An NYPLDeviceInfoProviding object to get deviceID and clientIP
   ///   required for license URL generation
   ///   - book: NYPLBook object
-  @objc init?(delegate: NYPLBookDownloadBroadcasting,
-              fileURL: URL,
-              deviceInfoProvider: NYPLDeviceInfoProviding,
-              forBook book: NYPLBook) {
+  @objc convenience init?(delegate: NYPLBookDownloadBroadcasting,
+                          fileURL: URL,
+                          deviceInfoProviding: NYPLDeviceInfoProviding,
+                          forBook book: NYPLBook) {
+    
+    guard let data = try? Data(contentsOf: fileURL) else {
+      NYPLAxisService
+        .logInitializationFailure(NYPLAxisService.nilDataFromFileURLFailure)
+      
+      delegate.failDownloadWithAlert(forBook: book)
+      return nil
+    }
+    
+    guard
+      let jsonObject = try? JSONSerialization
+        .jsonObject(with: data, options: .fragmentsAllowed),
+      let json = jsonObject as? [String: Any] else {
+        NYPLAxisService
+          .logInitializationFailure(NYPLAxisService.jsonSerializationFailure)
+        
+        delegate.failDownloadWithAlert(forBook: book)
+        return nil
+    }
+    
     /*
      The downloaded file is supposed to have a key for isbn and
      book_vault_uuid. Those keys are needed to download license.json,
      encryption.xml, container.xml, package.opf, and assets enclosed in
      package.opf.
      */
+    
+    let axisKeysProviding = NYPLAxisKeysProvider()
+    
     guard
-      let data = try? Data(contentsOf: fileURL),
-      let jsonObject = try? JSONSerialization
-        .jsonObject(with: data, options: .fragmentsAllowed),
-      let json = jsonObject as? [String: Any],
-      let isbn = json[AxisHelper.isbnKey] as? String,
-      let bookVaultId = json[AxisHelper.bookVaultKey] as? String
+      let isbn = json[axisKeysProviding.isbnKey] as? String,
+      let bookVaultId = json[axisKeysProviding.bookVaultKey] as? String
       else {
-        NYPLErrorLogger.logError(nil, summary: "error initiating AxisService")
+        NYPLAxisService
+          .logInitializationFailure(NYPLAxisService.requiredKeysFailure,
+                                    json: json)
+        
         delegate.failDownloadWithAlert(forBook: book)
         return nil
     }
     
-    self.isbn = isbn
-    self.fileURL = fileURL
-    self.delegate = delegate
-    self.bookVaultId = bookVaultId
-    self.baseURL = AxisHelper.baseURL.appendingPathComponent(isbn)
-    self.book = book
-    self.deviceInfoProvider = deviceInfoProvider
-    self.dedicatedWriteURL = fileURL
+    
+    let dedicatedWriteURL = fileURL
       .deletingLastPathComponent()
       .appendingPathComponent(book.identifier.sha256())
+    
+    let containerURL = dedicatedWriteURL
+      .appendingPathComponent(axisKeysProviding.containerFileName)
+    let endpointProviding = NYPLAxisPackageEndpointProvider(
+      containerURL: containerURL,
+      fullPathKey: axisKeysProviding.fullPathKey)
+    
+    let packagePathProviding = NYPLAxisPackagePathPrefixProvider()
+    let assetWriting = NYPLAssetWriter()
+    
+    self.init(delegate: delegate,
+              isbn: isbn,
+              bookVaultId: bookVaultId,
+              fileURL: fileURL,
+              book: book,
+              deviceInfoProviding: deviceInfoProviding,
+              packageEndpointproviding: endpointProviding,
+              packagePathProviding: packagePathProviding,
+              axisKeysProviding: axisKeysProviding,
+              assetWriter: assetWriting)
   }
   
-  /// Fulfill AxisNow license. Notifies NYPLBookDownloadBroadcasting upon completion or failure.
-  /// - Parameters:
-  ///   - downloadTask: downloadTask download task
-  @objc func fulfillAxisLicense(downloadTask: URLSessionDownloadTask) {
+  private static func logInitializationFailure(_ reason: String,
+                                               json: [String: Any]? = nil) {
     
+    var metadata: [String: Any] = [:]
+    metadata[NYPLAxisService.reason] = reason
+    if let json = json {
+      metadata[NYPLAxisService.jsonContent] = json
+    }
+    
+    NYPLErrorLogger.logError(
+      withCode: .axisDRMFulfillmentFail,
+      summary: NYPLAxisService.initializationFailureSummary,
+      metadata: metadata)
   }
   
 }

--- a/Simplified/AxisService/NYPLAxisXML.swift
+++ b/Simplified/AxisService/NYPLAxisXML.swift
@@ -1,0 +1,125 @@
+//
+//  AxisXML.swift
+//  Simplified
+//
+//  Created by Raman Singh on 2021-04-06.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+#if AXIS
+
+/// A wrapper class which aids debugging and allows recursive search with a given key in an NYPLXML object.
+struct NYPLAxisXML: CustomStringConvertible {
+  let children: [NYPLAxisXML]
+  let attributes: [AnyHashable: Any]
+  let name: String
+  let nameSpaceURI: String
+  let qualifiedName: String
+  let value: String
+  
+  // MARK: - Static Constants
+  static private let summary = "AXIS: Failed to generate AXISXML from data"
+  static let NYPLXMLGenerationFailure = "Failed generating NYPL XML from data"
+  
+  init(xml: NYPLXML) {
+    self.children = xml.children.compactMap({ $0 as? NYPLXML }).map { NYPLAxisXML(xml: $0) }
+    self.attributes = xml.attributes
+    self.name = xml.name
+    self.nameSpaceURI = xml.namespaceURI
+    self.qualifiedName = xml.qualifiedName
+    self.value = xml.value
+  }
+  
+  /// Failable initializer for AXISXML. Returns nil if data is nil or NYPLXML initialization fails. Logs erron on
+  /// failure
+  init?(data: Data?) {
+    guard let data = data else {
+      NYPLErrorLogger.logError(
+        withCode: .axisDRMFulfillmentFail,
+        summary: NYPLAxisXML.summary,
+        metadata: [NYPLAxisService.reason: NYPLAxisService.nilDataFromFileURLFailure])
+      
+      return nil
+    }
+    
+    guard let xml = NYPLXML(data: data) else {
+        NYPLErrorLogger.logError(
+          withCode: .axisDRMFulfillmentFail,
+          summary: NYPLAxisXML.summary,
+          metadata: [NYPLAxisService.reason: NYPLAxisXML.NYPLXMLGenerationFailure])
+        
+        return nil
+    }
+    
+    self.init(xml: xml)
+  }
+  
+  /// For debugging purposes
+  var description: String {
+    var result = "children: \(children.map { $0.name })"
+    result = result + "\nattributes: \(attributes)"
+    result = result + "\nname: \(name)"
+    result = result + "\nnameSpaceURI: \(nameSpaceURI)"
+    result = result + "\nqualifiedName: \(qualifiedName)"
+    result = result + "\nvalue: \(value)"
+    return result
+  }
+  
+  /// Finds and returns all values within the xml and its children matching the given key.
+  ///
+  /// Note: We're doing something akin to a `depth first pre-order search` of a general tree here.
+  /// The time complexity is `O(n)` where n is the number of nodes (children and their children and so forth).
+  /// The space complexity will be `O(|m|)` where `m` is the average size of each node.
+  ///
+  /// This method can be expensive for large xmls with lots of elements and sub elements. Since we don't
+  /// exit until all the nodes have been visited, there is no `best case` and all cases are `worst case`.
+  ///
+  /// - Parameter key: Key for the item
+  /// - Returns: An array of items matching the specified key. Returns an empty array if no element with
+  /// given key is found.
+  func findRecursivelyInAttributes(_ key: String) -> [String] {
+    var initial: [String] = []
+    if let value = self.attributes[key] as? String {
+      initial.append(value)
+    }
+    
+    let childValues = children
+      .map { $0.findRecursivelyInAttributes(key)}
+      .filter { !$0.isEmpty }
+      .flatMap { $0 }
+    
+    return initial + childValues
+  }
+  
+  /// Finds and returns the value of the first element in the xml and its children whose key matches the given
+  /// key.
+  ///
+  /// Note: We're doing something akin to a `depth first pre-order search` of a general tree here.
+  /// The time complexity is `O(n)` where n is the number of nodes (children and their children and so forth).
+  /// The space complexity will be `O(|m|)` where `m` is the average size of each node.
+  ///
+  /// Since we exist as soon as we find a node which matches the criteria, we have a `best case` where
+  /// time complexity is `O(1)` and space complexity is `O(v)` where v is the size of the first node
+  /// visitied.
+  ///
+  /// - Parameter key: Key for the item
+  /// - Returns: The first value found in the xml or in one of its children whose key matches the given key.
+  /// Returns nil if no element with given key is found.
+  func findFirstRecursivelyInAttributes(_ key: String) -> String? {
+    if let value = self.attributes[key] as? String {
+      return value
+    }
+    
+    for child in children {
+      if let value = child.findFirstRecursivelyInAttributes(key) {
+        return value
+      }
+    }
+    
+    return nil
+  }
+}
+
+#endif

--- a/Simplified/AxisService/NYPLRSACypher.swift
+++ b/Simplified/AxisService/NYPLRSACypher.swift
@@ -1,0 +1,200 @@
+//
+//  NYPLRSACypher.swift
+//  Simplified
+//
+//  Created by Raman Singh on 2021-04-06.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+#if AXIS
+
+protocol NYPLRSACryptographing {
+  var publicKey: String { get }
+  var privateKey: String { get }
+  var modulus: String { get }
+  var exponent: String { get }
+  func encryptText(_ message: String) -> String?
+  func decryptText(_ encryptedString: String) -> String?
+}
+
+struct NYPLRSACypher: NYPLRSACryptographing {
+  
+  let exponent: String
+  let modulus: String
+  let privateKey: String
+  let publicKey: String
+  private let privateKeySec: SecKey
+  private let publicKeySec: SecKey
+  
+  // MARK: - Static Constants
+  
+  // Key generation constants
+  static private let nyplRSAPrivate = "nypl.rsa.private"
+  static private let nyplRSAPublic = "nypl.rsa.public"
+  
+  // Failed Intitialization constants
+  static private let failedInitializationSummary = "AXIS: Failed to create NYPLRSACypher object!"
+  static private let publicSecKeyGenerationFailure = "Failed to generate public SecKey"
+  static private let privateSecKeyGenerationFailure = "Failed to generate private SecKey"
+  static private let resultPublicKeyGenerationFailure = "Failed to generate resultPublicKey"
+  static private let resultPrivateKeyGenerationFailure = "Failed to generate resultPrivateKey"
+  
+  // Failed Encryption/Decryption constants
+  static private let failedEncryptionSummary = "AXIS: Failed to encrypt text with public key"
+  static private let failedDecryptionSummary = "AXIS: Failed to decrypt text with private key"
+  static private let stringToDataConversionFailure = "Failed to convert message to data"
+  static private let nilEncryptedDataFailure = "encryptedData was nil"
+  static private let nilDecryptedDataFailure = "decryptedData was nil"
+  
+  private static var pub_attributes: CFDictionary = {
+    var keyPairAttr = [NSObject: NSObject]()
+    keyPairAttr[kSecAttrKeyType] = kSecAttrKeyTypeRSA
+    keyPairAttr[kSecAttrKeySizeInBits] = 2048 as NSObject
+    keyPairAttr[kSecPublicKeyAttrs] = publicKeyAttr as NSObject
+    keyPairAttr[kSecPrivateKeyAttrs] = privateKeyAttr as NSObject
+    return keyPairAttr as CFDictionary
+  }()
+  
+  private static let privateKeyAttr: [NSObject: NSObject] = [
+    kSecAttrIsPermanent:true as NSObject,
+    kSecAttrApplicationTag:nyplRSAPrivate.data(using: String.Encoding.utf8)! as NSObject,
+    kSecClass: kSecClassKey,
+    kSecReturnData: kCFBooleanTrue]
+  
+  private static let publicKeyAttr: [NSObject: NSObject] = [
+    kSecAttrIsPermanent:true as NSObject,
+    kSecAttrApplicationTag:nyplRSAPublic.data(using: String.Encoding.utf8)! as NSObject,
+    kSecClass: kSecClassKey,
+    kSecReturnData: kCFBooleanTrue]
+  
+  // MARK: - Initialization
+  init?() {
+    var pubKeySec, privKeySec: SecKey?
+    SecKeyGeneratePair(NYPLRSACypher.pub_attributes, &pubKeySec, &privKeySec)
+    
+    guard let pubSec = pubKeySec else {
+      NYPLRSACypher
+        .logFailedInitializationError(NYPLRSACypher.publicSecKeyGenerationFailure)
+      return nil
+    }
+    
+    guard let privSec = privKeySec else {
+      NYPLRSACypher
+        .logFailedInitializationError(NYPLRSACypher.privateSecKeyGenerationFailure)
+      return nil
+    }
+    
+    self.publicKeySec = pubSec
+    self.privateKeySec = privSec
+    
+    var resultPublicKey: AnyObject?
+    var resultPrivateKey: AnyObject?
+    
+    let statusPublicKey = SecItemCopyMatching(
+      NYPLRSACypher.publicKeyAttr as CFDictionary,
+      &resultPublicKey)
+    
+    let statusPrivateKey = SecItemCopyMatching(
+      NYPLRSACypher.privateKeyAttr as CFDictionary,
+      &resultPrivateKey)
+    
+    guard let publicKey = resultPublicKey as? Data else {
+      NYPLRSACypher
+        .logFailedInitializationError(NYPLRSACypher.resultPublicKeyGenerationFailure)
+      return nil
+    }
+    
+    guard let privateKey = resultPrivateKey as? Data else {
+      NYPLRSACypher
+        .logFailedInitializationError(NYPLRSACypher.resultPrivateKeyGenerationFailure)
+      return nil
+    }
+    
+    guard statusPublicKey == noErr else {
+      NYPLRSACypher
+        .logFailedInitializationError("statusPublicKey was \(statusPublicKey)")
+      return nil
+    }
+    
+    guard statusPrivateKey == noErr else {
+      NYPLRSACypher
+        .logFailedInitializationError("statusPrivateKey was \(statusPrivateKey)")
+      return nil
+    }
+    
+    self.publicKey = publicKey.base64EncodedString()
+    self.privateKey = privateKey.base64EncodedString()
+    self.modulus = self.publicKey.replacingOccurrences(of: "/", with: "-")
+    // we're creating a key with 2048 bits. Exponent for that is AQAB.
+    self.exponent = "AQAB"
+  }
+  
+  func encryptText(_ message: String) -> String? {
+    let _messageData = message.data(using: .utf8)
+    
+    guard let messageData = _messageData else {
+      NYPLRSACypher
+        .logFailedEncryptionError(NYPLRSACypher.stringToDataConversionFailure)
+      return nil
+    }
+    guard let encryptedData = SecKeyCreateEncryptedData(publicKeySec,
+                                                        .rsaEncryptionOAEPSHA1,
+                                                        messageData as CFData,
+                                                        nil)
+      else {
+        NYPLRSACypher
+          .logFailedEncryptionError(NYPLRSACypher.nilEncryptedDataFailure)
+        return nil
+    }
+    
+    return (encryptedData as Data).base64EncodedString()
+  }
+  
+  func decryptText(_ encryptedString: String) -> String? {
+    let _messageData = Data(base64Encoded: encryptedString)
+    
+    guard let messageData = _messageData else {
+      NYPLRSACypher
+        .logFailedDecryptionError(NYPLRSACypher.stringToDataConversionFailure)
+      return nil
+    }
+    
+    guard let decryptData = SecKeyCreateDecryptedData(privateKeySec,
+                                                      .rsaEncryptionOAEPSHA1,
+                                                      messageData as CFData,
+                                                      nil)
+      else {
+        NYPLRSACypher
+          .logFailedDecryptionError(NYPLRSACypher.nilDecryptedDataFailure)
+        return nil
+    }
+    
+    return String(data: decryptData as Data, encoding: String.Encoding.utf8)
+  }
+  
+  static private func logFailedInitializationError(_ reason: String) {
+    NYPLErrorLogger.logError(
+      withCode: .axisCriptographyFail,
+      summary: NYPLRSACypher.failedInitializationSummary,
+      metadata: [NYPLAxisService.reason: reason])
+  }
+  
+  static private func logFailedEncryptionError(_ resson: String) {
+    NYPLErrorLogger.logError(
+      withCode: .axisCriptographyFail,
+      summary: NYPLRSACypher.failedEncryptionSummary,
+      metadata: [NYPLAxisService.reason: resson])
+  }
+  
+  static private func logFailedDecryptionError(_ reason: String) {
+    NYPLErrorLogger.logError(
+      withCode: .axisCriptographyFail,
+      summary: NYPLRSACypher.failedDecryptionSummary,
+      metadata: [NYPLAxisService.reason: reason])
+  }
+  
+}
+
+#endif

--- a/Simplified/Logging/NYPLErrorLogger.swift
+++ b/Simplified/Logging/NYPLErrorLogger.swift
@@ -106,6 +106,8 @@ fileprivate let nullString = "null"
   case adobeDRMFulfillmentFail = 1001
   case lcpDRMFulfillmentFail = 1002
   case lcpPassphraseAuthorizationFail = 1003
+  case axisDRMFulfillmentFail = 1004
+  case axisCriptographyFail = 1005
 
   // wrong content
   case unknownRightsManagement = 1100

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -352,7 +352,7 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
         NYPLAxisService *axisService = [[NYPLAxisService alloc]
                                         initWithDelegate:self
                                         fileURL:tmpSavedFileURL
-                                        deviceInfoProvider:deviceInfoProvider
+                                        deviceInfoProviding:deviceInfoProvider
                                         forBook:book];
         
         [axisService fulfillAxisLicenseWithDownloadTask:downloadTask];


### PR DESCRIPTION
**What's this do?**
Downloads required files for books with AXIS DRM

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-19

**How should this be tested? / Do these changes have associated tests?**
User should be able to download an AXIS book using QA library

**Dependencies for merging? Releasing to production?**
Relies on https://github.com/NYPL-Simplified/Simplified-iOS/pull/1367 to be merged in in order to avoid crashing upon book download

**Does this include changes that require a new SimplyE build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Raman Singh verified it.