### PR TITLE
IOS-193 Fix AdobeDRM decoding after recent changes in R2Shared

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -473,6 +473,11 @@
 		7369A38C2649C07F0029D8AB /* ZIPFoundation.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 732F0433263374FC0018A82E /* ZIPFoundation.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7369A38D2649C07F0029D8AB /* ZXingObjC.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 732F0480263378EF0018A82E /* ZXingObjC.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7369A3912649C0AF0029D8AB /* NYPLAEToolkit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 732F03C3263350DB0018A82E /* NYPLAEToolkit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7369A39C264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7369A39B264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift */; };
+		7369A39D264AF9710029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7369A39B264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift */; };
+		7369A39E264AF9710029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7369A39B264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift */; };
+		7369A39F264AF9710029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7369A39B264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift */; };
+		7369A3A0264AF9710029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7369A39B264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift */; };
 		736A54B8254B3C680031C3AA /* NYPLSAMLHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 730263AB2540DE4200A53891 /* NYPLSAMLHelper.m */; };
 		736A54BD254B3C6D0031C3AA /* NYPLSignInBusinessLogic+DRM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737F4A6A254A137900A3C34B /* NYPLSignInBusinessLogic+DRM.swift */; };
 		736A54BE254B3C730031C3AA /* NYPLSignInBusinessLogic+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A794A525477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift */; };
@@ -1967,6 +1972,7 @@
 		7364D69B2492A38C0087B056 /* Publication+NYPLAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publication+NYPLAdditions.swift"; sourceTree = "<group>"; };
 		7364FC6025B7C5AB00B0A9FD /* firebase-upload.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "firebase-upload.sh"; sourceTree = "<group>"; };
 		7369A37E2649C02D0029D8AB /* ReadiumLCP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ReadiumLCP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7369A39B264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAdobeContentProtectionService.swift; sourceTree = "<group>"; };
 		73735306256828EA00FE1B7E /* OpenEBooks_OPDS2_Catalog_Feed-QA.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "OpenEBooks_OPDS2_Catalog_Feed-QA.json"; sourceTree = "<group>"; };
 		7375AE5925382AC900C85211 /* NYPLUserAccountMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserAccountMock.swift; sourceTree = "<group>"; };
 		737B9F83244FC648002B4464 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
@@ -2528,6 +2534,7 @@
 				21F238C724991A2A004DC0B1 /* AdobeDRMLibraryService.swift */,
 				21DDE32725D2CEFC002CBCE3 /* AdobeDRMContentProtection.swift */,
 				21DDE32D25D31DB4002CBCE3 /* AdobeDRMFetcher.swift */,
+				7369A39B264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift */,
 			);
 			path = AdobeDRM;
 			sourceTree = "<group>";
@@ -4419,6 +4426,7 @@
 				73B550F42511720E00D05B86 /* NYPLConfiguration+SE.swift in Sources */,
 				73F11E0E2519458600FCD22B /* NYPLSettings+SE.swift in Sources */,
 				739E60D9244A0D8600D00301 /* NYPLKeychain.m in Sources */,
+				7369A39D264AF9710029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */,
 				739E60DB244A0D8600D00301 /* NYPLReaderContainerDelegateBase.m in Sources */,
 				739E60DC244A0D8600D00301 /* LibraryService.swift in Sources */,
 				739E60DD244A0D8600D00301 /* NYPLOPDSEntry.m in Sources */,
@@ -4580,6 +4588,7 @@
 				73EB0AC025821DF4006BC997 /* NSError+NYPLAdditions.swift in Sources */,
 				73EB0AC125821DF4006BC997 /* NYPLReachability.m in Sources */,
 				73EB0AC225821DF4006BC997 /* NYPLReaderViewController.m in Sources */,
