### PR TITLE
Remove misleading log line + improve readability

### DIFF
--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -140,24 +140,19 @@ totalBytesExpectedToWrite:(int64_t const)totalBytesExpectedToWrite
       self.bookIdentifierToDownloadInfo[book.identifier] =
       [[self downloadInfoForBookIdentifier:book.identifier]
        withRightsManagement:NYPLMyBooksDownloadRightsManagementNone];
-    } else if ([downloadTask.response.MIMEType
-                isEqualToString:ContentTypeBearerToken]) {
+    } else if ([downloadTask.response.MIMEType isEqualToString:ContentTypeBearerToken]) {
       self.bookIdentifierToDownloadInfo[book.identifier] =
         [[self downloadInfoForBookIdentifier:book.identifier]
          withRightsManagement:NYPLMyBooksDownloadRightsManagementSimplifiedBearerTokenJSON];
 #if FEATURE_OVERDRIVE
-    } else if ([downloadTask.response.MIMEType
-                   isEqualToString:@"application/json"]) {
-         self.bookIdentifierToDownloadInfo[book.identifier] =
-           [[self downloadInfoForBookIdentifier:book.identifier]
-            withRightsManagement:NYPLMyBooksDownloadRightsManagementOverdriveManifestJSON];
+    } else if ([downloadTask.response.MIMEType isEqualToString:ContentTypeOverdriveAudiobookActual]) {
+      self.bookIdentifierToDownloadInfo[book.identifier] =
+      [[self downloadInfoForBookIdentifier:book.identifier]
+       withRightsManagement:NYPLMyBooksDownloadRightsManagementOverdriveManifestJSON];
 #endif
     } else if ([NYPLOPDSAcquisitionPath.supportedTypes containsObject:downloadTask.response.MIMEType]) {
-      // if response type represents supported type of book, proceed
-      NYPLLOG_F(@"Presuming no DRM for unrecognized MIME type \"%@\".", downloadTask.response.MIMEType);
-      NYPLMyBooksDownloadInfo *info =
-      [[self downloadInfoForBookIdentifier:book.identifier]
-       withRightsManagement:NYPLMyBooksDownloadRightsManagementNone];
+      NYPLMyBooksDownloadInfo *info = [[self downloadInfoForBookIdentifier:book.identifier]
+                                       withRightsManagement:NYPLMyBooksDownloadRightsManagementNone];
       if (info) {
         self.bookIdentifierToDownloadInfo[book.identifier] = info;
       }

--- a/SimplifiedTests/NYPLMyBooksDownloadCenterTests.swift
+++ b/SimplifiedTests/NYPLMyBooksDownloadCenterTests.swift
@@ -97,6 +97,6 @@ class NYPLMyBooksDownloadCenterTests: XCTestCase {
       XCTAssert(book.canCompleteDownload(withContentType: contentType))
     }
 
-    XCTAssert(book.canCompleteDownload(withContentType: "application/json"))
+    XCTAssert(book.canCompleteDownload(withContentType: ContentTypeOverdriveAudiobookActual))
   }
 }


### PR DESCRIPTION
**What's this do?**
Removes a very misleading log line and slightly improves readability in code detecting supported acquisition types.

**Why are we doing this? (w/ JIRA link if applicable)**
The removed log line caused confusion while QA'ing IOS-205.

**How should this be tested? / Do these changes have associated tests?**
nothing to check per se that is not covered by a regression.

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE build for QA?**
no

**Has the application documentation been updated for these changes?**
y

**Did someone actually run this code to verify it works?**
@ettore 