### PR TITLE
IOS-264 Update Cartfile, improve README + R2 integration script

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "8.9.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json" "8.9.0"
-github "NYPL-Simplified/NYPLAudiobookToolkit" "7dd20ac2ea341a28464840aafe93a8284dca8ee9"
+github "NYPL-Simplified/NYPLAudiobookToolkit" "3d6b92b4294259cfe393660a2e1de206264fcb31"
 github "NYPL-Simplified/PDFRendererProvider-iOS" "d63e6ba168cb91617a4aca5e306a92af1dd4497c"
 github "NYPL-Simplified/audiobook-ios-overdrive" "6e882e29a62d3a4e2cebe04a8943ed3855bcb599"
 github "NYPL-Simplified/CardCreator-iOS" "d6745eed41e6e6439024a23a74236f9f03a01d59"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Open `Simplified.xcodeproj` and build the `SimplyE-noDRM` target.
 
 # Building with DRM Support
 
-## Building the Application from Scratch
+## Building from Scratch
 
 01. Contact project lead and ensure you have access to all the required private repos.
 02. Build the dependencies (typically you'll need to run this only once):
@@ -52,9 +52,9 @@ cd Simplified-iOS #repo root
 ```
 The `scripts` directory contains a number of other scripts to build dependencies more granularly and also to build/archive/test the app from the command line. These scripts are the same used by our CI system. All these scripts must be run from the root of the Simplified-iOS repo, not from the `scripts` directory.
 
-## Building for Readium 2 Integration
+# Building for Readium 2 Integration
 
-Before working on R2 integration, make sure you can build the app without R2. Follow the steps listed above for building the app with DRM.
+Before working on R2 integration, make sure you can build the app by following the steps listed above.
 
 For working on integrating R2 into SimplyE, first clone the following frameworks as siblings of `Simplified-iOS` on the file system:
 ```bash
@@ -62,7 +62,7 @@ cd Simplified-iOS/..
 git clone https://github.com/readium/r2-shared-swift
 git clone https://github.com/readium/r2-streamer-swift
 git clone https://github.com/readium/r2-navigator-swift
-git clone https://github.com/readium/r2-lcp-swift
+git clone https://github.com/readium/r2-lcp-swift # only required for DRM support
 ```
 Then rebuild the dependencies:
 ```bash
@@ -73,7 +73,7 @@ Finally, open `SimplifiedR2.workspace` and use the `SimplyE-R2dev` target to bui
 
 # Building Open eBooks
 
-Open eBooks is an app primarily targeted toward the education space. It requires DRM.
+Open eBooks is an app primarily targeted toward the education space. It requires DRM. Follow the same steps as indicated above and use the "Open eBooks" Xcode target.
 
 # Contributing
 

--- a/scripts/build-carthage-R2-integration.sh
+++ b/scripts/build-carthage-R2-integration.sh
@@ -5,7 +5,10 @@
 #   all Carthage dependencies for working on R2 integration.
 #
 # SYNOPSIS
-#     ./scripts/build-carthage-R2-integration.sh
+#   ./scripts/build-carthage-R2-integration.sh [--no-private]
+#
+# PARAMETERS
+#   --no-private: skips integrating private repos for DRM support.
 #
 # USAGE
 #   Run this script from the root of Simplified-iOS repo.
@@ -36,12 +39,14 @@ carthage checkout
 mkdir -p Carthage/Build/iOS
 carthage build --use-xcframeworks --platform iOS
 
-echo "Building r2-lcp-swift Carthage dependencies..."
-cd ../r2-lcp-swift
-rm -rf Carthage
-carthage checkout
-mkdir -p Carthage/Build/iOS
-carthage build --use-xcframeworks --platform iOS
+if [ "$1" != "--no-private" ]; then # include private libraries (e.g. for DRM support)
+  echo "Building r2-lcp-swift Carthage dependencies..."
+  cd ../r2-lcp-swift
+  rm -rf Carthage
+  carthage checkout
+  mkdir -p Carthage/Build/iOS
+  carthage build --use-xcframeworks --platform iOS
+fi
 
 echo "Building r2-streamer-swift Carthage dependencies..."
 cd ../r2-streamer-swift
@@ -66,4 +71,4 @@ sed -i '' "s|github \"NYPL-Simplified/r2|#github \"NYPL-Simplified/r2|" Cartfile
 sed -i '' "s|github \"readium/r2.*||" Cartfile.resolved
 sed -i '' "s|github \"NYPL-Simplified/r2.*||" Cartfile.resolved
 
-./scripts/build-carthage.sh
+./scripts/build-carthage.sh $1


### PR DESCRIPTION
**What's this do?**
Pulls in changes for fixed warnings in NYPLAudiobookToolkit, makes the R2 integration script work without DRM support and updates the README accordingly.

**Why are we doing this? (w/ JIRA link if applicable)**
IOS-264

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 