### PR TITLE
iOS-37 Call new endpoints for LibraryRegistry

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -113,6 +113,8 @@
 		11F3771F19DB62B000487769 /* NYPLFacetView.m in Sources */ = {isa = PBXBuildFile; fileRef = 11F3771E19DB62B000487769 /* NYPLFacetView.m */; };
 		11F3773319E0876F00487769 /* NYPLCatalogFacet.m in Sources */ = {isa = PBXBuildFile; fileRef = 11F3773219E0876F00487769 /* NYPLCatalogFacet.m */; };
 		145798F6215BE9E300F68AFD /* ProblemReportEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 145798F5215BE9E300F68AFD /* ProblemReportEmail.swift */; };
+		17045778265F27B7006DF664 /* NYPLFinderBusinessLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17045777265F27B7006DF664 /* NYPLFinderBusinessLogicTests.swift */; };
+		1704578F26601AE9006DF664 /* NYPLLibraryRegistryFeedRequestHandlerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1704578E26601AE9006DF664 /* NYPLLibraryRegistryFeedRequestHandlerMock.swift */; };
 		17071065242A923400E2648F /* NYPLSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17071060242A923400E2648F /* NYPLSecrets.swift */; };
 		171966A924170819007BB87E /* NYPLBookState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171966A824170819007BB87E /* NYPLBookState.swift */; };
 		173F0823241AAA4E00A64658 /* NYPLBookStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173F0822241AAA4E00A64658 /* NYPLBookStateTests.swift */; };
@@ -2085,6 +2087,8 @@
 		11F54C2619410C700086FCAF /* NYPLOPDSEntryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYPLOPDSEntryTests.m; sourceTree = "<group>"; };
 		11F54C2919423A040086FCAF /* NYPLOPDSLinkTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYPLOPDSLinkTests.m; sourceTree = "<group>"; };
 		145798F5215BE9E300F68AFD /* ProblemReportEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemReportEmail.swift; sourceTree = "<group>"; };
+		17045777265F27B7006DF664 /* NYPLFinderBusinessLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLFinderBusinessLogicTests.swift; sourceTree = "<group>"; };
+		1704578E26601AE9006DF664 /* NYPLLibraryRegistryFeedRequestHandlerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLLibraryRegistryFeedRequestHandlerMock.swift; sourceTree = "<group>"; };
 		17071060242A923400E2648F /* NYPLSecrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLSecrets.swift; sourceTree = "<group>"; };
 		171966A824170819007BB87E /* NYPLBookState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBookState.swift; sourceTree = "<group>"; };
 		173F0822241AAA4E00A64658 /* NYPLBookStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBookStateTests.swift; sourceTree = "<group>"; };
@@ -3197,6 +3201,7 @@
 				17BE24DF25FABA0900AE707F /* NYPLAgeCheckChoiceStorageMock.swift */,
 				17BE24E625FABCDE00AE707F /* NYPLUserAccountProviderMock.swift */,
 				17BE24EC25FB09F000AE707F /* NYPLCurrentLibraryAccountProviderMock.swift */,
+				1704578E26601AE9006DF664 /* NYPLLibraryRegistryFeedRequestHandlerMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -3937,6 +3942,7 @@
 				735350B624918432006021BD /* URLRequest+NYPLTests.swift */,
 				17ADCF4E254BB84800D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift */,
 				17BE24D625F85D2300AE707F /* NYPLAgeCheckTests.swift */,
+				17045777265F27B7006DF664 /* NYPLFinderBusinessLogicTests.swift */,
 			);
 			path = SimplifiedTests;
 			sourceTree = "<group>";
@@ -4718,6 +4724,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1704578F26601AE9006DF664 /* NYPLLibraryRegistryFeedRequestHandlerMock.swift in Sources */,
 				735DD0C225229DAC0096D1F9 /* NYPLCatalogFacetTests.m in Sources */,
 				7384C800242BB43400D5F960 /* NYPLCachingTests.swift in Sources */,
 				5D3A28D522D400D00042B3BD /* UserProfileDocumentTests.swift in Sources */,
@@ -4728,6 +4735,7 @@
 				17BE24DA25F85D2300AE707F /* NYPLAgeCheckTests.swift in Sources */,
 				17BE24E025FABA0900AE707F /* NYPLAgeCheckChoiceStorageMock.swift in Sources */,
 				7375AE5A25382AC900C85211 /* NYPLUserAccountMock.swift in Sources */,
+				17045778265F27B7006DF664 /* NYPLFinderBusinessLogicTests.swift in Sources */,
 				73C3CF5A25CB8D6100CA8166 /* NYPLNetworkExecutorMock.swift in Sources */,
 				735771AE2537687D00067CEA /* NYPLURLSettingsProviderMock.swift in Sources */,
 				735771B12537691800067CEA /* NYPLDRMAuthorizingMock.swift in Sources */,

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		1744DF4E2640B31B00CBAAA8 /* Stringable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1744DF492640B31A00CBAAA8 /* Stringable.swift */; };
 		175D76D6264DAE8500BD11BA /* bpl_authentication_document.json in Resources */ = {isa = PBXBuildFile; fileRef = 175D76D5264DAE8500BD11BA /* bpl_authentication_document.json */; };
 		175D76D7264DAE8500BD11BA /* bpl_authentication_document.json in Resources */ = {isa = PBXBuildFile; fileRef = 175D76D5264DAE8500BD11BA /* bpl_authentication_document.json */; };
+		175D77752655F55A00BD11BA /* OPDS2LibraryRegistryFeed.json in Resources */ = {isa = PBXBuildFile; fileRef = B51C1DFB22860513003B49A5 /* OPDS2LibraryRegistryFeed.json */; };
 		175E480824EF36520066A6CF /* NYPLAnnouncementBusinessLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175E480724EF36520066A6CF /* NYPLAnnouncementBusinessLogic.swift */; };
 		17631AED25E488CD006079C4 /* NYPLAgeCheckViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17631AEC25E488CD006079C4 /* NYPLAgeCheckViewController.swift */; };
 		17631AEE25E488CD006079C4 /* NYPLAgeCheckViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17631AEC25E488CD006079C4 /* NYPLAgeCheckViewController.swift */; };
