### PR TITLE
OE-75 Hotfix to fix TenPrintCoverView crash on iOS 14.5

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -4042,7 +4042,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4063,7 +4063,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.OpenEbooks;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PRODUCT_NAME = "Open eBooks";
@@ -4099,7 +4099,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4120,7 +4120,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.OpenEbooks;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PRODUCT_NAME = "Open eBooks";


### PR DESCRIPTION
**What's this do?**
This simply updates the reference commit for the TenPrintCoverView library to include the fix @singhraman4282 did some time ago for SimplyE. This crash occurs also on Open eBooks but it's not as severe because we verified all books currently have covers. However, a failure can always happens and in that the app will crash on iOS 14.5.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-75

**How should this be tested? / Do these changes have associated tests?**
I will add QA steps in the ticket

**Dependencies for merging? Releasing to production?**
This is a hot fix that should be released ASAP, it's merging on the old 1.9.0 release baseline.

**Does this include changes that require a new SimplyE build for QA?**
definitely. 

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ettore 