### PR TITLE
IOS-234 Add Publisher's defaults toggle

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -825,6 +825,12 @@
 		73B5DFE026052A1800225C12 /* NYPLBookButtonsState.m in Sources */ = {isa = PBXBuildFile; fileRef = 73B5DFDA26052A1800225C12 /* NYPLBookButtonsState.m */; };
 		73B80BAB25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B80BAA25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift */; };
 		73B80BAD25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B80BAA25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift */; };
+		73BC285D269F96C00037930A /* NYPLReaderSettings+Conversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BC285C269F96C00037930A /* NYPLReaderSettings+Conversions.swift */; };
+		73BC285E269F96C00037930A /* NYPLReaderSettings+Conversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BC285C269F96C00037930A /* NYPLReaderSettings+Conversions.swift */; };
+		73BC285F269F96C00037930A /* NYPLReaderSettings+Conversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BC285C269F96C00037930A /* NYPLReaderSettings+Conversions.swift */; };
+		73BC2860269F96C00037930A /* NYPLReaderSettings+Conversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BC285C269F96C00037930A /* NYPLReaderSettings+Conversions.swift */; };
+		73BC286A269F995E0037930A /* NYPLReaderSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BC2869269F995E0037930A /* NYPLReaderSettingsTests.swift */; };
+		73BC286B269F995E0037930A /* NYPLReaderSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BC2869269F995E0037930A /* NYPLReaderSettingsTests.swift */; };
 		73BDB06E25A639B6002C5C4C /* LCPAudiobooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212B99D2258A36FD00C8BF79 /* LCPAudiobooks.swift */; };
 		73BDB07A25F198D200556C35 /* R2Streamer.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 731B2B12244A1D6500A7A649 /* R2Streamer.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		73BDB08125F198F800556C35 /* R2Navigator.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 731B2B18244A1D8600A7A649 /* R2Navigator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1945,6 +1951,8 @@
 		73B5DFDA26052A1800225C12 /* NYPLBookButtonsState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYPLBookButtonsState.m; sourceTree = "<group>"; };
 		73B5DFDB26052A1800225C12 /* NYPLBookButtonsState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYPLBookButtonsState.h; sourceTree = "<group>"; };
 		73B80BAA25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+CardCreation.swift"; sourceTree = "<group>"; };
+		73BC285C269F96C00037930A /* NYPLReaderSettings+Conversions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLReaderSettings+Conversions.swift"; sourceTree = "<group>"; };
+		73BC2869269F995E0037930A /* NYPLReaderSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLReaderSettingsTests.swift; sourceTree = "<group>"; };
 		73C3CF5925CB8D6100CA8166 /* NYPLNetworkExecutorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLNetworkExecutorMock.swift; sourceTree = "<group>"; };
 		73CC48A4260BFC4800F1E2C3 /* NYPLReadiumBookmark+Compare.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLReadiumBookmark+Compare.swift"; sourceTree = "<group>"; };
 		73CDA120243EDAD8009CC6A6 /* URLRequest+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Logging.swift"; sourceTree = "<group>"; };
@@ -2703,6 +2711,7 @@
 				734917D9242EB79700059AA5 /* NYPLR1R2UserSettings.swift */,
 				1188F3DF1A1ECC4B006B2F36 /* NYPLReaderSettings.h */,
 				1188F3E01A1ECC4B006B2F36 /* NYPLReaderSettings.m */,
+				73BC285C269F96C00037930A /* NYPLReaderSettings+Conversions.swift */,
 				7386C1F624525AFF004C78BD /* NYPLReaderTOCBusinessLogic.swift */,
 				737DCB8B245CCF2300A8F297 /* NYPLReaderBookmarksBusinessLogic.swift */,
 			);
@@ -3397,6 +3406,7 @@
 				735350B624918432006021BD /* URLRequest+NYPLTests.swift */,
 				17ADCF4E254BB84800D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift */,
 				17BE24D625F85D2300AE707F /* NYPLAgeCheckTests.swift */,
+				73BC2869269F995E0037930A /* NYPLReaderSettingsTests.swift */,
 			);
 			path = SimplifiedTests;
 			sourceTree = "<group>";
@@ -4024,6 +4034,7 @@
 				735771AE2537687D00067CEA /* NYPLURLSettingsProviderMock.swift in Sources */,
 				735771B12537691800067CEA /* NYPLDRMAuthorizingMock.swift in Sources */,
 				730EF263260955EF008E1DC3 /* NYPLBookmarkSpecTests.swift in Sources */,
