### PR TITLE
OE-145: User initiated book download termination

### DIFF
--- a/Simplified/AxisService/NYPLAxisService.swift
+++ b/Simplified/AxisService/NYPLAxisService.swift
@@ -81,7 +81,8 @@ import Foundation
   /// - Parameters:
   ///   - downloadTask: downloadTask download task
   @objc func fulfillAxisLicense(downloadTask: URLSessionDownloadTask) {
-    DispatchQueue.global(qos: .utility).async {
+    DispatchQueue.global(qos: .utility).async { [weak self] in
+      guard let self = self else { return }
       self.downloadAndValidateLicense()
       self.downloadMetadataContent()
       self.downloadPackage()
@@ -114,6 +115,14 @@ import Foundation
     packageDownloader.downloadPackageContent()
   }
   
+  
+  /// Called when book download is terminated by the user. All downloaded files related to the book are
+  /// deleted and no more files are downloaded.
+  @objc func downloadCancelledByUser() {
+    axisItemDownloader.cancelDownload()
+    try? FileManager.default.removeItem(at: self.dedicatedWriteURL)
+  }
+ 
 }
 
 extension NYPLAxisService: NYPLAxisDownloadProgressListening {

--- a/SimplifiedTests/NYPLAxisTests/Mocks/NYPLAxisContentDownloaderMock.swift
+++ b/SimplifiedTests/NYPLAxisTests/Mocks/NYPLAxisContentDownloaderMock.swift
@@ -33,4 +33,8 @@ class NYPLAxisContentDownloaderMock: NYPLAxisContentDownloading {
     desiredResult = .success(data)
   }
   
+  func cancelAllDownloads(withError error: Error) {
+    desiredResult = .failure(error)
+  }
+  
 }

--- a/SimplifiedTests/NYPLAxisTests/Mocks/NYPLAxisMetadataServiceMock.swift
+++ b/SimplifiedTests/NYPLAxisTests/Mocks/NYPLAxisMetadataServiceMock.swift
@@ -11,7 +11,10 @@ import Foundation
 
 class NYPLAxisMetadataServiceMock: NYPLDownloadRunnerMock, NYPLAxisMetadataContentHandling {
   
+  var willDownloadContent: (() -> Void)?
+  
   func downloadContent() {
+    willDownloadContent?()
     run()
   }
 

--- a/SimplifiedTests/NYPLAxisTests/Mocks/NYPLAxisPackageServiceMock.swift
+++ b/SimplifiedTests/NYPLAxisTests/Mocks/NYPLAxisPackageServiceMock.swift
@@ -11,7 +11,10 @@ import Foundation
 
 class NYPLAxisPackageServiceMock: NYPLDownloadRunnerMock, NYPLAxisPackageHandling {
   
+  var willDownloadContent: (() -> Void)?
+  
   func downloadPackageContent() {
+    willDownloadContent?()
     run()
   }
   


### PR DESCRIPTION
**What's this do?**
User initiated book download termination

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-145

**How should this be tested? / Do these changes have associated tests?**
Follow the steps in the ticket

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
Not yet

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Raman Singh verified it