### PR TITLE
IOS-172 Advance to PIN after hitting Return on Barcode field

### DIFF
--- a/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
@@ -279,6 +279,7 @@ Authenticating with any of those barcodes should work.
 
   self.usernameTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
   self.usernameTextField.autocorrectionType = UITextAutocorrectionTypeNo;
+  self.usernameTextField.returnKeyType = UIReturnKeyNext;
   [self.usernameTextField
    addTarget:self
    action:@selector(textFieldsDidChange)
@@ -306,6 +307,7 @@ Authenticating with any of those barcodes should work.
   }
 
   self.PINTextField.secureTextEntry = YES;
+  self.PINTextField.returnKeyType = UIReturnKeyDone;
   self.PINTextField.delegate = self.frontEndValidator;
   [self.PINTextField
    addTarget:self
@@ -1301,13 +1303,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
   } else {
     self.logInSignOutCell.textLabel.text = NSLocalizedString(@"LogIn", nil);
     self.logInSignOutCell.textLabel.textAlignment = NSTextAlignmentLeft;
-    BOOL const barcodeHasText = [self.usernameTextField.text
-                                 stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length;
-    BOOL const pinHasText = [self.PINTextField.text
-                             stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length;
-    BOOL const pinIsNotRequired = self.businessLogic.selectedAuthentication.pinKeyboard == LoginKeyboardNone;
-    BOOL const oauthLogin = self.businessLogic.selectedAuthentication.isOauth;
-    if((barcodeHasText && pinHasText) || (barcodeHasText && pinIsNotRequired) || oauthLogin) {
+    if ([self.frontEndValidator canAttemptSignIn]) {
       self.logInSignOutCell.userInteractionEnabled = YES;
       self.logInSignOutCell.textLabel.textColor = [NYPLConfiguration mainColor];
     } else {

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.m
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.m
@@ -175,6 +175,7 @@ CGFloat const marginPadding = 2.0;
 
   self.usernameTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
   self.usernameTextField.autocorrectionType = UITextAutocorrectionTypeNo;
+  self.usernameTextField.returnKeyType = UIReturnKeyNext;
   [self.usernameTextField
    addTarget:self
    action:@selector(textFieldsDidChange)
@@ -197,6 +198,7 @@ CGFloat const marginPadding = 2.0;
   }
 
   self.PINTextField.secureTextEntry = YES;
+  self.PINTextField.returnKeyType = UIReturnKeyDone;
   self.PINTextField.delegate = self.frontEndValidator;
   [self.PINTextField
    addTarget:self
@@ -757,14 +759,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
   }
 
   self.logInCell.textLabel.text = NSLocalizedString(@"LogIn", nil);
-  BOOL const barcodeHasText = [self.usernameTextField.text
-                               stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length;
-  BOOL const pinHasText = [self.PINTextField.text
-                           stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length;
-  BOOL const pinIsNotRequired = self.businessLogic.selectedAuthentication.pinKeyboard == LoginKeyboardNone;
-  BOOL const oauthLogin = self.businessLogic.selectedAuthentication.isOauth;
-
-  if ((barcodeHasText && (pinHasText || pinIsNotRequired)) || oauthLogin) {
+  if ([self.frontEndValidator canAttemptSignIn]) {
     self.logInCell.userInteractionEnabled = YES;
     self.logInCell.textLabel.textColor = [NYPLConfiguration mainColor];
   } else {


### PR DESCRIPTION
**What's this do?**
On the sign in UI (both in Settings tab and modal) this configures the Return button for the Username field to advance to the PIN field; the Return button for the PIN field to attempt to log in.

This also refactors the logic that determines when the Log In button is enabled, and reuses it for triggering login when the user presses the Done button on the PIN keyboard.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/IOS-172

**How should this be tested? / Do these changes have associated tests?**
See ticket

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ettore 