+				73BC286A269F995E0037930A /* NYPLReaderSettingsTests.swift in Sources */,
 				B51C1DFE22860563003B49A5 /* OPDS2CatalogsFeedTests.swift in Sources */,
 				73A794BD2548E36100C59CC1 /* NYPLBookCreationTests.swift in Sources */,
 				5D73DA4322A080BA00162CB8 /* NYPLMyBooksDownloadCenterTests.swift in Sources */,
@@ -4073,6 +4084,7 @@
 				735DD0AF252293700096D1F9 /* NYPLMyBooksDownloadCenterTests.swift in Sources */,
 				73D4DC1A2627A0C0005CAFFA /* NYPLAnnotationResponseTests.swift in Sources */,
 				7311FD2C25CBD086004447CB /* NYPLSignInOutBusinessLogicUIDelegateMock.swift in Sources */,
+				73BC286B269F995E0037930A /* NYPLReaderSettingsTests.swift in Sources */,
 				7320AB51251EC07300E3F04D /* NYPLOPDSAcquisitionPathTests.swift in Sources */,
 				735DD0D12522A0730096D1F9 /* URLRequest+NYPLTests.swift in Sources */,
 				735771AC2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift in Sources */,
@@ -4196,6 +4208,7 @@
 				739E609B244A0D8600D00301 /* NYPLSettingsAccountDetailViewController.m in Sources */,
 				739E609D244A0D8600D00301 /* NYPLBarcode.swift in Sources */,
 				739E609E244A0D8600D00301 /* NYPLSession.m in Sources */,
+				73BC285E269F96C00037930A /* NYPLReaderSettings+Conversions.swift in Sources */,
 				739E609F244A0D8600D00301 /* NYPLSettingsEULAViewController.m in Sources */,
 				739E60A0244A0D8600D00301 /* NYPLMyBooksDownloadInfo.m in Sources */,
 				21DF7F9425AF5E1E0090402A /* ReaderModule.swift in Sources */,
@@ -4400,6 +4413,7 @@
 				73EB0AA325821DF4006BC997 /* NYPLRootTabBarController+SE.swift in Sources */,
 				73EB0AA425821DF4006BC997 /* NYPLCatalogNavigationController.m in Sources */,
 				73EB0AA525821DF4006BC997 /* NYPLEntryPointView.swift in Sources */,
+				73BC285F269F96C00037930A /* NYPLReaderSettings+Conversions.swift in Sources */,
 				73EB0AA625821DF4006BC997 /* NYPLOPDSGroup.m in Sources */,
 				73EB0AA825821DF4006BC997 /* NYPLAppReviewPrompt.swift in Sources */,
 				73EB0AA925821DF4006BC997 /* NYPLFacetBarView.swift in Sources */,
@@ -4622,6 +4636,7 @@
 				7369A3A0264AF9710029D8AB /* NYPLAdobeContentProtectionService.swift in Sources */,
 				73FCA2D325005BA4001B0C5D /* BundledHTMLViewController.swift in Sources */,
 				73FCA2D425005BA4001B0C5D /* NYPLBookDetailView.m in Sources */,
+				73BC2860269F96C00037930A /* NYPLReaderSettings+Conversions.swift in Sources */,
 				73FCA2D525005BA4001B0C5D /* UIButton+NYPLAppearanceAdditions.m in Sources */,
 				73FCA2D625005BA4001B0C5D /* NYPLBookCoverRegistry.m in Sources */,
 				73FCA2D725005BA4001B0C5D /* NYPLBookDetailDownloadingView.m in Sources */,
@@ -4898,6 +4913,7 @@
 				7347312925142FE200BE3D2C /* NYPLSettings+SE.swift in Sources */,
 				E6202A021DD4E6F300C99553 /* NYPLSettingsAccountDetailViewController.m in Sources */,
 				2198F910250A90EE000D9DAB /* AudioBookVendorsHelper.swift in Sources */,
+				73BC285D269F96C00037930A /* NYPLReaderSettings+Conversions.swift in Sources */,
 				E68CCFC51F9F80CF003DDA6C /* NYPLBarcode.swift in Sources */,
 				21DF7F9325AF5E1E0090402A /* ReaderModule.swift in Sources */,
 				118B7ABF195CBF72005CE3E7 /* NYPLSession.m in Sources */,

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -1811,6 +1811,7 @@
 		731272AC259CF6F90032D7B4 /* xcode-export-appstore.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "xcode-export-appstore.sh"; sourceTree = "<group>"; };
 		731272B1259CFB180032D7B4 /* testflight-upload.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "testflight-upload.sh"; sourceTree = "<group>"; };
 		7314D13F2551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+SignOut.swift"; sourceTree = "<group>"; };
+		73165C67268662FA0021A6AD /* checkout-r2-branch.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "checkout-r2-branch.sh"; sourceTree = "<group>"; };
 		731A5B1124621F2B00B5E663 /* NYPLSignInBusinessLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSignInBusinessLogic.swift; sourceTree = "<group>"; };
 		731B2B12244A1D6500A7A649 /* R2Streamer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2Streamer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		731B2B18244A1D8600A7A649 /* R2Navigator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2Navigator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3030,6 +3031,7 @@
 				73CEF8342526FE80006B2820 /* firebase */,
 				73EB0B7F2582CCE9006BC997 /* build-3rd-party-dependencies.sh */,
 				73DA43A62404BA5600985482 /* build-carthage.sh */,
