### PR TITLE
IOS-277 Add info about book being nil to log event

### DIFF
--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -665,6 +665,7 @@ didCompleteWithError:(NSError *)error
                                @"book.title": book.title ?: @"N/A",
                                @"book.distributor": book.distributor ?: @"N/A",
                                @"book registry state": [NYPLBookStateHelper stringValueFromBookState:state] ?: @"N/A",
+                               @"book instance nil?": @(book == nil),
                                @"fulfillmentId": fulfillmentId ?: @"N/A",
                                @"needsAuth": @(NYPLUserAccount.sharedAccount.authDefinition.needsAuth),
                              }];


### PR DESCRIPTION
**What's this do?**
Add info about book instance being nil or not in the context of diagnosing IOS-270

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/IOS-270
https://jira.nypl.org/browse/IOS-277

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ettore 