### PR TITLE
Streamline Axis build and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 This repo contains the client-side code for the New York Public Library's [SimplyE](https://www.nypl.org/books-music-movies/ebookcentral/simplye) and [Open eBooks](https://openebooks.net) apps.
 
-The 2 apps share most of the code base. App-specific source files will have a `SE` / `OE` prefix or suffix, while configuration files reside under the `SimplyE` and `OpenEbooks` directories at the root of the repo. 
+The 2 apps share most of the code base. App-specific source files will have a `SE` / `OE` prefix or suffix, while configuration files reside in the `SimplyE` and `OpenEbooks` directories at the root of the repo. 
 
-Consequently, [releases](https://github.com/NYPL-Simplified/Simplified-iOS/releases) in this repo track both apps. However, you won't see any Open eBooks versions before 1.9.0 because historically Open eBooks lived in a separate repo. Releases that lack an app specifier, i.e. any version before v3.6.2, are SimplyE releases.
+Consequently, [releases](https://github.com/NYPL-Simplified/Simplified-iOS/releases) in this repo track both apps. However, you won't see any Open eBooks versions before 1.9.0 because historically Open eBooks lived in a separate repo. Releases that lack an app specifier, i.e. any version such as v3.6.1 and earlier, are SimplyE releases.
 
 # System Requirements
 
 - Install Xcode 12.4 in `/Applications`, open it and make sure to install additional components if it asks you.
-- Install [Carthage](https://github.com/Carthage/Carthage) if you haven't already. Using `brew` is recommended.
+- Install [Carthage](https://github.com/Carthage/Carthage) 0.38 or newer if you haven't already. Using `brew` is recommended.
 
-# Building without Adobe DRM nor Private Repos
+# Building without DRM support
 
 ```bash
 git clone git@github.com:NYPL-Simplified/Simplified-iOS.git
@@ -28,12 +28,12 @@ git checkout develop
 ```
 Open `Simplified.xcodeproj` and build the `SimplyE-noDRM` target.
 
-# Building With Adobe DRM
+# Building with DRM Support
 
 ## Building the Application from Scratch
 
 01. Contact project lead and ensure you have access to all the required private repos.
-02. Then simply run:
+02. Build the dependencies (typically you'll need to run this only once):
 ```bash
 git clone git@github.com:NYPL-Simplified/Simplified-iOS.git
 cd Simplified-iOS

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -216,7 +216,6 @@
 		5916E7D8262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7D3262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift */; };
 		5916E7DF2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */; };
 		5916E7E02627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */; };
-		5916E7E22627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */; };
 		5916E7E32627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5916E7DE2627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift */; };
 		5941F5EC268C5E8500F69F0B /* NYPLAxis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 59F7F771268B513800CCA592 /* NYPLAxis.framework */; };
 		5941F5ED268C5E8500F69F0B /* NYPLAxis.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 59F7F771268B513800CCA592 /* NYPLAxis.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1508,13 +1507,13 @@
 				739EC8932643D588001FE730 /* Minizip.xcframework in Embed Frameworks */,
 				739EC88C2643D522001FE730 /* NYPLAEToolkit.framework in Embed Frameworks */,
 				739EC8942643D588001FE730 /* NYPLAudiobookToolkit.xcframework in Embed Frameworks */,
+				5941F5ED268C5E8500F69F0B /* NYPLAxis.framework in Embed Frameworks */,
 				739EC8952643D588001FE730 /* NYPLCardCreator.xcframework in Embed Frameworks */,
 				739EC8962643D588001FE730 /* OverdriveProcessor.xcframework in Embed Frameworks */,
 				739EC8972643D588001FE730 /* PDFRendererProvider.xcframework in Embed Frameworks */,
 				739EC8982643D588001FE730 /* PureLayout.xcframework in Embed Frameworks */,
 				739EC8992643D588001FE730 /* ReadiumLCP.xcframework in Embed Frameworks */,
 				739EC89A2643D588001FE730 /* R2Navigator.xcframework in Embed Frameworks */,
-				5941F5ED268C5E8500F69F0B /* NYPLAxis.framework in Embed Frameworks */,
 				739EC89B2643D588001FE730 /* R2Streamer.xcframework in Embed Frameworks */,
 				739EC89C2643D588001FE730 /* R2Shared.xcframework in Embed Frameworks */,
 				739EC89D2643D588001FE730 /* SQLite.xcframework in Embed Frameworks */,
@@ -2307,6 +2306,7 @@
 				732F0452263376BB0018A82E /* Minizip.xcframework in Frameworks */,
 				7347B4E0265EFD1300E4E386 /* nanopb.xcframework in Frameworks */,
 				732F04662633776A0018A82E /* NYPLAudiobookToolkit.xcframework in Frameworks */,
+				5941F5EC268C5E8500F69F0B /* NYPLAxis.framework in Frameworks */,
 				732F046B2633778A0018A82E /* NYPLCardCreator.xcframework in Frameworks */,
 				732F0457263376FA0018A82E /* OverdriveProcessor.xcframework in Frameworks */,
 				732F04712633783B0018A82E /* PDFRendererProvider.xcframework in Frameworks */,
@@ -2316,7 +2316,6 @@
 				73DED81625A6304E00A4D63B /* R2LCPClient.framework in Frameworks */,
 				732F0489263379690018A82E /* R2Navigator.xcframework in Frameworks */,
 				732F0493263379BA0018A82E /* R2Shared.xcframework in Frameworks */,
-				5941F5EC268C5E8500F69F0B /* NYPLAxis.framework in Frameworks */,
 				732F048E2633799E0018A82E /* R2Streamer.xcframework in Frameworks */,
 				732F0432263374860018A82E /* ReadiumLCP.xcframework in Frameworks */,
 				73FCA36C25005BA4001B0C5D /* Security.framework in Frameworks */,
@@ -4714,7 +4713,6 @@
 				73EB0B1625821DF4006BC997 /* AudioBookVendors+Extensions.swift in Sources */,
 				73EB0B1725821DF4006BC997 /* NYPLLibraryNavigationController.m in Sources */,
 				73D8D27725A68D3B00DF5F69 /* UIViewController+NYPL.swift in Sources */,
-				5916E7E22627922B0021CD67 /* NYPLSignInBusinessLogic+Axis.swift in Sources */,
 				73EB0B1825821DF4006BC997 /* RemoteHTMLViewController.swift in Sources */,
 				73EB0B1925821DF4006BC997 /* NYPLBookDetailsProblemDocumentViewController.swift in Sources */,
 				73EB0B1A25821DF4006BC997 /* NYPLCatalogGroupedFeed.m in Sources */,

--- a/scripts/build-carthage.sh
+++ b/scripts/build-carthage.sh
@@ -31,13 +31,6 @@ else
 fi
 
 if [ "$1" != "--no-private" ]; then
-  echo NYPLAxis here we come
-  ./scripts/buildNYPLAxis.sh
-else
-  echo no NYPLAxis here
-fi
-
-if [ "$1" != "--no-private" ]; then
   if [ "$BUILD_CONTEXT" == "ci" ]; then
     # in a CI context we cannot have siblings repos, so we check them out nested
     CERTIFICATES_PATH_PREFIX="."
@@ -63,6 +56,6 @@ if [ "$1" != "--no-private" ]; then
 fi
 
 if [ "$BUILD_CONTEXT" != "ci" ] || [ "$1" == "--no-private" ]; then
-  echo "Carthage build..."
+  echo "Carthage bootstrap..."
   carthage bootstrap --platform ios --use-xcframeworks
 fi

--- a/scripts/buildNYPLAxis.sh
+++ b/scripts/buildNYPLAxis.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-echo Building NYPLAxis
-cd Axis-iOS
-./buildFramework.sh
-cd ..
-
-
-

--- a/scripts/setup-repo-drm.sh
+++ b/scripts/setup-repo-drm.sh
@@ -31,3 +31,7 @@ ln -s $ADOBE_SDK_PATH adobe-rmsdk
 
 cd $ADOBE_SDK_PATH
 ./uncompress.sh
+
+if [ "$BUILD_CONTEXT" != "ci" ]; then
+  git clone git@github.com:NYPL-Simplified/Axis-iOS.git
+fi


### PR DESCRIPTION
**What's this do?**
- Updates the README removing references of Adobe
- Moves axis repo checkout to setup script
- Removes Axis build script since Xcode automatically builds linked subproject targets

**Why are we doing this? (w/ JIRA link if applicable)**
regular maintenance / Ettore getting comfortable with new Axis code

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
merging to feature branch

**Does this include changes that require a new SimplyE build for QA?**
no

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 