### PR TITLE
OE-178 Hide Publisher's defaults toggle till UX approval

### DIFF
--- a/Simplified/Reader2/UI/NYPLReaderSettingsView.m
+++ b/Simplified/Reader2/UI/NYPLReaderSettingsView.m
@@ -215,8 +215,10 @@
   self.publisherDefaultContainer.distribution = UIStackViewDistributionFill;
   self.publisherDefaultContainer.spacing = 10;
   self.publisherDefaultContainer.alignment = UIStackViewAlignmentCenter;
+#if OPENEBOOKS
+  self.publisherDefaultContainer.hidden = YES;
+#endif
   [self addSubview:self.publisherDefaultContainer];
-
 
   // brightness slider ---------------------------------------------------------
   self.brightnessView = [[UIView alloc] init];
@@ -271,9 +273,20 @@
   CGFloat const padding = 10;
   CGFloat const topPadding = 16;
   CGFloat const innerWidth = CGRectGetWidth(self.frame) - padding * 2;
+#if OPENEBOOKS
+  CGFloat const numRows = 4.0;
+#else
   CGFloat const numRows = 5.0;
+#endif
+
   CGFloat const rowHeight = round((CGRectGetHeight(self.frame) - topPadding) / numRows);
-  
+
+#if OPENEBOOKS
+  CGFloat const publisherDefaultsRowHeight = 0;
+#else
+  CGFloat const publisherDefaultsRowHeight = rowHeight;
+#endif
+
   self.sansButton.frame = CGRectMake(padding,
                                      topPadding,
                                      round(innerWidth / 3.0),
@@ -318,13 +331,13 @@
   self.publisherDefaultContainer.frame = CGRectMake(padding,
                                                     CGRectGetMaxY(self.increaseButton.frame),
                                                     innerWidth,
-                                                    rowHeight);
+                                                    publisherDefaultsRowHeight);
 
   self.brightnessView.frame = CGRectMake(padding,
                                          CGRectGetMaxY(self.publisherDefaultContainer.frame),
                                          innerWidth,
                                          rowHeight);
-  
+
   self.brightnessLowImageView.frame =
     CGRectMake(0,
                (CGRectGetHeight(self.brightnessView.frame) / 2 -


### PR DESCRIPTION
**What's this do?**
Simply hides the row with the toggle but leaves the view installed so that the existing layout code doesn't need to be changed drastically. 

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-178

**How should this be tested? / Do these changes have associated tests?**
see ticket

**Dependencies for merging? Releasing to production?**
merging to develop since just to be on the safe side, and since this is unrelated to Axis DRM.

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no, because I will merge develop into the feature branch and then build Axis branch instead.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
Ettore did on iPhone and iPad