@@ -4441,6 +4442,7 @@
 				2D4379FE1C46FDB600AE1AD5 /* ReaderClientCert.sig in Resources */,
 				17E81F2C261FF758001003C2 /* Localizable.stringsdict in Resources */,
 				2D6256911D41582A0080A81F /* software-licenses.html in Resources */,
+				175D77752655F55A00BD11BA /* OPDS2LibraryRegistryFeed.json in Resources */,
 				E65977C51F82AC91003CD6BC /* NYPL_Launch_Screen.storyboard in Resources */,
 				03F94CCF1DD627AA00CE8F4F /* Accounts.json in Resources */,
 				A823D81B192BABA400B55DE2 /* InfoPlist.strings in Resources */,

--- a/Simplified/Accounts/Library/AccountsManager.swift
+++ b/Simplified/Accounts/Library/AccountsManager.swift
@@ -12,9 +12,14 @@ let currentAccountIdentifierKey  = "NYPLCurrentAccountIdentifier"
   func account(_ uuid: String) -> Account?
 }
 
+protocol NYPLLibraryRegistryFeedRequestHandling {
+  func accounts(_ key: String?) -> [Account]
+  func loadCatalogs(url: URL?, completion: ((Bool) -> ())?)
+}
+
 /// Manage the library accounts for the app.
 /// Initialized with JSON.
