### PR TITLE
Bump OE version number to 2.0.0 and update PR template

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -5497,7 +5497,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5521,7 +5521,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.1;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.OpenEbooks;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
@@ -5556,7 +5556,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5580,7 +5580,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.1;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.OpenEbooks;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -10,8 +10,8 @@
 **Dependencies for merging? Releasing to production?**
 [Description of any watchouts, dependencies, or issues we should be aware of goes here]
 
-**Does this include changes that require a new SimplyE build for QA?**
-[Bump the SimplyE build number to generate a new build on NYPL-Simplified/iOS-binaries]
+**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
+[Bump the version or build number to push a new build to Firebase]
 
 **Has the application documentation been updated for these changes?**
 


### PR DESCRIPTION
**What's this do?**
This should trigger and deliver a build of Open eBooks to Firebase.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-157

**How should this be tested? / Do these changes have associated tests?**
This should receive a regression test to verify R2 works correctly on Open ebooks too.

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE or Open eBooks build for QA?**
yes

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ettore 