### PR TITLE
IOS-181 Remove OE downloaded content hot-fix

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -5726,7 +5726,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5749,7 +5749,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.OpenEbooks;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
@@ -5784,7 +5784,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5807,7 +5807,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.OpenEbooks;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";

--- a/Simplified/AppInfrastructure/NYPLBookContentMetadataFilesHelper.swift
+++ b/Simplified/AppInfrastructure/NYPLBookContentMetadataFilesHelper.swift
@@ -27,7 +27,8 @@ import Foundation
     if (account != AccountsManager.NYPLAccountUUIDs[0]) {
       dirURL = dirURL.appendingPathComponent(String(account))
     }
-    
+
+    Log.info(#function, "Book content directory URL: \(dirURL)")
     return dirURL
   }
 }

--- a/Simplified/Book/Models/NYPLBookRegistry.h
+++ b/Simplified/Book/Models/NYPLBookRegistry.h
@@ -142,6 +142,10 @@ genericBookmarks:(nullable NSArray<NYPLBookLocation *> *)genericBookmarks;
 // TODO: Remove when migrate to Swift, use setState:forIdentifier: instead
 - (void)setStateWithCode:(NSInteger)stateCode forIdentifier:(nonnull NSString *)identifier;
 
+// Reset the book state for the given book identifier to NYPLBookStateDownloadNeeded
+// for books that were in a downloaded/downloading states.
+- (void)resetStateToDownloadNeededForIdentifier:(nonnull NSString *)identifier;
+
 // Returns the state of a book given its identifier.
 - (NYPLBookState)stateForIdentifier:(nonnull NSString *)identifier;
 

--- a/Simplified/Book/Models/NYPLBookRegistry.m
+++ b/Simplified/Book/Models/NYPLBookRegistry.m
@@ -151,6 +151,7 @@ static NSString *const RecordsKey = @"records";
 
 - (void)justLoad
 {
+  NYPLLOG_F(@"Current Library Acct UUID: %@", [AccountsManager sharedInstance].currentAccount.uuid);
   [self loadWithoutBroadcastingForAccount:[AccountsManager sharedInstance].currentAccount.uuid];
   [self broadcastChange];
 }

--- a/Simplified/Migrations/OEMigrations.swift
+++ b/Simplified/Migrations/OEMigrations.swift
@@ -19,6 +19,10 @@ extension NYPLMigrationManager {
     migrate_1_8_1(ifNeededFrom: versionComponents)
     #endif
     migrate_1_9_0(ifNeededFrom: versionComponents)
+
+    #if AXIS
+    migrate_2_1_1(ifNeededFrom: versionComponents)
+    #endif
   }
   #if FEATURE_DRM_CONNECTOR
   /// v1.8.1
@@ -148,4 +152,45 @@ extension NYPLMigrationManager {
     }
   }
 
+  /// Since v2.1.0 OE supports only Axis DRM books. Books
+  /// previously downloaded with Adobe DRM are treated as unsupported, therefore
+  /// not openable anymore in the ereader. (This was necessary because the
+  /// contract with Adobe ended at a hard date.)
+  /// To avoid confusion, and since the same books are redownloadable in Axis
+  /// format, we wipe out all downloaded content from disk, and change the state
+  /// of those books so that the user knows that they need to be downloaded
+  /// again.
+  private static func migrate_2_1_1(ifNeededFrom previousVersion: [Int]) -> Void {
+    guard !previousVersion.isEmpty, version(previousVersion, isLessThan: [2, 1, 1]) else {
+      return
+    }
+
+    let accountMgr = AccountsManager.shared
+    Log.info(#function, "accountMgr.currentAccountId=\(String(describing: accountMgr.currentAccountId))")
+
+    // we need to set up the account sets before resetting the download center,
+    // because otherwise the reset function will do nothing.
+    accountMgr.updateAccountSet { [weak accountMgr] _ in
+      Log.info(#function, "accountMgr.currentAccount.uuid=\(String(describing: accountMgr?.currentAccount?.uuid))")
+
+      // Wipe out all downloaded books from disk.
+      NYPLMyBooksDownloadCenter.shared()?.reset()
+
+      // Change the book state for our books so that they are downloadable
+      // again. Note that there may be other sync operations in progress
+      // already (syncResettingCache:completionHandler:backgroundFetchHandler:)
+      // but those do not interfere with the code below because they won't
+      // change the book state. This dependency is not enforced in code and
+      // therefore it is very fragile. The need for this migration is
+      // short lived since users won't be able to check out books in Adobe
+      // format anymore.
+      if let allBooks = NYPLBookRegistry.shared().allBooks as? [NYPLBook] {
+        for book in allBooks {
+          NYPLBookRegistry.shared().setStateWithCode(NYPLBookState.DownloadNeeded.rawValue,
+                                                     forIdentifier: book.identifier)
+        }
+      }
+      NYPLBookRegistry.shared().save()
+    }
+  }
 }

--- a/Simplified/Migrations/OEMigrations.swift
+++ b/Simplified/Migrations/OEMigrations.swift
@@ -176,6 +176,8 @@ extension NYPLMigrationManager {
       // Wipe out all downloaded books from disk.
       NYPLMyBooksDownloadCenter.shared()?.reset()
 
+      let registry = NYPLBookRegistry.shared()
+
       // Change the book state for our books so that they are downloadable
       // again. Note that there may be other sync operations in progress
       // already (syncResettingCache:completionHandler:backgroundFetchHandler:)
@@ -186,11 +188,10 @@ extension NYPLMigrationManager {
       // format anymore.
       if let allBooks = NYPLBookRegistry.shared().allBooks as? [NYPLBook] {
         for book in allBooks {
-          NYPLBookRegistry.shared().setStateWithCode(NYPLBookState.DownloadNeeded.rawValue,
-                                                     forIdentifier: book.identifier)
+          registry.resetStateToDownloadNeeded(forIdentifier: book.identifier)
         }
       }
-      NYPLBookRegistry.shared().save()
+      registry.save()
     }
   }
 }


### PR DESCRIPTION
**What's this do?**
Emergency brute force fix that removes all downloads and updates the book registry to say that the currently loaned books need to be re-downloaded. This is for fixing the inability to read previously downloaded Adobe DRM content. 

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-181

**How should this be tested? / Do these changes have associated tests?**
- Install OE 2.0.0 (3) from Firebase and download a book. This will be in Adobe format.
- Install OE 2.1.0 (5) from Firebase. The adobe book should still appear in My Books but you won't be able to open that book anymore. Download an additional book.
- install OE 2.1.1 from Firebase or TestFlight. You should still be able to see both books in My Books, but those books will need to be re-downloaded. You should be able to do so and and open them for reading.

If you still have OE 2.0.0 installed from TestFlight or App Store, you could repeat the above using TestFlight/App Store builds if you prefer.

**Dependencies for merging? Releasing to production?**
this will go in a hot fix release based on top of 2.1.0, not develop.

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
yes

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 