+				73165C67268662FA0021A6AD /* checkout-r2-branch.sh */,
 				738E4715258ABB6300BEEC1D /* build-carthage-R2-integration.sh */,
 				7383ADE4264607FA00226358 /* clean-carthage.sh */,
 				73609AD8245B53CB00F0E08B /* update-certificates.sh */,

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -5288,7 +5288,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5313,7 +5313,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PRODUCT_NAME = "SimplyE-R2dev";
@@ -5347,7 +5347,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5372,7 +5372,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PRODUCT_NAME = "SimplyE-R2dev";
@@ -5406,7 +5406,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5427,7 +5427,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
@@ -5461,7 +5461,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5482,7 +5482,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
@@ -5753,7 +5753,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5777,7 +5777,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "SimplyE Development";
@@ -5810,7 +5810,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5834,7 +5834,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.7.0;
+				MARKETING_VERSION = 3.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "SimplyE Distribution";

--- a/Simplified/Reader2/BusinessLogic/NYPLR1R2UserSettings.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLR1R2UserSettings.swift
@@ -57,36 +57,60 @@ class NYPLR1R2UserSettings: NSObject {
     r2UserSettings?.save()
   }
 
-  /// Sets the color scheme in both R1 and R2 user reader settings.
-  /// - Parameter colorScheme: The chosen color scheme to set.
-  /// - Note: This does not persist the change. Call `save()` for that.
-  func setColorScheme(_ colorScheme: NYPLReaderSettingsColorScheme) {
-    r1UserSettings.colorScheme = colorScheme
+  var backgroundColor: UIColor {
+    return r1UserSettings.backgroundColor
+  }
 
-    if let appearance = r2UserSettings?.userProperties.getProperty(reference: ReadiumCSSReference.appearance.rawValue) as? Enumerable {
-      appearance.index = colorScheme.rawValue
+  /// The setter sets the color scheme in both R1 and R2 user reader settings.
+  /// - Note: This does not persist the change. Call `save()` for that.
+  var colorScheme: NYPLReaderSettingsColorScheme {
+    get {
+      // on app versions w/ R2 (SE 3.7.0+, OE 2.0+), R1 and R2 settings match.
+      // on older app versions, the R1 setting will be the only available one.
+      return r1UserSettings.colorScheme
+    }
+
+    set {
+      r1UserSettings.colorScheme = newValue
+
+      if let appearance = r2UserSettings?.userProperties.getProperty(reference: ReadiumCSSReference.appearance.rawValue) as? Enumerable {
+        appearance.index = newValue.rawValue
+      }
     }
   }
 
-  /// Sets the font family to be used in both R1 and R2 user settings.
-  /// - Parameter fontFace: The font chosen by the user.
+  /// The setter sets the font family to be used in both R1 and R2 user settings.
   /// - Note: This does not persist the change. Call `save()` for that.
-  func setFontFace(_ fontFace: NYPLReaderSettingsFontFace) {
-    r1UserSettings.fontFace = fontFace
+  var fontFace: NYPLReaderSettingsFontFace {
+    get {
+      // on app versions w/ R2 (SE 3.7.0+, OE 2.0+), R1 and R2 settings match.
+      // on older app versions, the R1 setting will be the only available one.
+      return r1UserSettings.fontFace
+    }
 
-    let fontFamily = r2UserSettings?.userProperties.getProperty(reference: ReadiumCSSReference.fontFamily.rawValue) as? Enumerable
-    let fontOverride = r2UserSettings?.userProperties.getProperty(reference: ReadiumCSSReference.fontOverride.rawValue) as? Switchable
+    set {
+      // ensure we keep R1 in sync with R2
+      r1UserSettings.fontFace = newValue
 
-    if let fontFamily = fontFamily {
-      // we don't use the "Original" font, so we add 1 to the chosen index
-      fontFamily.index = fontFace.rawValue + 1
-      if let fontOverride = fontOverride {
-        // if we had to use the Original font, we would need to set the
-        // `fontOverride.on` setting to false. Since in our use case this is
-        // never true, we can just set it to true.
-        fontOverride.on = true
+      let fontFamily = r2UserSettings?.userProperties.getProperty(reference: ReadiumCSSReference.fontFamily.rawValue) as? Enumerable
+      let fontOverride = r2UserSettings?.userProperties.getProperty(reference: ReadiumCSSReference.fontOverride.rawValue) as? Switchable
+
+      if let fontFamily = fontFamily {
+        // we don't use the "Original" font, so we add 1 to the chosen index
+        fontFamily.index = newValue.rawValue + 1
+        if let fontOverride = fontOverride {
+          // if we had to use the Original font, we would need to set the
+          // `fontOverride.on` setting to false. Since in our use case this is
+          // never true, we can just set it to true.
+          fontOverride.on = true
+        }
       }
     }
+  }
+
+  var fontSize: NYPLReaderSettingsFontSize {
+    // R1 and R2 settings are always kept in sync
+    return r1UserSettings.fontSize
   }
 
   /// Modifies the value of the font size according to the specified `change`.

--- a/Simplified/Reader2/BusinessLogic/NYPLR1R2UserSettings.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLR1R2UserSettings.swift
@@ -28,6 +28,10 @@ class NYPLR1R2UserSettings: NSObject {
     self.r2UserSettings = r2UserSettings
     super.init()
     configR2Fonts()
+
+    // this helps with layout on small screens especially when publisher's
+    // defaults are off.
+    setHyphenation(true)
   }
 
   /// Get associated colors for a specific appearance setting.
@@ -105,6 +109,20 @@ class NYPLR1R2UserSettings: NSObject {
           fontOverride.on = true
         }
       }
+    }
+  }
+
+  var publisherDefault: Bool {
+    get {
+      let publisherDefault = r2UserSettings?.userProperties
+        .getProperty(reference: ReadiumCSSReference.publisherDefault.rawValue) as? Switchable
+      return publisherDefault?.on ?? false
+    }
+
+    set {
+      let publisherDefault = r2UserSettings?.userProperties
+        .getProperty(reference: ReadiumCSSReference.publisherDefault.rawValue) as? Switchable
+      publisherDefault?.on = newValue
     }
   }
 
@@ -187,6 +205,12 @@ class NYPLR1R2UserSettings: NSObject {
                      values: ["Original", "Helvetica", "Georgia", "OpenDyslexic"],
                      reference: ReadiumCSSReference.fontFamily.rawValue,
                      name: ReadiumCSSName.fontFamily.rawValue)
+  }
+
+  private func setHyphenation(_ value: Bool) {
+    let hyphens = r2UserSettings?.userProperties
+      .getProperty(reference: ReadiumCSSReference.hyphens.rawValue) as? Switchable
+    hyphens?.on = value
   }
 }
 

