### PR TITLE
IOS-263 Log annotation api errors to Crashlytics

### DIFF
--- a/Simplified/Logging/NYPLErrorLogger.swift
+++ b/Simplified/Logging/NYPLErrorLogger.swift
@@ -63,7 +63,7 @@ fileprivate let nullString = "null"
   case nilCFI = 500
   case bookmarkReadError = 501
 
-  // Parse failure
+  // Parse / serialization failures
   case parseProfileDataCorrupted = 600
   case parseProfileTypeMismatch = 601
   case parseProfileValueNotFound = 602
@@ -75,6 +75,8 @@ fileprivate let nullString = "null"
   case parseProblemDocFail = 608
   case overdriveFulfillResponseParseFail = 609
   case authDataParseFail = 610
+  case parseFail = 611
+  case serializationFail = 612
 
   // account management
   case authDocLoadFail = 700
@@ -284,7 +286,7 @@ fileprivate let nullString = "null"
       metadata[NSUnderlyingErrorKey] = error
     }
     addAccountInfoToMetadata(&metadata)
-    
+
     let userInfo = additionalInfo(severity: .info,
                                   message: "Local Login Failed With Error",
                                   metadata: metadata)
@@ -419,9 +421,7 @@ fileprivate let nullString = "null"
       }
     }
 
-    let userInfo = additionalInfo(
-      severity: .error,
-      metadata: metadata)
+    let userInfo = additionalInfo(severity: .error, metadata: metadata)
 
     let err = NSError(domain: summary,
                       code: NYPLErrorCode.parseProblemDocFail.rawValue,


### PR DESCRIPTION
**What's this do?**
Adds the errors received when POSTing annotations to the Crashlytics report. 

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/IOS-263

**How should this be tested? / Do these changes have associated tests?**
no changes in  behavior should be experienced by the user. The part of the regression that covers reading progress updates and bookmarks should cover this.

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no -- however after this I will start a new release for SimplyE.

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 