+				7369A39F264AF9710029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */,
 				73EB0AC325821DF4006BC997 /* NYPLCatalogLaneCell.m in Sources */,
 				73EB0AC425821DF4006BC997 /* URLResponse+NYPL.swift in Sources */,
 				73EB0AC525821DF4006BC997 /* NYPLSettings+SE.swift in Sources */,
@@ -4777,6 +4786,7 @@
 				73FCA2D125005BA4001B0C5D /* NYPLReaderTOCViewController.m in Sources */,
 				73FCA2D225005BA4001B0C5D /* OPDS2CatalogsFeed.swift in Sources */,
 				739ECB2625101CCE00691A70 /* NSNotification+NYPL.swift in Sources */,
+				7369A3A0264AF9710029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */,
 				73FCA2D325005BA4001B0C5D /* BundledHTMLViewController.swift in Sources */,
 				73FCA2D425005BA4001B0C5D /* NYPLBookDetailView.m in Sources */,
 				73FCA2D525005BA4001B0C5D /* UIButton+NYPLAppearanceAdditions.m in Sources */,
@@ -5145,6 +5155,7 @@
 				AE77E9B832371587493FF281 /* NYPLOPDSEntry.m in Sources */,
 				11DC19281A12F92500721DBA /* NYPLReaderSettingsView.m in Sources */,
 				733DEC92241090C7008C74BC /* NYPLRootTabBarController+R2.swift in Sources */,
+				7369A39C264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */,
 				113DB8A719C24E54004E1154 /* NYPLIndeterminateProgressView.m in Sources */,
 				119BEB89198C43A600121439 /* NSString+NYPLStringAdditions.m in Sources */,
 				E6B6E76F1F6859A4007EE361 /* NYPLKeychainManager.swift in Sources */,
@@ -5561,6 +5572,7 @@
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5616,6 +5628,7 @@
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5908,6 +5921,7 @@
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5965,6 +5979,7 @@
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -475,7 +475,6 @@
 		7369A3912649C0AF0029D8AB /* NYPLAEToolkit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 732F03C3263350DB0018A82E /* NYPLAEToolkit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7369A39C264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7369A39B264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift */; };
 		7369A39D264AF9710029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7369A39B264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift */; };
-		7369A39E264AF9710029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7369A39B264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift */; };
 		7369A39F264AF9710029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7369A39B264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift */; };
 		7369A3A0264AF9710029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7369A39B264AF9700029D8AB /* NYPLAdobeContentProtectionService.swift */; };
 		736A54B8254B3C680031C3AA /* NYPLSAMLHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 730263AB2540DE4200A53891 /* NYPLSAMLHelper.m */; };
@@ -5571,7 +5570,6 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 4;
 				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
@@ -5627,7 +5625,6 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 4;
 				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
@@ -5682,7 +5679,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5741,7 +5738,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5920,7 +5917,6 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 4;
 				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
@@ -5978,7 +5974,6 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 4;
 				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
@@ -6,47 +6,77 @@
 //  Copyright © 2021 NYPL Labs. All rights reserved.
 //
 
+#if FEATURE_DRM_CONNECTOR
+
 import Foundation
 import R2Shared
 