--- a/Simplified/Reader2/BusinessLogic/NYPLReaderSettings+Conversions.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLReaderSettings+Conversions.swift
@@ -1,0 +1,24 @@
+//
+//  NYPLReaderSettings+Conversions.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 7/14/21.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+
+extension NYPLReaderSettingsFontFace {
+  static func fromRawValue(_ rawValue: NSInteger) -> NYPLReaderSettingsFontFace {
+    switch rawValue {
+    case 0:
+      return .sans
+    case 1:
+      return .serif
+    case 2:
+      return .openDyslexic
+    default:
+      return .sans
+    }
+  }
+}

--- a/Simplified/Reader2/UI/NYPLReaderSettingsView.h
+++ b/Simplified/Reader2/UI/NYPLReaderSettingsView.h
@@ -23,6 +23,9 @@ typedef NS_ENUM(NSUInteger, NYPLReaderFontSizeChange) {
 - (void)readerSettingsView:(nonnull NYPLReaderSettingsView *)readerSettingsView
          didSelectFontFace:(NYPLReaderSettingsFontFace)fontFace;
 
+- (void)readerSettingsView:(nonnull NYPLReaderSettingsView *)readerSettingsView
+didChangePublisherDefaults:(BOOL)isEnabled;
+
 @end
 
 //==============================================================================
@@ -38,6 +41,7 @@ typedef NS_ENUM(NSUInteger, NYPLReaderFontSizeChange) {
 @property (nonatomic, weak, nullable) id<NYPLReaderSettingsViewDelegate> delegate;
 @property (nonatomic) NYPLReaderSettingsFontSize fontSize;
 @property (nonatomic) NYPLReaderSettingsFontFace fontFace;
+@property (nonatomic) BOOL publisherDefault;
 
 + (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)init NS_UNAVAILABLE;

--- a/Simplified/Reader2/UI/NYPLReaderSettingsView.m
+++ b/Simplified/Reader2/UI/NYPLReaderSettingsView.m
@@ -31,15 +31,13 @@
   self = [super init];
   if (!self) return nil;
   
+  self.observers = [NSMutableArray array];
   CGSize const size = [self sizeThatFits:CGSizeMake(width, CGFLOAT_MAX)];
   self.frame = CGRectMake(0, 0, size.width, size.height);
-
-  self.observers = [NSMutableArray array];
-  
   self.backgroundColor = [NYPLConfiguration backgroundColor];
-
   [self sizeToFit];
 
+   // font family --------------------------------------------------------------
   NSDictionary *underlineAttribute = @{NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle)};
   NSDictionary *noUnderlineAttribute = @{NSUnderlineStyleAttributeName: @(NSUnderlineStyleNone)};
   
@@ -64,7 +62,6 @@
             forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.sansButton];
 