-@objcMembers final class AccountsManager: NSObject, NYPLLibraryAccountsProvider
+@objcMembers final class AccountsManager: NSObject, NYPLLibraryAccountsProvider, NYPLLibraryRegistryFeedRequestHandling
 {
   static let NYPLAccountUUIDs = [
     "urn:uuid:065c0c11-0d0f-42a3-82e4-277b18786949", //NYPL proper

--- a/Simplified/Accounts/Library/AccountsManager.swift
+++ b/Simplified/Accounts/Library/AccountsManager.swift
@@ -251,10 +251,14 @@ let currentAccountIdentifierKey  = "NYPLCurrentAccountIdentifier"
   /// - Parameter completion: Always invoked at the end of the load process.
   /// No guarantees are being made about whether this is called on the main
   /// thread or not.
-  func loadCatalogs(completion: ((Bool) -> ())?) {
+  func loadCatalogs(url: URL? = nil, completion: ((Bool) -> ())?) {
     Log.debug(#file, "Entering loadCatalog...")
-    let targetUrl = NYPLSettings.shared.useBetaLibraries ? NYPLConfiguration.betaUrl : NYPLConfiguration.prodUrl
+    var targetUrl = NYPLSettings.shared.useBetaLibraries ? NYPLConfiguration.betaUrl : NYPLConfiguration.prodUrl
     let hash = NYPLSettings.shared.useBetaLibraries ? NYPLConfiguration.betaFeedKeyHash : NYPLConfiguration.prodFeedKeyHash
+    
+    if let url = url {
+      targetUrl = url
+    }
 
     let wasAlreadyLoading = addLoadingCompletionHandler(key: hash, completion)
     guard !wasAlreadyLoading else { return }

--- a/Simplified/Accounts/Library/AccountsManager.swift
+++ b/Simplified/Accounts/Library/AccountsManager.swift
@@ -107,7 +107,7 @@ protocol NYPLLibraryRegistryFeedRequestHandling {
   #endif
 
   private override init() {
-    self.accountSet = NYPLSettings.shared.useBetaLibraries ? NYPLConfiguration.betaFeedKeyHash : NYPLConfiguration.prodFeedKeyHash
+    self.accountSet = NYPLConfiguration.feedKeyHash
     self.ageCheck = NYPLAgeCheck(ageCheckChoiceStorage: NYPLSettings.shared)
     
     super.init()
@@ -253,13 +253,14 @@ protocol NYPLLibraryRegistryFeedRequestHandling {
   /// After loading the library accounts, the authentication document
   /// for the current library will be loaded in sequence.
   ///
+  /// - Parameter url: Url for library registry feed if specified.
   /// - Parameter completion: Always invoked at the end of the load process.
   /// No guarantees are being made about whether this is called on the main
   /// thread or not.
   func loadCatalogs(url: URL? = nil, completion: ((Bool) -> ())?) {
     Log.debug(#file, "Entering loadCatalog...")
     var targetUrl = NYPLSettings.shared.useBetaLibraries ? NYPLConfiguration.betaUrl : NYPLConfiguration.prodUrl
-    let hash = NYPLSettings.shared.useBetaLibraries ? NYPLConfiguration.betaFeedKeyHash : NYPLConfiguration.prodFeedKeyHash
+    let hash = NYPLConfiguration.feedKeyHash
     
     if let url = url {
       targetUrl = url
@@ -330,7 +331,7 @@ protocol NYPLLibraryRegistryFeedRequestHandling {
 
   func updateAccountSet(completion: ((Bool) -> ())?) {
     accountSetsWorkQueue.sync(flags: .barrier) {
-      self.accountSet = NYPLSettings.shared.useBetaLibraries ? NYPLConfiguration.betaFeedKeyHash : NYPLConfiguration.prodFeedKeyHash
+      self.accountSet = NYPLConfiguration.feedKeyHash
     }
 
     if self.accounts().isEmpty {

--- a/Simplified/Accounts/Library/AccountsManager.swift
+++ b/Simplified/Accounts/Library/AccountsManager.swift
@@ -102,7 +102,7 @@ let currentAccountIdentifierKey  = "NYPLCurrentAccountIdentifier"
   #endif
 
   private override init() {
-    self.accountSet = NYPLSettings.shared.useBetaLibraries ? NYPLConfiguration.betaUrlHash : NYPLConfiguration.prodUrlHash
+    self.accountSet = NYPLSettings.shared.useBetaLibraries ? NYPLConfiguration.betaFeedKeyHash : NYPLConfiguration.prodFeedKeyHash
     self.ageCheck = NYPLAgeCheck(ageCheckChoiceStorage: NYPLSettings.shared)
     
     super.init()
@@ -254,8 +254,7 @@ let currentAccountIdentifierKey  = "NYPLCurrentAccountIdentifier"
   func loadCatalogs(completion: ((Bool) -> ())?) {
     Log.debug(#file, "Entering loadCatalog...")
     let targetUrl = NYPLSettings.shared.useBetaLibraries ? NYPLConfiguration.betaUrl : NYPLConfiguration.prodUrl
-    let hash = targetUrl.absoluteString.md5().base64EncodedStringUrlSafe()
-      .trimmingCharacters(in: ["="])
+    let hash = NYPLSettings.shared.useBetaLibraries ? NYPLConfiguration.betaFeedKeyHash : NYPLConfiguration.prodFeedKeyHash
 
     let wasAlreadyLoading = addLoadingCompletionHandler(key: hash, completion)
     guard !wasAlreadyLoading else { return }
@@ -322,7 +321,7 @@ let currentAccountIdentifierKey  = "NYPLCurrentAccountIdentifier"
 
   func updateAccountSet(completion: ((Bool) -> ())?) {
     accountSetsWorkQueue.sync(flags: .barrier) {
-      self.accountSet = NYPLSettings.shared.useBetaLibraries ? NYPLConfiguration.betaUrlHash : NYPLConfiguration.prodUrlHash
+      self.accountSet = NYPLSettings.shared.useBetaLibraries ? NYPLConfiguration.betaFeedKeyHash : NYPLConfiguration.prodFeedKeyHash
     }
 
     if self.accounts().isEmpty {

--- a/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
@@ -20,7 +20,7 @@ extension NYPLConfiguration {
                      ofType: "json")!)
   private static let prodFeedKey = "OpenEBooksLibraryRegistryProdFeedKey"
   
-  static var prodUrl = feedFileUrl
+  static let prodUrl = feedFileUrl
   private static let prodFeedKeyHash = prodFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
 
   // MARK:- Beta library catalog
@@ -32,7 +32,7 @@ extension NYPLConfiguration {
                      ofType: "json")!)
   private static let betaFeedKey = "OpenEBooksLibraryRegistryBetaFeedKey"
 
-  static var betaUrl = betaFeedFileUrl
+  static let betaUrl = betaFeedFileUrl
   private static let betaFeedKeyHash = betaFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
   
   static let feedKeyHash = {

--- a/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
@@ -21,7 +21,7 @@ extension NYPLConfiguration {
   private static let prodFeedKey = "OpenEBooksLibraryRegistryProdFeedKey"
   
   static var prodUrl = feedFileUrl
-  static let prodFeedKeyHash = prodFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+  private static let prodFeedKeyHash = prodFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
 
   // MARK:- Beta library catalog
 
@@ -32,7 +32,7 @@ extension NYPLConfiguration {
                      ofType: "json")!)
   private static let betaFeedKey = "OpenEBooksLibraryRegistryBetaFeedKey"
 
-  private static var betaUrl = betaFeedFileUrl
+  static var betaUrl = betaFeedFileUrl
   private static let betaFeedKeyHash = betaFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
   
   static let feedKeyHash = {

--- a/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
@@ -18,9 +18,10 @@ extension NYPLConfiguration {
   private static let feedFileUrl = URL(fileURLWithPath:
     Bundle.main.path(forResource: "OpenEBooks_OPDS2_Library_Registry_Feed",
                      ofType: "json")!)
-  private static let feedFileUrlHash = feedFileUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+  private static let prodFeedKey = "OpenEBooksLibraryRegistryProdFeedKey"
+  
   static var prodUrl = feedFileUrl
-  static var prodUrlHash = feedFileUrlHash
+  static let prodFeedKeyHash = prodFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
 
   // MARK:- Beta library catalog
 
@@ -29,10 +30,10 @@ extension NYPLConfiguration {
   private static let betaFeedFileUrl = URL(fileURLWithPath:
     Bundle.main.path(forResource: "OpenEBooks_OPDS2_Library_Registry_Feed-QA",
                      ofType: "json")!)
-  private static let betaFeedFileUrlHash = feedFileUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+  private static let betaFeedKey = "OpenEBooksLibraryRegistryBetaFeedKey"
 
   static var betaUrl = betaFeedFileUrl
-  static var betaUrlHash = feedFileUrlHash
+  static let betaFeedKeyHash = betaFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
 
   // MARK:-
 

--- a/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
@@ -32,8 +32,12 @@ extension NYPLConfiguration {
                      ofType: "json")!)
   private static let betaFeedKey = "OpenEBooksLibraryRegistryBetaFeedKey"
 
-  static var betaUrl = betaFeedFileUrl
-  static let betaFeedKeyHash = betaFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+  private static var betaUrl = betaFeedFileUrl
+  private static let betaFeedKeyHash = betaFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+  
+  static let feedKeyHash = {
+    return NYPLSettings.shared.useBetaLibraries ? betaFeedKeyHash : prodFeedKeyHash
+  }()
 
   // MARK:-
 

--- a/Simplified/AppInfrastructure/NYPLConfiguration+SE.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+SE.swift
@@ -10,24 +10,18 @@ import Foundation
 
 extension NYPLConfiguration {
 
-//  static let betaUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries/qa")!
-//  static let prodUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries")!
-  
-  // TODO: Using sample feed data for testing,
-  //        remove URLs below when ready for production,
-  //        remove SimplyE from json file's targets
-  static let betaUrl = URL(fileURLWithPath:
-    Bundle.main.path(forResource: "OPDS2LibraryRegistryFeed",
-                     ofType: "json")!)
-  static let prodUrl = URL(fileURLWithPath:
-    Bundle.main.path(forResource: "OPDS2LibraryRegistryFeed",
-                     ofType: "json")!)
+  static let betaUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries/qa")!
+  static let prodUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries")!
 
   private static let betaFeedKey = "SimplyELibraryRegistryBetaFeedKey"
   private static let prodFeedKey = "SimplyELibraryRegistryProdFeedKey"
   
-  static let betaFeedKeyHash = betaFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
-  static let prodFeedKeyHash = prodFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+  private static let betaFeedKeyHash = betaFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+  private static let prodFeedKeyHash = prodFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+  
+  static let feedKeyHash = {
+    return NYPLSettings.shared.useBetaLibraries ? betaFeedKeyHash : prodFeedKeyHash
+  }()
 
   @objc static func mainColor() -> UIColor {
     let libAccount = AccountsManager.sharedInstance().currentAccount

--- a/Simplified/AppInfrastructure/NYPLConfiguration+SE.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+SE.swift
@@ -10,11 +10,24 @@ import Foundation
 
 extension NYPLConfiguration {
 
-  static let betaUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries/qa")!
-  static let prodUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries")!
+//  static let betaUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries/qa")!
+//  static let prodUrl = URL(string: "https://libraryregistry.librarysimplified.org/libraries")!
+  
+  // TODO: Using sample feed data for testing,
+  //        remove URLs below when ready for production,
+  //        remove SimplyE from json file's targets
+  static let betaUrl = URL(fileURLWithPath:
+    Bundle.main.path(forResource: "OPDS2LibraryRegistryFeed",
+                     ofType: "json")!)
+  static let prodUrl = URL(fileURLWithPath:
+    Bundle.main.path(forResource: "OPDS2LibraryRegistryFeed",
+                     ofType: "json")!)
 
-  static let betaUrlHash = betaUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
-  static let prodUrlHash = prodUrl.absoluteString.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+  private static let betaFeedKey = "SimplyELibraryRegistryBetaFeedKey"
+  private static let prodFeedKey = "SimplyELibraryRegistryProdFeedKey"
+  
+  static let betaFeedKeyHash = betaFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
+  static let prodFeedKeyHash = prodFeedKey.md5().base64EncodedStringUrlSafe().trimmingCharacters(in: ["="])
 
   @objc static func mainColor() -> UIColor {
     let libAccount = AccountsManager.sharedInstance().currentAccount

--- a/Simplified/LibraryFinder/NYPLLibraryFinderBusinessLogic.swift
+++ b/Simplified/LibraryFinder/NYPLLibraryFinderBusinessLogic.swift
@@ -45,10 +45,10 @@ class NYPLLibraryFinderBusinessLogic: NSObject, NYPLLibraryFinderDataProviding {
   
   var userLocation: CLLocationCoordinate2D? = nil
   
-  init(userAccounts: [Account] = [Account](), requestHandler: NYPLLibraryRegistryFeedRequestHandling) {
+  init(userAccounts: [Account] = [Account](), libraryRegistry: NYPLLibraryRegistryFeedRequestHandling) {
     self.userAccounts = userAccounts
     self.newLibraryAccounts = [Account]()
-    self.libraryRegistry = requestHandler
+    self.libraryRegistry = libraryRegistry
   }
   
   func requestLibraryList(searchKeyword: String?, completion: @escaping (Bool) -> ()) {

--- a/Simplified/LibraryFinder/NYPLLibraryFinderBusinessLogic.swift
+++ b/Simplified/LibraryFinder/NYPLLibraryFinderBusinessLogic.swift
@@ -41,7 +41,7 @@ class NYPLLibraryFinderBusinessLogic: NSObject, NYPLLibraryFinderDataProviding {
   
   let userAccounts: [Account]
   var newLibraryAccounts: [Account]
-  let libraryRegistry: NYPLLibraryRegistryFeedRequestHandling
+  private let libraryRegistry: NYPLLibraryRegistryFeedRequestHandling
   
   var userLocation: CLLocationCoordinate2D? = nil
   
@@ -65,11 +65,7 @@ class NYPLLibraryFinderBusinessLogic: NSObject, NYPLLibraryFinderDataProviding {
       }
       
       if success {
-        let userAccountUUIDs: [String] = self.userAccounts.compactMap { $0.uuid }
-        let filteredAccounts = self.libraryRegistry.accounts(nil).filter {
-          !userAccountUUIDs.contains($0.uuid)
-        }
-        self.newLibraryAccounts = filteredAccounts
+        self.updateNewLibraryAccounts()
       }
       completion(success)
     }
@@ -112,5 +108,13 @@ class NYPLLibraryFinderBusinessLogic: NSObject, NYPLLibraryFinderDataProviding {
     urlComponents?.queryItems = queryItems
     
     return urlComponents?.url
+  }
+  
+  private func updateNewLibraryAccounts() {
+    let userAccountUUIDs: [String] = userAccounts.compactMap { $0.uuid }
+    let filteredAccounts = libraryRegistry.accounts(nil).filter {
+      !userAccountUUIDs.contains($0.uuid)
+    }
+    newLibraryAccounts = filteredAccounts
   }
 }

--- a/Simplified/LibraryFinder/NYPLLibraryFinderBusinessLogic.swift
+++ b/Simplified/LibraryFinder/NYPLLibraryFinderBusinessLogic.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreLocation
 
 protocol NYPLLibraryFinderDataProviding {
   var userAccounts: [Account] { get }
@@ -16,10 +17,21 @@ protocol NYPLLibraryFinderDataProviding {
   func requestLibraryList(searchKeyword: String?, completion: @escaping (Error?) -> ())
 }
 
+enum LibraryFinderQueryItemKey: String {
+  case location
+  case stage
+  case query
+}
+
 class NYPLLibraryFinderBusinessLogic: NSObject, NYPLLibraryFinderDataProviding {
+  private let searchUrlString = "http://librarysimplified.org/terms/rel/search"
+  private let nearbyUrlString = "http://librarysimplified.org/terms/rel/nearby"
+  
   // TODO: Use `let` instead of `var` if userAccounts is not intended to change
   var userAccounts: [Account]
   var newLibraryAccounts: [Account]
+  
+  var userLocation: CLLocationCoordinate2D? = nil
   
   init(userAccounts: [Account] = [Account](), newLibraryAccounts: [Account] = [Account]()) {
     // TODO: iOS-35 Fetch library list from new API endpoints
@@ -28,8 +40,47 @@ class NYPLLibraryFinderBusinessLogic: NSObject, NYPLLibraryFinderDataProviding {
   }
   
   func requestLibraryList(searchKeyword: String?, completion: @escaping (Error?) -> ()) {
-    // TODO: iOS-35 Perform API request with query keyword
-    // TODO: iOS-34 Add location information to request
+    var queryItems = [URLQueryItem]()
+    var targetUrlString = userLocation != nil ? nearbyUrlString : searchUrlString
+    
+    if let searchKeyword = searchKeyword,
+       searchKeyword.count > 0
+    {
+      targetUrlString = searchUrlString
+      queryItems.append(
+        URLQueryItem(
+          name: LibraryFinderQueryItemKey.query.rawValue,
+          value: searchKeyword
+        )
+      )
+    }
+    
+    if let location = userLocation {
+      let locationString = "\(location.latitude),\(location.longitude)"
+      queryItems.append(
+        URLQueryItem(
+          name: LibraryFinderQueryItemKey.location.rawValue,
+          value: locationString
+        )
+      )
+    }
+    
+    queryItems.append(
+      URLQueryItem(
+        name: LibraryFinderQueryItemKey.stage.rawValue,
+        value: NYPLSettings.shared.useBetaLibraries ? "all" : "production"
+      )
+    )
+    
+    var urlComponents = URLComponents(string: targetUrlString)
+    urlComponents?.queryItems = queryItems
+    
+    guard let targetUrl = urlComponents?.url else {
+      // Handle completion with error
+      return
+    }
+    
+    Log.debug(#function, targetUrl.absoluteString)
     
     // For testing
     Log.debug(#file, "API Request - request library list with keyword - \(searchKeyword)")

--- a/Simplified/LibraryFinder/UI/NYPLLibraryFinderLibraryCell.swift
+++ b/Simplified/LibraryFinder/UI/NYPLLibraryFinderLibraryCell.swift
@@ -65,10 +65,10 @@ class NYPLLibraryFinderLibraryCell: UICollectionViewCell {
     nameLabel.text = account.name
     // TODO: iOS-36 Assign data value to UI componenets after parser and data model are updated
     descriptionLabel.text = account.subtitle
-    distanceLabel.text = "20 Mi"
-    postalCodeLabel.text = "12345"
+    distanceLabel.text = account.distance
+    postalCodeLabel.text = account.area
     
-    configureBadgeLabel(text: "BADGE")
+    configureBadgeLabel(text: account.areaType)
   }
   
   private func setupUI() {

--- a/Simplified/LibraryFinder/UI/NYPLLibraryFinderViewController.swift
+++ b/Simplified/LibraryFinder/UI/NYPLLibraryFinderViewController.swift
@@ -152,22 +152,24 @@ class NYPLLibraryFinderViewController: UICollectionViewController, UICollectionV
     activityIndicator.isHidden = false
     activityIndicator.startAnimating()
     collectionView.isUserInteractionEnabled = false
-    dataProvider.requestLibraryList(searchKeyword: searchBar.text) { [weak self] error in
-      self?.didUpdateLibraryList(error: error)
+    dataProvider.requestLibraryList(searchKeyword: searchBar.text) { [weak self] success in
+      self?.didUpdateLibraryList(success: success)
     }
   }
   
-  private func didUpdateLibraryList(error: Error?) {
-    activityIndicator.stopAnimating()
-    activityIndicator.isHidden = true
-    collectionView.isUserInteractionEnabled = true
-    if let error = error {
-      let alert = NYPLAlertUtils.alert(title: "Failed to update library list", error: error as NSError)
-      present(alert, animated: true, completion: nil)
-      return
+  private func didUpdateLibraryList(success: Bool) {
+    NYPLMainThreadRun.asyncIfNeeded {
+      self.activityIndicator.stopAnimating()
+      self.activityIndicator.isHidden = true
+      self.collectionView.isUserInteractionEnabled = true
+      if !success {
+        let alert = NYPLAlertUtils.alert(title: "Failed to update library list", message: "UnknownRequestError")
+        self.present(alert, animated: true, completion: nil)
+        return
+      }
+      
+      self.collectionView.reloadSections([NYPLLibraryFinderSection.newLibrary.rawValue])
     }
-    
-    collectionView.reloadSections([NYPLLibraryFinderSection.newLibrary.rawValue])
   }
   
   // MARK: - UI Setup

--- a/Simplified/LibraryFinder/UI/NYPLLibraryFinderViewController.swift
+++ b/Simplified/LibraryFinder/UI/NYPLLibraryFinderViewController.swift
@@ -15,7 +15,7 @@ private enum NYPLLibraryFinderSection: Int, CaseIterable {
 }
 
 class NYPLLibraryFinderViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
-  var isMyLibraryHidden = false
+  var isMyLibraryHidden = true
   
   private let dataProvider: NYPLLibraryFinderDataProviding
   private var completion: (Account) -> ()

--- a/Simplified/LibraryFinder/UI/NYPLLibraryFinderViewController.swift
+++ b/Simplified/LibraryFinder/UI/NYPLLibraryFinderViewController.swift
@@ -49,6 +49,10 @@ class NYPLLibraryFinderViewController: UICollectionViewController, UICollectionV
   }
 
   override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    if UICollectionViewController.instancesRespond(to: #selector(collectionView(_:didSelectItemAt:))) {
+      super.collectionView(collectionView, didSelectItemAt: indexPath)
+    }
+    
     collectionView.deselectItem(at: indexPath, animated: true)
     
     if indexPath.section == NYPLLibraryFinderSection.newLibrary.rawValue {

--- a/Simplified/LibraryFinder/UI/NYPLLibraryFinderViewController.swift
+++ b/Simplified/LibraryFinder/UI/NYPLLibraryFinderViewController.swift
@@ -39,6 +39,7 @@ class NYPLLibraryFinderViewController: UICollectionViewController, UICollectionV
     registerCollectionViewCell()
     setupCollectionViewUI()
     setupActivityIndicator()
+    updateLibraryList()
   }
   
   // MARK: - CollectionView DataSource
@@ -147,7 +148,16 @@ class NYPLLibraryFinderViewController: UICollectionViewController, UICollectionV
   
   // MARK: - UI Update
   
-  func didUpdateLibraryList(error: Error?) {
+  private func updateLibraryList() {
+    activityIndicator.isHidden = false
+    activityIndicator.startAnimating()
+    collectionView.isUserInteractionEnabled = false
+    dataProvider.requestLibraryList(searchKeyword: searchBar.text) { [weak self] error in
+      self?.didUpdateLibraryList(error: error)
+    }
+  }
+  
+  private func didUpdateLibraryList(error: Error?) {
     activityIndicator.stopAnimating()
     activityIndicator.isHidden = true
     collectionView.isUserInteractionEnabled = true
@@ -245,12 +255,7 @@ extension NYPLLibraryFinderViewController: NYPLLibraryFinderDisplaying {
 
 extension NYPLLibraryFinderViewController: UISearchBarDelegate {
   func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-    activityIndicator.isHidden = false
-    activityIndicator.startAnimating()
-    collectionView.isUserInteractionEnabled = false
     searchBar.resignFirstResponder()
-    dataProvider.requestLibraryList(searchKeyword: searchBar.text) { [weak self] error in
-      self?.didUpdateLibraryList(error: error)
-    }
+    updateLibraryList()
   }
 }

--- a/Simplified/LibraryFinder/UI/NYPLLibraryFinderViewController.swift
+++ b/Simplified/LibraryFinder/UI/NYPLLibraryFinderViewController.swift
@@ -49,7 +49,6 @@ class NYPLLibraryFinderViewController: UICollectionViewController, UICollectionV
   }
 
   override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    super.collectionView(collectionView, didSelectItemAt: indexPath)
     collectionView.deselectItem(at: indexPath, animated: true)
     
     if indexPath.section == NYPLLibraryFinderSection.newLibrary.rawValue {
@@ -162,6 +161,7 @@ class NYPLLibraryFinderViewController: UICollectionViewController, UICollectionV
       self.activityIndicator.stopAnimating()
       self.activityIndicator.isHidden = true
       self.collectionView.isUserInteractionEnabled = true
+      self.backgroundLabel.isHidden = (self.dataProvider.newLibraryAccounts.count > 0)
       if !success {
         let alert = NYPLAlertUtils.alert(title: "Failed to update library list", message: "UnknownRequestError")
         self.present(alert, animated: true, completion: nil)
@@ -200,7 +200,6 @@ class NYPLLibraryFinderViewController: UICollectionViewController, UICollectionV
       layout.estimatedItemSize = CGSize(width: collectionView.bounds.width - insets, height: 100)
     }
     
-    // TODO: iOS-34 Only show background label when location service not allowed
     collectionView.backgroundView = backgroundLabel
   }
   

--- a/Simplified/Settings/NYPLSettingsAccountsList.swift
+++ b/Simplified/Settings/NYPLSettingsAccountsList.swift
@@ -18,13 +18,14 @@
     }
   }
   fileprivate var libraryAccounts: [Account]
-  fileprivate var userAddedSecondaryAccounts: [String]!
+  fileprivate var userAddedSecondaryAccounts: [String]
   fileprivate let manager: AccountsManager
   
   required init(accounts: [String]) {
     self.accounts = accounts
     self.manager = AccountsManager.shared
     self.libraryAccounts = manager.accounts()
+    self.userAddedSecondaryAccounts = [String]()
 
     super.init(nibName:nil, bundle:nil)
   }
@@ -199,7 +200,7 @@
       return
     }
     showLoadingUI(loadState: .success)
-    var array = userAddedSecondaryAccounts!
+    var array = userAddedSecondaryAccounts
     array.append(uuid)
     NYPLSettings.shared.settingsAccountsList = array
     accounts = array

--- a/Simplified/Settings/NYPLSettingsAccountsList.swift
+++ b/Simplified/Settings/NYPLSettingsAccountsList.swift
@@ -183,7 +183,7 @@
       AccountsManager.shared.account($0)
     }
     
-    let finderBusinessLogic = NYPLLibraryFinderBusinessLogic(userAccounts: userLibraryAccounts, requestHandler: AccountsManager.shared)
+    let finderBusinessLogic = NYPLLibraryFinderBusinessLogic(userAccounts: userLibraryAccounts, libraryRegistry: AccountsManager.shared)
     let finderVC = NYPLLibraryFinderViewController(dataProvider: finderBusinessLogic) { [weak self] account in
       self?.userAddedSecondaryAccounts.append(account.uuid)
       self?.updateSettingsAccountList()

--- a/Simplified/Settings/NYPLSettingsAccountsList.swift
+++ b/Simplified/Settings/NYPLSettingsAccountsList.swift
@@ -181,21 +181,8 @@
     let userLibraryAccounts = accounts.compactMap {
       AccountsManager.shared.account($0)
     }
-    let sortedLibraryAccounts = self.libraryAccounts.sorted { (a, b) in
-      // Check if we're one of the three "special" libraries that always come first.
-      // This is a complete hack.
-      let idA = AccountsManager.NYPLAccountUUIDs.firstIndex(of: a.uuid) ?? Int.max
-      let idB = AccountsManager.NYPLAccountUUIDs.firstIndex(of: b.uuid) ?? Int.max
-      if idA <= 2 || idB <= 2 {
-        // One of the libraries is special, so sort it first. Lower ids are "more
-        // special" than higher ids and thus show up earlier.
-        return idA < idB
-      }
-      // Neither library is special so we just go alphabetically.
-      return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
-    }
     
-    let finderBusinessLogic = NYPLLibraryFinderBusinessLogic(userAccounts: userLibraryAccounts, newLibraryAccounts: sortedLibraryAccounts)
+    let finderBusinessLogic = NYPLLibraryFinderBusinessLogic(userAccounts: userLibraryAccounts, requestHandler: AccountsManager.shared)
     let finderVC = NYPLLibraryFinderViewController(dataProvider: finderBusinessLogic) { [weak self] account in
       self?.userAddedSecondaryAccounts.append(account.uuid)
       self?.updateSettingsAccountList()
@@ -204,45 +191,6 @@
       self?.navigationController?.popViewController(animated: true)
     }
     self.navigationController?.pushViewController(finderVC, animated: true)
-    
-//    let alert = UIAlertController(title: NSLocalizedString(
-//      "Add Your Library",
-//      comment: "Title to tell a user that they can add another account to the list"),
-//                                  message: nil,
-//                                  preferredStyle: .actionSheet)
-//    alert.popoverPresentationController?.barButtonItem = self.navigationItem.rightBarButtonItem
-//    alert.popoverPresentationController?.permittedArrowDirections = .up
-//
-//    let sortedLibraryAccounts = self.libraryAccounts.sorted { (a, b) in
-//      // Check if we're one of the three "special" libraries that always come first.
-//      // This is a complete hack.
-//      let idA = AccountsManager.NYPLAccountUUIDs.firstIndex(of: a.uuid) ?? Int.max
-//      let idB = AccountsManager.NYPLAccountUUIDs.firstIndex(of: b.uuid) ?? Int.max
-//      if idA <= 2 || idB <= 2 {
-//        // One of the libraries is special, so sort it first. Lower ids are "more
-//        // special" than higher ids and thus show up earlier.
-//        return idA < idB
-//      }
-//      // Neither library is special so we just go alphabetically.
-//      return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
-//    }
-//
-//    for userAccount in sortedLibraryAccounts {
-//      if (!userAddedSecondaryAccounts.contains(userAccount.uuid) && userAccount.uuid != manager.currentAccount?.uuid) {
-//        alert.addAction(UIAlertAction(title: userAccount.name,
-//          style: .default,
-//          handler: { action in
-//            self.userAddedSecondaryAccounts.append(userAccount.uuid)
-//            self.updateSettingsAccountList()
-//            self.updateNavBar()
-//            self.tableView.reloadData()
-//        }))
-//      }
-//    }
-//
-//    alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel button title"), style: .cancel, handler:nil))
-//
-//    self.present(alert, animated: true, completion: nil)
   }
   
   private func updateSettingsAccountList() {
@@ -254,6 +202,7 @@
     var array = userAddedSecondaryAccounts!
     array.append(uuid)
     NYPLSettings.shared.settingsAccountsList = array
+    accounts = array
   }
   
   // MARK: UITableViewDataSource

--- a/Simplified/WelcomeScreen/NYPLWelcomeScreenViewController.swift
+++ b/Simplified/WelcomeScreen/NYPLWelcomeScreenViewController.swift
@@ -185,7 +185,7 @@ import PureLayout
     }
     
     let presentLibraryFinder = {
-      let finderBusinessLogic = NYPLLibraryFinderBusinessLogic(requestHandler: AccountsManager.shared)
+      let finderBusinessLogic = NYPLLibraryFinderBusinessLogic(libraryRegistry: AccountsManager.shared)
       let finderVC = NYPLLibraryFinderViewController(dataProvider: finderBusinessLogic) { [weak self] account in
         guard let self = self else {
           return

--- a/Simplified/WelcomeScreen/NYPLWelcomeScreenViewController.swift
+++ b/Simplified/WelcomeScreen/NYPLWelcomeScreenViewController.swift
@@ -185,11 +185,7 @@ import PureLayout
     }
     
     let presentLibraryFinder = {
-      var userAccounts = [Account]()
-      if let simplyEAccount = AccountsManager.shared.account(AccountsManager.shared.SimplyEAccountUUID) {
-        userAccounts.append(simplyEAccount)
-      }
-      let finderBusinessLogic = NYPLLibraryFinderBusinessLogic(userAccounts: userAccounts)
+      let finderBusinessLogic = NYPLLibraryFinderBusinessLogic(requestHandler: AccountsManager.shared)
       let finderVC = NYPLLibraryFinderViewController(dataProvider: finderBusinessLogic) { [weak self] account in
         guard let self = self else {
           return

--- a/SimplifiedTests/Mocks/NYPLLibraryRegistryFeedRequestHandlerMock.swift
+++ b/SimplifiedTests/Mocks/NYPLLibraryRegistryFeedRequestHandlerMock.swift
@@ -1,0 +1,26 @@
+//
+//  NYPLLibraryRegistryFeedRequestHandlerMock.swift
+//  SimplyETests
+//
+//  Created by Ernest Fan on 2021-05-27.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+@testable import SimplyE
+
+class NYPLLibraryRegistryFeedRequestHandlerMock: NYPLLibraryRegistryFeedRequestHandling {
+  var libraryAccounts: [Account] = [Account]()
+  var requestUrl: URL? = nil
+  
+  func accounts(_ key: String?) -> [Account] {
+    return libraryAccounts
+  }
+  
+  func loadCatalogs(url: URL?, completion: ((Bool) -> ())?) {
+    requestUrl = url
+    if let completion = completion {
+      completion(true)
+    }
+  }
+}

--- a/SimplifiedTests/NYPLFinderBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLFinderBusinessLogicTests.swift
@@ -1,0 +1,82 @@
+//
+//  NYPLFinderBusinessLogicTests.swift
+//  SimplyETests
+//
+//  Created by Ernest Fan on 2021-05-26.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import XCTest
+import CoreLocation
+
+@testable import SimplyE
+
+class NYPLFinderBusinessLogicTests: XCTestCase {
+
+  var businessLogic: NYPLLibraryFinderBusinessLogic!
+  var libraryRegistryMock: NYPLLibraryRegistryFeedRequestHandlerMock!
+  var libraryAccounts: [Account]!
+  
+  override func setUpWithError() throws {
+    libraryAccounts = [Account]()
+    let testFeedUrl = Bundle.init(for: OPDS2LibraryRegistryFeedTests.self)
+      .url(forResource: "OPDS2LibraryRegistryFeed", withExtension: "json")!
+    let data = try Data(contentsOf: testFeedUrl)
+    let feed = try OPDS2LibraryRegistryFeed.fromData(data)
+    for catalog in feed.catalogs {
+      libraryAccounts.append(Account(libraryCatalog: catalog))
+    }
+    
+    let userAccounts: [Account] = [libraryAccounts.first!]
+    
+    libraryRegistryMock = NYPLLibraryRegistryFeedRequestHandlerMock()
+    
+    businessLogic = NYPLLibraryFinderBusinessLogic(userAccounts: userAccounts, libraryRegistry: libraryRegistryMock)
+  }
+
+  override func tearDownWithError() throws {
+    libraryRegistryMock.requestUrl = nil
+    libraryRegistryMock.libraryAccounts = [Account]()
+    
+    businessLogic.userLocation = nil
+    businessLogic.newLibraryAccounts = [Account]()
+  }
+
+  func testLibraryRegistryRequestUrlWithSearchKeyword() throws {
+    businessLogic.requestLibraryList(searchKeyword: "test") { (success) in
+      XCTAssertEqual(self.libraryRegistryMock.requestUrl?.absoluteString, "http://librarysimplified.org/terms/rel/search?query=test&stage=all")
+    }
+  }
+
+  func testLibraryRegistryRequestUrlWithSearchKeywordAndLocation() throws {
+    businessLogic.userLocation = CLLocationCoordinate2DMake(41, -87)
+    businessLogic.requestLibraryList(searchKeyword: "test") { (success) in
+      XCTAssertEqual(self.libraryRegistryMock.requestUrl?.absoluteString, "http://librarysimplified.org/terms/rel/search?query=test&location=41.0,-87.0&stage=all")
+    }
+  }
+  
+  func testLibraryRegistryRequestUrlWithLocation() throws {
+    businessLogic.userLocation = CLLocationCoordinate2DMake(41, -87)
+    businessLogic.requestLibraryList(searchKeyword: nil) { (success) in
+      XCTAssertEqual(self.libraryRegistryMock.requestUrl?.absoluteString, "http://librarysimplified.org/terms/rel/nearby?location=41.0,-87.0&stage=all")
+    }
+    
+    businessLogic.requestLibraryList(searchKeyword: "") { (success) in
+      XCTAssertEqual(self.libraryRegistryMock.requestUrl?.absoluteString, "http://librarysimplified.org/terms/rel/nearby?location=41.0,-87.0&stage=all")
+    }
+  }
+  
+  func testUpdateBusinessLogicLibraryAccounts() throws {
+    XCTAssertEqual(businessLogic.newLibraryAccounts.count, 0)
+    libraryRegistryMock.libraryAccounts = libraryAccounts
+    
+    businessLogic.requestLibraryList(searchKeyword: "") { (success) in
+      XCTAssertEqual(self.businessLogic.newLibraryAccounts.count, self.libraryAccounts.count - self.businessLogic.userAccounts.count)
+    }
+    
+    libraryRegistryMock.libraryAccounts = [Account]()
+    businessLogic.requestLibraryList(searchKeyword: "") { (success) in
+      XCTAssertEqual(self.businessLogic.newLibraryAccounts.count, 0)
+    }
+  }
+}

--- a/SimplifiedTests/NYPLFinderBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLFinderBusinessLogicTests.swift
@@ -16,6 +16,7 @@ class NYPLFinderBusinessLogicTests: XCTestCase {
   var businessLogic: NYPLLibraryFinderBusinessLogic!
   var libraryRegistryMock: NYPLLibraryRegistryFeedRequestHandlerMock!
   var libraryAccounts: [Account]!
+  var stageValue: String!
   
   override func setUpWithError() throws {
     libraryAccounts = [Account]()
@@ -32,6 +33,8 @@ class NYPLFinderBusinessLogicTests: XCTestCase {
     libraryRegistryMock = NYPLLibraryRegistryFeedRequestHandlerMock()
     
     businessLogic = NYPLLibraryFinderBusinessLogic(userAccounts: userAccounts, libraryRegistry: libraryRegistryMock)
+    
+    stageValue = NYPLSettings.shared.useBetaLibraries ? LibraryFinderQueryStage.beta.rawValue : LibraryFinderQueryStage.production.rawValue
   }
 
   override func tearDownWithError() throws {
@@ -44,25 +47,25 @@ class NYPLFinderBusinessLogicTests: XCTestCase {
 
   func testLibraryRegistryRequestUrlWithSearchKeyword() throws {
     businessLogic.requestLibraryList(searchKeyword: "test") { (success) in
-      XCTAssertEqual(self.libraryRegistryMock.requestUrl?.absoluteString, "http://librarysimplified.org/terms/rel/search?query=test&stage=all")
+      XCTAssertEqual(self.libraryRegistryMock.requestUrl?.absoluteString, "http://librarysimplified.org/terms/rel/search?query=test&stage=" + self.stageValue)
     }
   }
 
   func testLibraryRegistryRequestUrlWithSearchKeywordAndLocation() throws {
     businessLogic.userLocation = CLLocationCoordinate2DMake(41, -87)
     businessLogic.requestLibraryList(searchKeyword: "test") { (success) in
-      XCTAssertEqual(self.libraryRegistryMock.requestUrl?.absoluteString, "http://librarysimplified.org/terms/rel/search?query=test&location=41.0,-87.0&stage=all")
+      XCTAssertEqual(self.libraryRegistryMock.requestUrl?.absoluteString, "http://librarysimplified.org/terms/rel/search?query=test&location=41.0,-87.0&stage=" + self.stageValue)
     }
   }
   
   func testLibraryRegistryRequestUrlWithLocation() throws {
     businessLogic.userLocation = CLLocationCoordinate2DMake(41, -87)
     businessLogic.requestLibraryList(searchKeyword: nil) { (success) in
-      XCTAssertEqual(self.libraryRegistryMock.requestUrl?.absoluteString, "http://librarysimplified.org/terms/rel/nearby?location=41.0,-87.0&stage=all")
+      XCTAssertEqual(self.libraryRegistryMock.requestUrl?.absoluteString, "http://librarysimplified.org/terms/rel/nearby?location=41.0,-87.0&stage=" + self.stageValue)
     }
     
     businessLogic.requestLibraryList(searchKeyword: "") { (success) in
-      XCTAssertEqual(self.libraryRegistryMock.requestUrl?.absoluteString, "http://librarysimplified.org/terms/rel/nearby?location=41.0,-87.0&stage=all")
+      XCTAssertEqual(self.libraryRegistryMock.requestUrl?.absoluteString, "http://librarysimplified.org/terms/rel/nearby?location=41.0,-87.0&stage=" + self.stageValue)
     }
   }
   


### PR DESCRIPTION
**What's this do?**
Dependency inject `AccountsManager` into `NYPLFinderBusinessLogic` in order to load registry feed
Construct request URL with new endpoints, user's location and search keyword
Some minor UI fixes and clean up

**Why are we doing this? (w/ JIRA link if applicable)**
[iOS-37](https://jira.nypl.org/browse/IOS-37)

**How should this be tested? / Do these changes have associated tests?**
Not ready to be tested

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 