-#if FEATURE_DRM_CONNECTOR
-
 class AdobeDRMContentProtection: ContentProtection {
-  func open(asset: PublicationAsset, fetcher: Fetcher, credentials: String?, allowUserInteraction: Bool, sender: Any?, completion: @escaping (CancellableResult<ProtectedAsset?, Publication.OpeningError>) -> Void) {
+  func open(asset: PublicationAsset,
+            fetcher: Fetcher,
+            credentials: String?,
+            allowUserInteraction: Bool,
+            sender: Any?,
+            completion: @escaping (CancellableResult<ProtectedAsset?,
+                                                     Publication.OpeningError>) -> Void) {
     
     // Publication asset must be a FileAsset, as we are opening a file
     // If not, we can't open and use Adobe DRM
     guard let fileAsset = asset as? FileAsset else {
-      NYPLErrorLogger.logError(nil, summary: "AdobeDRMContentProtection.open expected asset of FileAsset type, received \(type(of: asset)))")
-      completion(.failure(.unavailable(nil)))
+      NYPLErrorLogger.logError(withCode: .adobeDRMFulfillmentFail,
+                               summary: "Missing file asset while opening Adobe DRM epub",
+                               metadata: [
+                                "asset type": type(of: asset),
+                                "asset name": asset.name,
+                                "allowUserInteraction": allowUserInteraction
+                               ])
+      completion(.failure(.unsupportedFormat))
       return
     }
     
-    do {
-      // META-INF is a part of .epub structure
-      // Adobe DRM expects to find encryption algorithms for each .epub file in it
-      // Other DRM software may look for other files to underestand the type of .epub protection,
-      // for example, LCP is looking for .lcpl file to open .epub files.
-      let encryptionPath = "META-INF/encryption.xml"
-      let resource = fetcher.get(encryptionPath)
-      // If encryption.xml doesn't exist, this is not an Adobe DRM .epub
-      // resource.read().get() throws in this case
-      let encryptionData = try resource.read().get()
-      let adobeFetcher = AdobeDRMFetcher(url: fileAsset.url, fetcher: fetcher, encryptionData: encryptionData)
-      let protectedAsset = ProtectedAsset(
-        asset: asset,
-        fetcher: adobeFetcher,
-        onCreatePublication: nil
-      )
-      completion(.success(protectedAsset))
-    } catch {
+    guard let encryptionData = fetcher.fetchAdobeEncryptionData() else {
       // .success(nil) means it is not an asset protected with Adobe DRM
       // Streamer continues to iterate over available ContentProtections
       // Don't use .failure(...) in this case, it means .epub is protected with this type of Content Protection,
       // but it failed to open it.
       completion(.success(nil))
+      return
     }
-    
+
+    let adobeFetcher = AdobeDRMFetcher(url: fileAsset.url, fetcher: fetcher, encryptionData: encryptionData)
+    let protectedAsset = ProtectedAsset(
+      asset: asset,
+      fetcher: adobeFetcher,
+      onCreatePublication: { _, _, _, services in
+        services.setContentProtectionServiceFactory { pubServiceContext in
+          NYPLAdobeContentProtectionService(context: pubServiceContext)
+        }
+      }
+    )
+    completion(.success(protectedAsset))
+  }
+}
+
+private extension Fetcher {
+  func fetchAdobeEncryptionData() -> Data? {
+    // The `META-INF` directory is a part of EPUBs structure, and Adobe DRM
+    // expects to find encryption algorithms for each .epub file in it.
+    // Other DRM systems may look for other files to underestand the type of
+    // content protection: for example, LCP is looking for an .lcpl file.
+    let encryptionRelativePath = "META-INF/encryption.xml"
+
+    // If the encryption.xml file doesn't exist, this is definitely
+    // not an Adobe DRM .epub...
+    let resource = get("/" + encryptionRelativePath)
+
+    guard let data = try? resource.read().get() else {
+      // ... although let's attempt without the leading slash, since that
+      // expectation has been changing on the R2 side
+      let resource = get(encryptionRelativePath)
+      return try? resource.read().get()
+    }
+
+    return data
   }
 }
 

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMFetcher.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMFetcher.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2021 NYPL Labs. All rights reserved.
 //
 
+#if FEATURE_DRM_CONNECTOR
+
 import Foundation
 import R2Shared
-
-#if FEATURE_DRM_CONNECTOR
 
 /// Adobe DRM fetcher
 /// Decrypts .epub contents data
@@ -46,7 +46,7 @@ class AdobeDRMFetcher: Fetcher {
     do {
       let resource = fetcher.get(link)
       let encryptedData = try resource.read().get()
-      let href = link.href.starts(with: "/") ? String(link.href.dropFirst()) : link.href // remove leading /
+      let href = link.href.starts(with: "/") ? String(link.href.dropFirst()) : link.href
       let data = container.decode(encryptedData, at: href)
       return DataResource(link: link, data: data)
     } catch {
@@ -55,7 +55,7 @@ class AdobeDRMFetcher: Fetcher {
   }
   
   func close() {
-    // No need to close anything.
+    fetcher.close()
   }
 }
 

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/NYPLAdobeContentProtectionService.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/NYPLAdobeContentProtectionService.swift
@@ -1,0 +1,51 @@
+//
+//  NYPLAdobeContentProtectionService.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 5/11/21.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+#if FEATURE_DRM_CONNECTOR
+
+import Foundation
+import R2Shared
+import R2Streamer
+import R2Navigator
+
+final class NYPLAdobeContentProtectionService: ContentProtectionService {
+  var error: Error?
+  let context: PublicationServiceContext
+
+  init(context: PublicationServiceContext) {
+    self.context = context
+    self.error = nil
+    if let adobeFetcher = context.fetcher as? AdobeDRMFetcher {
+      if let drmError = adobeFetcher.container.epubDecodingError {
+        self.error = NSError(domain: "Adobe DRM decoding error",
+                             code: NYPLErrorCode.adobeDRMFulfillmentFail.rawValue,
+                             userInfo: [
+                              "AdobeDRMContainer error msg": drmError
+                             ])
+      }
+    }
+  }
+
+  /// A restricted publication has a limited access to its manifest and
+  /// resources and can’t be rendered with a Navigator. It is usually
+  /// only used to import a publication to the user’s bookshelf.
+  var isRestricted: Bool {
+    context.publication.ref == nil || error != nil
+  }
+
+  var rights: UserRights {
+    isRestricted ? AllRestrictedUserRights() : UnrestrictedUserRights()
+  }
+
+  var name: LocalizedString? {
+    LocalizedString.nonlocalized("Adobe DRM")
+  }
+
+}
+
+#endif

--- a/Simplified/Reader2/ReaderStackConfiguration/LibraryService.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/LibraryService.swift
@@ -32,14 +32,14 @@ final class LibraryService: Loggable {
   init(publicationServer: PublicationServer) {
     self.publicationServer = publicationServer
     
-    #if LCP
-    drmLibraryServices.append(LCPLibraryService())
-    #endif
-    
     #if FEATURE_DRM_CONNECTOR
     drmLibraryServices.append(AdobeDRMLibraryService())
     #endif
     
+    #if LCP
+    drmLibraryServices.append(LCPLibraryService())
+    #endif
+
     streamer = Streamer(
       contentProtections: drmLibraryServices.compactMap { $0.contentProtection }
     )


### PR DESCRIPTION
**What's this do?**
This is addressing the breakage we experienced after upgrading the latest R2 version, `2.0.0-beta.2`, after which opening books with Adobe DRM started failing. The [issue](https://github.com/readium/r2-shared-swift/issues/136) I opened on r2-shared-swift adds more background. This commit follows some of the suggestions from @mickael-menu from that discussion, particularly the requirement to have a `ContentProtectionService` implementation and making sure to close the `fetcher` once done. 
I decided for now to stick with our current fetcher implementation because it has been QA'ed for a while now and so far it has been reliable. The other solutions (such as using `TransformingFetcher` instead of our own custom implementation) are probably more correct but it seems risky introducing more fundamental changes right now.

@vladimirfedorov adding you too since you know more about this code, if you can, it would be great to have your input. Not sure if you're still using adobe drm but if so you might encounter this issue too.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/IOS-193

**How should this be tested? / Do these changes have associated tests?**
I will add instructions in the ticket.

**Dependencies for merging? Releasing to production?**
This fix doesn't need to be in 3.6.5, since R2 is still under a feature flag, so it's not blocking release.

**Does this include changes that require a new SimplyE build for QA?**
yes

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 