### PR TITLE
IOS-57 Add book info to audiobook error report

### DIFF
--- a/Simplified/Book/UI/NYPLBookCellDelegate+Audiobooks.m
+++ b/Simplified/Book/UI/NYPLBookCellDelegate+Audiobooks.m
@@ -169,15 +169,19 @@
     NSString *logLevel = (level == LogLevelInfo ? @"info" :
                           (level == LogLevelWarn ? @"warning" : @"error"));
     NSString *summary = [NSString stringWithFormat:@"NYPLAudiobookToolkit %@", logLevel];
+    NSDictionary *metadata = @{
+      @"context": msg,
+      @"book": [self.book loggableDictionary] ?: @"N/A",
+    };
 
     if (error) {
       [NYPLErrorLogger logError:error
                         summary:summary
-                       metadata:@{ @"context": msg }];
+                       metadata:metadata];
     } else if (level > LogLevelDebug) {
       [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeAudiobookExternalError
                                 summary:summary
-                               metadata:@{ @"context": msg }];
+                               metadata:metadata];
     }
   }];
 }


### PR DESCRIPTION
**What's this do?**
adds book details to audiobook errors logged to Crashlytics

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/IOS-57

**How should this be tested? / Do these changes have associated tests?**
will add details in ticket

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ettore 