### PR TITLE
IOS-270 Fix + log more info for crash on book return

### DIFF
--- a/Simplified/Book/Models/NYPLBookRegistry.m
+++ b/Simplified/Book/Models/NYPLBookRegistry.m
@@ -757,7 +757,13 @@ genericBookmarks:(NSArray<NYPLBookLocation *> *)genericBookmarks
 {
   @synchronized(self) {
     [self.coverRegistry removePinnedThumbnailImageForBookIdentifier:identifier];
-    [self.identifiersToRecords removeObjectForKey:identifier];
+    if (identifier) {
+      // introduced for IOS-270. While it seems impossible for the app to
+      // create a book instance with a nil id or set the id to nil, somehow
+      // that is happening while returning the book. See other IOS-270 tags in
+      // the code base for more context.
+      [self.identifiersToRecords removeObjectForKey:identifier];
+    }
     [self broadcastChange];
   }
 }

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -644,6 +644,23 @@ didCompleteWithError:(NSError *)error
   // Process Adobe Return
 #if defined(FEATURE_DRM_CONNECTOR)
   NSString *fulfillmentId = [[NYPLBookRegistry sharedRegistry] fulfillmentIdForIdentifier:identifier];
+
+  // -------- tmp code to diagnose IOS-270 --------
+  if (book.identifier == nil) {
+    [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeAppLogicInconsistency
+                              summary:@"Attempting to returning book with nil id"
+                             metadata:@{
+                               @"book identifier var": identifier ?: @"N/A",
+                               @"book.revokeURL": book.revokeURL ?: @"N/A",
+                               @"book.title": book.title ?: @"N/A",
+                               @"book.distributor": book.distributor ?: @"N/A",
+                               @"book registry state": [NYPLBookStateHelper stringValueFromBookState:state] ?: @"N/A",
+                               @"fulfillmentId": fulfillmentId ?: @"N/A",
+                               @"needsAuth": @(NYPLUserAccount.sharedAccount.authDefinition.needsAuth),
+                             }];
+  }
+  // ----------------------------------------------
+
   if (fulfillmentId && NYPLUserAccount.sharedAccount.authDefinition.needsAuth) {
     NYPLLOG_F(@"Return attempt for book. userID: %@",[[NYPLUserAccount sharedAccount] userID]);
     [[NYPLADEPT sharedInstance] returnLoan:fulfillmentId


### PR DESCRIPTION
**What's this do?**
Adds a nil check to fix a crash and also add a log event to try to diagnose why the nil id is happening in the first place. See full analysis in ticket.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/IOS-270

**How should this be tested? / Do these changes have associated tests?**
I don't have steps to reproduce this issue. I will try to add some details for QA in the ticket.

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
y

**Did someone actually run this code to verify it works?**
@ettore 