### PR TITLE
OE-137: Hide activity indicator when book processing is completed

### DIFF
--- a/Simplified/Reader2/ReaderPresentation/NYPLRootTabBarController+R2.swift
+++ b/Simplified/Reader2/ReaderPresentation/NYPLRootTabBarController+R2.swift
@@ -38,6 +38,15 @@ import Foundation
         let alertController = NYPLAlertUtils.alert(title: "Content Protection Error", message: error.localizedDescription)
         NYPLAlertUtils.presentFromViewControllerOrNil(alertController: alertController, viewController: self, animated: true, completion: nil)
       }
+      
+      // We want to remove the activity handler after the book has succeeded or
+      // failed loading. Removing too early might allow the user to tap on the
+      // read button again before the book opens.
+      NotificationCenter.default.post(
+        name: NSNotification.NYPLBookProcessingDidChange,
+        object: nil,
+        userInfo: [
+          NYPLNotificationKeys.bookProcessingBookIDKey: book.identifier, NYPLNotificationKeys.bookProcessingValueKey: false])
     }
   }
 }


### PR DESCRIPTION
**What's this do?**
Hide activity indicator in book details view controller when book processing is completed

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-137

**How should this be tested? / Do these changes have associated tests?**
Follow the steps in the ticket

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
Not yet

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Raman Singh verified on iPhone 12 pro max (14.2) and iPad 9 Pro (13.7) 