### PR TITLE
IOS-299 Fix color issue in Light Mode and remove unneeded error report

### DIFF
--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -72,9 +72,6 @@ extension NYPLNetworkResponder: URLSessionDelegate {
   func urlSession(_ session: URLSession, didBecomeInvalidWithError err: Error?) {
     if let err = err {
       NYPLErrorLogger.logError(err, summary: "URLSession became invalid")
-    } else {
-      NYPLErrorLogger.logError(withCode: .invalidURLSession,
-                               summary: "URLSessionDelegate: session became invalid")
     }
 
     taskInfoLock.lock()

--- a/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
@@ -341,7 +341,7 @@ Authenticating with any of those barcodes should work.
   [self setupTableData];
   
   self.syncSwitch = [[UISwitch alloc] initWithFrame:CGRectZero];
-  [self.syncSwitch setOnTintColor:[NYPLConfiguration actionColor]];
+  [self.syncSwitch setOnTintColor:[NYPLConfiguration mainColor]];
   [self checkSyncPermissionForCurrentPatron];
 }
 


### PR DESCRIPTION
**What's this do?**
While in Light mode, the Sync Bookmarks switch appeared with the blue color used for Dark Mode.
Also removed unneeded error report for a condition that is not an error.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/IOS-299

**How should this be tested? / Do these changes have associated tests?**
will update ticket

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ettore