-  
   self.serifButton = [UIButton buttonWithType:UIButtonTypeCustom];
   self.serifButton.accessibilityLabel = [[NSString alloc] initWithFormat:NSLocalizedString(@"SerifFont", nil)];
   self.serifButton.backgroundColor = [NYPLConfiguration backgroundColor];
@@ -85,8 +82,7 @@
                        action:@selector(didSelectSerif)
              forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.serifButton];
-  
-  
+
   self.openDyslexicButton = [UIButton buttonWithType:UIButtonTypeCustom];
   self.openDyslexicButton.accessibilityLabel = [[NSString alloc] initWithFormat:NSLocalizedString(@"OpenDyslexicFont", nil)];
   self.openDyslexicButton.backgroundColor = [NYPLConfiguration backgroundColor];
@@ -108,6 +104,9 @@
              forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.openDyslexicButton];
 
+
+  // background color ----------------------------------------------------------
+  const CGFloat fontSize = 18;
   self.whiteOnBlackButton = [UIButton buttonWithType:UIButtonTypeCustom];
   self.whiteOnBlackButton.accessibilityLabel = [[NSString alloc] initWithFormat:NSLocalizedString(@"WhiteOnBlackText", nil)];
   self.whiteOnBlackButton.backgroundColor = [NYPLConfiguration readerBackgroundDarkColor];
@@ -125,7 +124,7 @@
                        initWithString:NSLocalizedString(@"AlphabetFontStyle", nil)
                        attributes:whiteColourWithUnderline]
    forState:UIControlStateDisabled];
-  self.whiteOnBlackButton.titleLabel.font = [UIFont systemFontOfSize:18];
+  self.whiteOnBlackButton.titleLabel.font = [UIFont systemFontOfSize:fontSize];
   [self.whiteOnBlackButton addTarget:self
                               action:@selector(didSelectWhiteOnBlack)
                     forControlEvents:UIControlEventTouchUpInside];
@@ -143,7 +142,7 @@
   
   [self.blackOnSepiaButton setAttributedTitle:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"AlphabetFontStyle", nil)
                                                                               attributes:underlineAttribute] forState:UIControlStateDisabled];
-  self.blackOnSepiaButton.titleLabel.font = [UIFont systemFontOfSize:18];
+  self.blackOnSepiaButton.titleLabel.font = [UIFont systemFontOfSize:fontSize];
   [self.blackOnSepiaButton addTarget:self
                               action:@selector(didSelectBlackOnSepia)
                     forControlEvents:UIControlEventTouchUpInside];
@@ -161,12 +160,14 @@
   
   [self.blackOnWhiteButton setAttributedTitle:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"AlphabetFontStyle", nil)
                                                                               attributes:underlineAttribute] forState:UIControlStateDisabled];
-  self.blackOnWhiteButton.titleLabel.font = [UIFont systemFontOfSize:18];
+  self.blackOnWhiteButton.titleLabel.font = [UIFont systemFontOfSize:fontSize];
   [self.blackOnWhiteButton addTarget:self
                               action:@selector(didSelectBlackOnWhite)
                     forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.blackOnWhiteButton];
 
+
+  // font size -----------------------------------------------------------------
   self.decreaseButton = [UIButton buttonWithType:UIButtonTypeCustom];
   self.decreaseButton.accessibilityLabel = [[NSString alloc] initWithFormat:NSLocalizedString(@"DecreaseFontSize", nil)];
   self.decreaseButton.backgroundColor = [NYPLConfiguration backgroundColor];
@@ -190,6 +191,8 @@
                 forControlEvents:UIControlEventTouchUpInside];
   [self addSubview:self.increaseButton];
 
+
+  // brightness slider ---------------------------------------------------------
   self.brightnessView = [[UIView alloc] init];
   [self addSubview:self.brightnessView];
   
@@ -569,6 +572,8 @@
   
   CGFloat const thin = 1.0 / [UIScreen mainScreen].scale;
 
