### PR TITLE
OE-142: Fixed incorrect banner and button timer for some axis books

### DIFF
--- a/Simplified/Book/UI/NYPLBookButtonsView.m
+++ b/Simplified/Book/UI/NYPLBookButtonsView.m
@@ -303,9 +303,21 @@
       [self.book.defaultAcquisition.availability
        matchUnavailable:nil
        limited:^(NYPLOPDSAcquisitionAvailabilityLimited *const _Nonnull limited) {
+        
+        NSDate *untilDate = self.book.defaultAcquisition.availability.until;
+        NSDate *sinceDate = self.book.defaultAcquisition.availability.since;
+        
+        BOOL hasIncorrectDates = NO;
+        
+        if (untilDate && sinceDate) {
+          hasIncorrectDates = (untilDate.timeIntervalSinceReferenceDate - sinceDate.timeIntervalSinceReferenceDate == 3600);
+        }
+        
         if ([limited.until timeIntervalSinceNow] > 0) {
           [button setType:NYPLRoundedButtonTypeClock];
-          [button setEndDate:limited.until];
+          if (!hasIncorrectDates) {
+            [button setEndDate:limited.until];
+          }
         }
       }
        unlimited:nil

--- a/Simplified/Book/UI/NYPLBookDetailNormalView.m
+++ b/Simplified/Book/UI/NYPLBookDetailNormalView.m
@@ -177,8 +177,23 @@ typedef NS_ENUM (NSInteger, NYPLProblemReportButtonState) {
 -(NSString *)messageStringForNYPLBookButtonStateSuccessful
 {
   NSString *message = NSLocalizedString(@"BookDetailViewControllerDownloadSuccessfulTitle", nil);
-  if (self.book.defaultAcquisition.availability.until) {
-    NSString *timeUntilString = [self.book.defaultAcquisition.availability.until longTimeUntilString];
+  NSDate *untilDate = self.book.defaultAcquisition.availability.until;
+  if (untilDate) {
+    
+#if defined(AXIS)
+    /// On rare occasions, when we download a book, we get the until date an hour ahead of since date.
+    /// When that happens, we just show the original message.
+    NSDate *sinceDate = self.book.defaultAcquisition.availability.since;
+    if (sinceDate) {
+      BOOL incorrectDates = (untilDate.timeIntervalSinceReferenceDate - sinceDate.timeIntervalSinceReferenceDate == 3600);
+      
+      if (incorrectDates) {
+        return message;
+      }
+    }
+#endif
+    
+    NSString *timeUntilString = [untilDate longTimeUntilString];
     NSString *timeEstimateMessage = [NSString stringWithFormat:NSLocalizedString(@"It will expire in %@.", @"Tell the user how much time they have left for the book they have borrowed."),timeUntilString];
     return [NSString stringWithFormat:@"%@\n%@",message,timeEstimateMessage];
   } else {


### PR DESCRIPTION
**What's this do?**
Fixes incorrect expiration date on some axis books

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-142

**How should this be tested? / Do these changes have associated tests?**
Follow the steps in the ticket

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
Not yet

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Raman Singh verified it