### PR TITLE
IOS-199 Error out if Adobe fulfillment fails

### DIFF
--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -267,7 +267,16 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
            fulfillWithACSMData:ACSMData
            tag:book.identifier
            userID:[[NYPLUserAccount sharedAccount] userID]
-           deviceID:[[NYPLUserAccount sharedAccount] deviceID]];
+           deviceID:[[NYPLUserAccount sharedAccount] deviceID]
+           completion:^(NSError *fulfillError) {
+            if (fulfillError) {
+              [self logBookDownloadFailure:book
+                                    reason:@"Unable to fulfill loan with Adobe"
+                              downloadTask:downloadTask
+                                  metadata:nil];
+              [self failDownloadWithAlertForBook:book];
+            }
+          }];
         }
 #endif
         break;


### PR DESCRIPTION
**What's this do?**
If Adobe DRM fails fulfilling a book loan request for whatever reason, SimplyE silently swallows the error and proceeds as nothing happened. This changes the behavior to fail immediately and report an error to the user.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/IOS-199

**How should this be tested? / Do these changes have associated tests?**
We should verify fulfillment works as before in the and that there are not false positives reported by Adobe. A regression should cover this.

**Dependencies for merging? Releasing to production?**
Requires https://github.com/NYPL-Simplified/DRM-iOS-Adobe/pull/20 to be merged first, then I have to update the commit hash for this PR to match that.

**Does this include changes that require a new SimplyE build for QA?**
this could go together with PR https://github.com/NYPL-Simplified/Simplified-iOS/pull/1389

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 