### PR TITLE
OE-133: Opening a book from book details page dismisses book details page

### DIFF
--- a/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
+++ b/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
@@ -112,6 +112,13 @@ final class ReaderModule: ReaderModuleAPI {
       backItem.title = NSLocalizedString("Back", comment: "Text for Back button")
       readerVC.navigationItem.backBarButtonItem = backItem
       readerVC.hidesBottomBarWhenPushed = true
+      
+      // If the navigation controller is already presenting a view controller,
+      // we dismiss it so that it does not float on top the book being loaded.
+      if let presented = navigationController.presentedViewController {
+        presented.dismiss(animated: true, completion: nil)
+      }
+
       navigationController.pushViewController(readerVC, animated: true)
 
     } catch {


### PR DESCRIPTION
**What's this do?**
Dismisses book details view controller if presented before opening the book

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-133

**How should this be tested? / Do these changes have associated tests?**
Follow the steps in the ticket

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
Not yet

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Raman Singh verified on iPhone 12 Pro Max (14.4), iPad 9.7 inch Pro (13.3), and iPad 12.9 inch Pro (14.4)