+  // horizontal lines
+
   {
     UIView *const line = [[UIView alloc] initWithFrame:
                           CGRectMake(CGRectGetMinX(self.openDyslexicButton.frame),
@@ -611,6 +616,8 @@
     [self addSubview:line];
   }
   
+  // vertical lines
+
   {
     UIView *const line = [[UIView alloc] initWithFrame:
                           CGRectMake(CGRectGetMinX(self.serifButton.frame),

--- a/Simplified/Reader2/UI/NYPLReaderSettingsView.m
+++ b/Simplified/Reader2/UI/NYPLReaderSettingsView.m
@@ -19,6 +19,9 @@
 @property (nonatomic) UIButton *serifButton;
 @property (nonatomic) UIButton *openDyslexicButton;
 @property (nonatomic) UIButton *whiteOnBlackButton;
+@property (nonatomic) UIStackView *publisherDefaultContainer;
+@property (nonatomic) UILabel *publisherDefaultLabel;
+@property (nonatomic) UISwitch *publisherDefaultSwitch;
 
 @end
 
@@ -192,6 +195,29 @@
   [self addSubview:self.increaseButton];
 
 
+  // publisher's default -------------------------------------------------------
+  self.publisherDefaultLabel = [[UILabel alloc] init];
+  self.publisherDefaultLabel.text = NSLocalizedString(@"Publisher's Defaults", nil);
+  self.publisherDefaultLabel.font = [UIFont systemFontOfSize:fontSize];
+  self.publisherDefaultLabel.allowsDefaultTighteningForTruncation = YES;
+  self.publisherDefaultLabel.numberOfLines = 1;
+
+  self.publisherDefaultSwitch = [[UISwitch alloc] init];
+  self.publisherDefaultSwitch.onTintColor = NYPLConfiguration.mainColor;
+  [self.publisherDefaultSwitch addTarget:self
+                                  action:@selector(didTogglePublisherDefault)
+                        forControlEvents:UIControlEventTouchUpInside];
+
+  self.publisherDefaultContainer = [[UIStackView alloc]
+                                    initWithArrangedSubviews:@[self.publisherDefaultLabel,
+                                                               self.publisherDefaultSwitch]];
+  self.publisherDefaultContainer.axis = UILayoutConstraintAxisHorizontal;
+  self.publisherDefaultContainer.distribution = UIStackViewDistributionFill;
+  self.publisherDefaultContainer.spacing = 10;
+  self.publisherDefaultContainer.alignment = UIStackViewAlignmentCenter;
+  [self addSubview:self.publisherDefaultContainer];
+
+
   // brightness slider ---------------------------------------------------------
   self.brightnessView = [[UIView alloc] init];
   [self addSubview:self.brightnessView];
@@ -245,7 +271,8 @@
   CGFloat const padding = 10;
   CGFloat const topPadding = 16;
   CGFloat const innerWidth = CGRectGetWidth(self.frame) - padding * 2;
-  CGFloat const rowHeight = round((CGRectGetHeight(self.frame) - topPadding) / 4.0);
+  CGFloat const numRows = 5.0;
+  CGFloat const rowHeight = round((CGRectGetHeight(self.frame) - topPadding) / numRows);
   
   self.sansButton.frame = CGRectMake(padding,
                                      topPadding,
@@ -287,9 +314,14 @@
                                          CGRectGetMaxY(self.whiteOnBlackButton.frame),
                                          innerWidth / 2.0,
                                          rowHeight);
-  
+
+  self.publisherDefaultContainer.frame = CGRectMake(padding,
+                                                    CGRectGetMaxY(self.increaseButton.frame),
+                                                    innerWidth,
+                                                    rowHeight);
+
   self.brightnessView.frame = CGRectMake(padding,
-                                         CGRectGetMaxY(self.decreaseButton.frame),
+                                         CGRectGetMaxY(self.publisherDefaultContainer.frame),
                                          innerWidth,
                                          rowHeight);
   
@@ -327,7 +359,7 @@
 - (CGSize)sizeThatFits:(CGSize)size
 {
   CGFloat const defaultWidth = 320;
-  CGFloat const defaultHeight = 240;
+  CGFloat const defaultHeight = 295;
 
   if(CGSizeEqualToSize(size, CGSizeZero)) {
     return CGSizeMake(defaultWidth, defaultHeight);
@@ -489,6 +521,15 @@
   
   [self.blackOnWhiteButton setAttributedTitle:[[NSAttributedString alloc] initWithString:NSLocalizedString(@"AlphabetFontStyle", nil)
                                                                               attributes:blackColourWithUnderline] forState:UIControlStateDisabled];
+
+  self.publisherDefaultLabel.textColor = foregroundColor;
+  self.publisherDefaultLabel.backgroundColor = backgroundColor;
+}
+
+- (void)setPublisherDefault:(BOOL)publisherDefault
+{
+  _publisherDefault = publisherDefault;
+  self.publisherDefaultSwitch.on = publisherDefault;
 }
 
 - (void)didSelectSans
@@ -562,6 +603,14 @@
                    didChangeFontSize:NYPLReaderFontSizeChangeIncrease];
 }
 
+- (void)didTogglePublisherDefault
+{
+  self.publisherDefault = !self.publisherDefault;
+  
+  [self.delegate readerSettingsView:self
+         didChangePublisherDefaults:self.publisherDefault];
+}
+
 - (void)updateLineViews
 {
   for(UIView *const lineView in self.lineViews) {
@@ -615,7 +664,17 @@
     [line setBackgroundColor:[UIColor lightGrayColor]];
     [self addSubview:line];
   }
-  
+
+  {
+    UIView *const line = [[UIView alloc] initWithFrame:
+                          CGRectMake(CGRectGetMinX(self.brightnessView.frame),
+                                     CGRectGetMinY(self.publisherDefaultContainer.frame),
+                                     CGRectGetWidth(self.brightnessView.frame),
+                                     thin)];
+    [line setBackgroundColor:[UIColor lightGrayColor]];
+    [self addSubview:line];
+  }
+
   // vertical lines
 
   {

--- a/Simplified/Reader2/UI/NYPLUserSettingsVC.swift
+++ b/Simplified/Reader2/UI/NYPLUserSettingsVC.swift
@@ -53,10 +53,11 @@ import R2Navigator
   override func loadView() {
     let view = NYPLReaderSettingsView(width: 300)
     view.delegate = self
-    view.colorScheme = NYPLReaderSettings.shared().colorScheme
-    view.fontSize = NYPLReaderSettings.shared().fontSize
-    view.fontFace = NYPLReaderSettings.shared().fontFace
-    view.backgroundColor = NYPLReaderSettings.shared().backgroundColor
+
+    view.colorScheme = userSettings.colorScheme
+    view.fontSize = userSettings.fontSize
+    view.fontFace = userSettings.fontFace
+    view.backgroundColor = userSettings.backgroundColor
     self.view = view;
   }
 
@@ -76,7 +77,7 @@ extension NYPLUserSettingsVC: NYPLReaderSettingsViewDelegate {
 
   func readerSettingsView(_ readerSettingsView: NYPLReaderSettingsView,
                           didSelect colorScheme: NYPLReaderSettingsColorScheme) {
-    userSettings.setColorScheme(colorScheme)
+    userSettings.colorScheme = colorScheme
     userSettings.save()
     delegate?.applyCurrentSettings()
   }
@@ -94,7 +95,7 @@ extension NYPLUserSettingsVC: NYPLReaderSettingsViewDelegate {
 
   func readerSettingsView(_ readerSettingsView: NYPLReaderSettingsView,
                           didSelect fontFace: NYPLReaderSettingsFontFace) {
-    userSettings.setFontFace(fontFace)
+    userSettings.fontFace = fontFace
     userSettings.save()
     delegate?.applyCurrentSettings()
   }

--- a/Simplified/Reader2/UI/NYPLUserSettingsVC.swift
+++ b/Simplified/Reader2/UI/NYPLUserSettingsVC.swift
@@ -58,6 +58,8 @@ import R2Navigator
     view.fontSize = userSettings.fontSize
     view.fontFace = userSettings.fontFace
     view.backgroundColor = userSettings.backgroundColor
+    view.publisherDefault = userSettings.publisherDefault
+    
     self.view = view;
   }
 
@@ -99,4 +101,12 @@ extension NYPLUserSettingsVC: NYPLReaderSettingsViewDelegate {
     userSettings.save()
     delegate?.applyCurrentSettings()
   }
+
+  func readerSettingsView(_  readerSettingsView: NYPLReaderSettingsView,
+                          didChangePublisherDefaults isEnabled: Bool) {
+    userSettings.publisherDefault = isEnabled
+    userSettings.save()
+    delegate?.applyCurrentSettings()
+  }
+
 }

--- a/SimplifiedTests/NYPLReaderSettingsTests.swift
+++ b/SimplifiedTests/NYPLReaderSettingsTests.swift
@@ -1,0 +1,18 @@
+//
+//  NYPLReaderSettingsTests.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 7/14/21.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import XCTest
+@testable import SimplyE
+
+class NYPLReaderSettingsTests: XCTestCase {
+  func testReaderSettingsFontFaceValues() throws {
+    XCTAssertEqual(NYPLReaderSettingsFontFace.fromRawValue(0), .sans)
+    XCTAssertEqual(NYPLReaderSettingsFontFace.fromRawValue(1), .serif)
+    XCTAssertEqual(NYPLReaderSettingsFontFace.fromRawValue(2), .openDyslexic)
+  }
+}

--- a/scripts/build-carthage-R2-integration.sh
+++ b/scripts/build-carthage-R2-integration.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # SUMMARY
-#   This scripts wipes your Carthage folder, checks out and rebuilds
+#   This scripts wipes your Carthage folders and rebuilds
 #   all Carthage dependencies for working on R2 integration.
 #
 # SYNOPSIS
@@ -9,7 +9,12 @@
 #
 # USAGE
 #   Run this script from the root of Simplified-iOS repo.
-#   Use this script in conjuction with the SimplifiedR2.workspace. This
+#
+#   You can use the `checkout-r2-branch.sh` script to easily toggle
+#   all R2 repos between the stable release we use in production builds,
+#   and the most recent code on `develop`.
+#
+#   Use this script in conjunction with the SimplifiedR2.workspace. This
 #   assumes that you have the R2 repos checked out as siblings of
 #   Simplified-iOS.
 #
@@ -26,7 +31,6 @@ CURRENT_DIR=`pwd`
 
 echo "Building r2-shared-swift Carthage dependencies..."
 cd ../r2-shared-swift
-git checkout 2.0.1
 rm -rf Carthage
 carthage checkout
 mkdir -p Carthage/Build/iOS
@@ -34,7 +38,6 @@ carthage build --use-xcframeworks --platform iOS
 
 echo "Building r2-lcp-swift Carthage dependencies..."
 cd ../r2-lcp-swift
-git checkout 2.0.0
 rm -rf Carthage
 carthage checkout
 mkdir -p Carthage/Build/iOS
@@ -42,7 +45,6 @@ carthage build --use-xcframeworks --platform iOS
 
 echo "Building r2-streamer-swift Carthage dependencies..."
 cd ../r2-streamer-swift
-git checkout 2.0.0
 rm -rf Carthage
 carthage checkout
 mkdir -p Carthage/Build/iOS
@@ -50,7 +52,6 @@ carthage build --use-xcframeworks --platform iOS
 
 echo "Building r2-navigator-swift Carthage dependencies..."
 cd ../r2-navigator-swift
-git checkout 2.0.0
 rm -rf Carthage
 carthage checkout
 mkdir -p Carthage/Build/iOS

--- a/scripts/checkout-r2-branch.sh
+++ b/scripts/checkout-r2-branch.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# SUMMARY
+#   Use this script to easily toggle all R2 repos between the stable release
+#   we use in production builds and the most recent code on `develop`.
+#
+# SYNOPSIS
+#   ./scripts/checkout-r2-branch.sh [develop]
+#
+# PARAMETERS
+#   develop: check out the develop branch of every R2 frameworks we use.
+#            If missing, it will check out the tags we officially use in
+#            SimplyE / Open eBooks.
+#
+# USAGE
+#   Run this script from the root of Simplified-iOS repo.
+#
+#   This script assumes that you have the R2 repos checked out as siblings of
+#   Simplified-iOS.
+#
+#   Use this script in conjunction with the build-carthage-R2-integration.sh
+#   to build the checked out code.
+
+if [ "$1" == "develop" ]; then
+
+  echo "Checking out 'develop' on r2-shared-swift..."
+  cd ../r2-shared-swift
+  git checkout develop
+
+  echo "Checking out 'develop' on r2-lcp-swift..."
+  cd ../r2-lcp-swift
+  git checkout develop
+
+  echo "Checking out 'develop' on r2-streamer-swift..."
+  cd ../r2-streamer-swift
+  git checkout develop
+
+  echo "Checking out 'develop' on r2-navigator-swift..."
+  cd ../r2-navigator-swift
+  git checkout develop
+
+else
+
+  echo "Checking out latest stable tag on r2-shared-swift..."
+  cd ../r2-shared-swift
+  git checkout 2.0.1
+
+  echo "Checking out latest stable tag on r2-lcp-swift..."
+  cd ../r2-lcp-swift
+  git checkout 2.0.0
+
+  echo "Checking out latest stable tag on r2-streamer-swift..."
+  cd ../r2-streamer-swift
+  git checkout 2.0.0
+
+  echo "Checking out latest stable tag on r2-navigator-swift..."
+  cd ../r2-navigator-swift
+  git checkout 2.0.0
+
+fi


### PR DESCRIPTION
**What's this do?**
- adds toggle for disabling publisher's epub defaults
- minor refactor of our user settings
- adds a script to easily toggle between the stable tags and the `develop` branch of the R2 repos 

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/IOS-234

**How should this be tested? / Do these changes have associated tests?**
see ticket

**Dependencies for merging? Releasing to production?**
this will appear in the next SimplyE

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
yes

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 