### PR TITLE
Remove adobe from OE license

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -3488,6 +3488,7 @@
 				7394FBD8252F936E00037515 /* Announcements */,
 				73225DE5250B46CE00EF1877 /* AppInfrastructure */,
 				21E7E07424FEA7C100189224 /* Audiobooks */,
+				59054578268A12A100D0E4C5 /* AxisService */,
 				73B5DFD72605296300225C12 /* Book */,
 				739ECB2725101F1600691A70 /* Catalog */,
 				73DE53322525A588003E2C56 /* ErrorHandling */,
@@ -3505,7 +3506,6 @@
 				7327A88D23EE00FE00954748 /* Utilities */,
 				73DE53332525A83F003E2C56 /* Views */,
 				738CB2092509AD3B00891F31 /* WelcomeScreen */,
-				59054578268A12A100D0E4C5 /* AxisService */,
 				A823D817192BABA400B55DE2 /* Supporting Files */,
 			);
 			path = Simplified;
@@ -4067,7 +4067,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/\"\nsed -i '' \"s/SimplyE/Open eBooks/\" software-licenses.html\n";
+			shellScript = "cd \"$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/\"\nsed -i '' \"s/SimplyE/Open eBooks/\" software-licenses.html\nsed -i '' \"s/.*ADOBEADEPT.*//\" software-licenses.html \n";
 		};
 		739E614C244A0D8600D00301 /* Copy Frameworks (Carthage) */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Simplified/software-licenses.html
+++ b/Simplified/software-licenses.html
@@ -34,13 +34,8 @@ limitations under the License.</p>
 
 <h1 id="licenses-for-included-software">Licenses for Included Software</h1>
 
-<h2 id="adobe-drm-connector">Adobe DRM Connector</h2>
-<p>The Software contains Adobe DRM (“the Adobe Software”), which NYPL has
-provided to you by license arrangement with Adobe Systems Incorporated (“Adobe”), a
-Delaware corporation having a place of business at 345 Park Avenue, San Jose, CA
-95110-2704, and with webqem pty ltd (the “Adobe Supplier”), a corporation having a
-place of business at PO Box 809, Neutral Bay, New South Wales, 2089, Australia. See the END USER LICENSE
-AGREEMENT to understand rights granted in the application for its use.</p>
+<h2 class="ADOBEADEPT" id="adobe-drm-connector">Adobe DRM Connector</h2>
+<p class="ADOBEADEPT">The Software contains Adobe DRM (“the Adobe Software”), which NYPL has provided to you by license arrangement with Adobe Systems Incorporated (“Adobe”), a Delaware corporation having a place of business at 345 Park Avenue, San Jose, CA 95110-2704, and with webqem pty ltd (the “Adobe Supplier”), a corporation having a place of business at PO Box 809, Neutral Bay, New South Wales, 2089, Australia. See the END USER LICENSE AGREEMENT to understand rights granted in the application for its use.</p>
 
 <h2 id="ZXing">Zebra Crossing</h2>
 <p>Copyright 2012 ZXing authors (<a href="https://github.com/zxingify/zxingify-objc">


### PR DESCRIPTION
**What's this do?**
fixes up the software license file since we don't have Adobe anymore

**Why are we doing this? (w/ JIRA link if applicable)**
legal reasons 

**How should this be tested? / Do these changes have associated tests?**
open software licenses item in Settings

**Dependencies for merging? Releasing to production?**
merging to feature branch

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ettore 