### PR TITLE
IOS-148 Dependency inject NYPLAnnotations and update unit tests

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -125,6 +125,8 @@
 		17631AEE25E488CD006079C4 /* NYPLAgeCheckViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17631AEC25E488CD006079C4 /* NYPLAgeCheckViewController.swift */; };
 		17631AF025E488CD006079C4 /* NYPLAgeCheckViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17631AEC25E488CD006079C4 /* NYPLAgeCheckViewController.swift */; };
 		1763C0D624F460FE00A4D0E2 /* NYPLAnnouncementManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1763C0D524F460FE00A4D0E2 /* NYPLAnnouncementManagerTests.swift */; };
+		178AD3E8276053BE003A6C12 /* NYPLAnnotationsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178AD3E7276053BE003A6C12 /* NYPLAnnotationsMock.swift */; };
+		178AD3F8276C7638003A6C12 /* NYPLAnnotationsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178AD3E7276053BE003A6C12 /* NYPLAnnotationsMock.swift */; };
 		1798538B255A4092009F94D9 /* NYPLBookLocation+Locator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1798538A255A4092009F94D9 /* NYPLBookLocation+Locator.swift */; };
 		1798538C255A4092009F94D9 /* NYPLBookLocation+Locator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1798538A255A4092009F94D9 /* NYPLBookLocation+Locator.swift */; };
 		1798538E255A4092009F94D9 /* NYPLBookLocation+Locator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1798538A255A4092009F94D9 /* NYPLBookLocation+Locator.swift */; };
@@ -1788,6 +1790,7 @@
 		17631AEC25E488CD006079C4 /* NYPLAgeCheckViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAgeCheckViewController.swift; sourceTree = "<group>"; };
 		1763C0D524F460FE00A4D0E2 /* NYPLAnnouncementManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAnnouncementManagerTests.swift; sourceTree = "<group>"; };
 		176F8A802519684D00CE5BFB /* AudioEngine.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AudioEngine.xcframework; path = NYPLAEToolkit/build/AudioEngine.xcframework; sourceTree = "<group>"; };
+		178AD3E7276053BE003A6C12 /* NYPLAnnotationsMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAnnotationsMock.swift; sourceTree = "<group>"; };
 		1798538A255A4092009F94D9 /* NYPLBookLocation+Locator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLBookLocation+Locator.swift"; sourceTree = "<group>"; };
 		17A5AB4E25D201BD005DFF05 /* LCPPassphraseAuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPPassphraseAuthenticationService.swift; sourceTree = "<group>"; };
 		17ADCF4E254BB84800D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLReaderBookmarksBusinessLogicTests.swift; sourceTree = "<group>"; };
@@ -2855,6 +2858,7 @@
 				17BE24DF25FABA0900AE707F /* NYPLAgeCheckChoiceStorageMock.swift */,
 				17BE24E625FABCDE00AE707F /* NYPLUserAccountProviderMock.swift */,
 				17BE24EC25FB09F000AE707F /* NYPLCurrentLibraryAccountProviderMock.swift */,
+				178AD3E7276053BE003A6C12 /* NYPLAnnotationsMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -4266,6 +4270,7 @@
 				73F6BFA3261E515E00A71AB8 /* NYPLR1BookmarkDeserializationTests.swift in Sources */,
 				17BE24E725FABCDE00AE707F /* NYPLUserAccountProviderMock.swift in Sources */,
 				7311FD2B25CBD086004447CB /* NYPLSignInOutBusinessLogicUIDelegateMock.swift in Sources */,
+				178AD3E8276053BE003A6C12 /* NYPLAnnotationsMock.swift in Sources */,
 				173F0823241AAA4E00A64658 /* NYPLBookStateTests.swift in Sources */,
 				2199020624FD3334001BC727 /* NYPLJWKConversionTest.swift in Sources */,
 				17BE24ED25FB09F000AE707F /* NYPLCurrentLibraryAccountProviderMock.swift in Sources */,
@@ -4318,6 +4323,7 @@
 				73A794CB25492C9800C59CC1 /* NYPLFake.swift in Sources */,
 				735DD0CE2522A0730096D1F9 /* UIColor+NYPLAdditionsTests.swift in Sources */,
 				7320AB36251EBC9900E3F04D /* Date+NYPLAdditionsTests.swift in Sources */,
+				178AD3F8276C7638003A6C12 /* NYPLAnnotationsMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
@@ -1,7 +1,49 @@
 import UIKit
 import R2Shared
 
-@objcMembers final class NYPLAnnotations: NSObject {
+protocol NYPLAnnotationSyncing: AnyObject {
+  // Server status
+  
+  static func requestServerSyncStatus(forAccount userAccount: NYPLUserAccount,
+                                      completion: @escaping (_ enableSync: Bool) -> ())
+  
+  static func updateServerSyncSetting(toEnabled enabled: Bool, completion:@escaping (Bool)->())
+  
+  // Reading position
+  
+  static func syncReadingPosition(ofBook bookID: String?,
+                                  publication: Publication?,
+                                  toURL url:URL?,
+                                  completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ())
+  
+  static func postReadingPosition(forBook bookID: String, selectorValue: String)
+  
+  // Bookmark
+  
+  static func getServerBookmarks(forBook bookID:String?,
+                                 publication: Publication?,
+                                 atURL annotationURL:URL?,
+                                 completion: @escaping (_ bookmarks: [NYPLReadiumBookmark]?) -> ())
+  
+  static func deleteBookmarks(_ bookmarks: [NYPLReadiumBookmark])
+  
+  static func deleteBookmark(annotationId: String,
+                             completionHandler: @escaping (_ success: Bool) -> ())
+  
+  static func uploadLocalBookmarks(_ bookmarks: [NYPLReadiumBookmark],
+                                   forBook bookID: String,
+                                   completion: @escaping ([NYPLReadiumBookmark], [NYPLReadiumBookmark])->())
+  
+  static func postBookmark(_ bookmark: NYPLReadiumBookmark,
+                           forBookID bookID: String,
+                           completion: @escaping (_ serverID: String?) -> ())
+  
+  // Permission
+  
+  static func syncIsPossibleAndPermitted() -> Bool
+}
+
+@objcMembers final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
   // MARK: - Sync Settings
 
   /// Shows (if needed) the opt-in flow for syncing the user bookmarks and

--- a/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
@@ -91,6 +91,11 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
   /// - Returns: A newly created bookmark object, unless the input location
   /// lacked progress information.
   func addBookmark(_ bookmarkLoc: NYPLBookmarkR2Location) -> NYPLReadiumBookmark? {
+    guard bookmarkExisting(at: bookmarkLoc) == nil else {
+      Log.error(#function, "Bookmark already exists at R2 location: \(bookmarkLoc)")
+      return nil
+    }
+    
     guard let bookmark = bookmarksFactory.make(fromR2Location: bookmarkLoc) else {
       Log.error(#function, "Unable to add bookmark from R2 location: \(bookmarkLoc)")
       return nil

--- a/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
@@ -21,12 +21,15 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
   private let bookRegistry: NYPLBookRegistryProvider
   private let currentLibraryAccountProvider: NYPLCurrentLibraryAccountProvider
   private let bookmarksFactory: NYPLBookmarkFactory
+  
+  private let annotationsSynchronizer: NYPLAnnotationSyncing.Type
 
   init(book: NYPLBook,
        r2Publication: Publication,
        drmDeviceID: String?,
        bookRegistryProvider: NYPLBookRegistryProvider,
-       currentLibraryAccountProvider: NYPLCurrentLibraryAccountProvider) {
+       currentLibraryAccountProvider: NYPLCurrentLibraryAccountProvider,
+       annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
     self.book = book
     self.publication = r2Publication
     self.drmDeviceID = drmDeviceID
@@ -36,6 +39,8 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
     self.bookmarksFactory = NYPLBookmarkFactory(publication: publication,
                                                 drmDeviceID: drmDeviceID)
 
+    self.annotationsSynchronizer = annotationsSynchronizer
+    
     super.init()
   }
 
@@ -108,7 +113,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
         return
     }
     
-    NYPLAnnotations.postBookmark(bookmark, forBookID: book.identifier) { serverAnnotationID in
+    annotationsSynchronizer.postBookmark(bookmark, forBookID: book.identifier) { serverAnnotationID in
       Log.info(#function, serverAnnotationID != nil ? "Bookmark upload succeed" : "Bookmark failed to upload")
       bookmark.annotationId = serverAnnotationID
       self.bookRegistry.add(bookmark, forIdentifier: self.book.identifier)
@@ -152,7 +157,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
     }
     
     if details.syncPermissionGranted && annotationId.count > 0 {
-      NYPLAnnotations.deleteBookmark(annotationId: annotationId) { (success) in
+      annotationsSynchronizer.deleteBookmark(annotationId: annotationId) { (success) in
         Log.info(#file, success ?
           "Bookmark successfully deleted" :
           "Failed to delete bookmark from server. Will attempt again on next Sync")
@@ -171,7 +176,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
   // MARK: - Bookmark Syncing
 
   func shouldAllowRefresh() -> Bool {
-    return NYPLAnnotations.syncIsPossibleAndPermitted()
+    return annotationsSynchronizer.syncIsPossibleAndPermitted()
   }
     
   func syncBookmarks(completion: @escaping (Bool, [NYPLReadiumBookmark]) -> ()) {
@@ -188,7 +193,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
       // First check for and upload any local bookmarks that have never been saved to the server.
       // Wait til that's finished, then download the server's bookmark list and filter out any that can be deleted.
       let localBookmarks = self.bookRegistry.readiumBookmarks(forIdentifier: self.book.identifier)
-      NYPLAnnotations.uploadLocalBookmarks(localBookmarks, forBook: self.book.identifier) { (bookmarksUploaded, bookmarksFailedToUpload) in
+      self.annotationsSynchronizer.uploadLocalBookmarks(localBookmarks, forBook: self.book.identifier) { (bookmarksUploaded, bookmarksFailedToUpload) in
         for localBookmark in localBookmarks {
           for uploadedBookmark in bookmarksUploaded {
             if localBookmark.isEqual(uploadedBookmark) {
@@ -197,8 +202,9 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
           }
         }
         
-        NYPLAnnotations.getServerBookmarks(forBook: self.book.identifier, publication: self.publication, atURL: self.book.annotationsURL) { serverBookmarks in
-
+        self.annotationsSynchronizer.getServerBookmarks(forBook: self.book.identifier,
+                                                        publication: self.publication,
+                                                        atURL: self.book.annotationsURL) { serverBookmarks in
           guard let serverBookmarks = serverBookmarks else {
             self.handleBookmarksSyncFail(message: "Ending sync without running completion. Returning original list of bookmarks.",
                                          completion: completion)
@@ -274,7 +280,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
       bookRegistry.add(bookmark, forIdentifier: self.book.identifier)
     }
     
-    NYPLAnnotations.deleteBookmarks(serverBookmarksToDelete)
+    annotationsSynchronizer.deleteBookmarks(serverBookmarksToDelete)
     
     completion()
   }

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -54,14 +54,17 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
 
     lastReadPositionPoster = NYPLLastReadPositionPoster(
       book: book,
-      bookRegistryProvider: NYPLBookRegistry.shared())
+      bookRegistryProvider: NYPLBookRegistry.shared(),
+      annotationsSynchronizer: NYPLAnnotations.self
+    )
 
     bookmarksBusinessLogic = NYPLReaderBookmarksBusinessLogic(
       book: book,
       r2Publication: publication,
       drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
       bookRegistryProvider: NYPLBookRegistry.shared(),
-      currentLibraryAccountProvider: AccountsManager.shared)
+      currentLibraryAccountProvider: AccountsManager.shared,
+      annotationsSynchronizer: NYPLAnnotations.self)
 
     bookmarksBusinessLogic.syncBookmarks { (_, _) in }
 

--- a/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
+++ b/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
@@ -1,0 +1,140 @@
+//
+//  NYPLAnnotationsMock.swift
+//  SimplyETests
+//
+//  Created by Ernest Fan on 2021-12-07.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import Foundation
+import R2Shared
+@testable import SimplyE
+
+class NYPLAnnotationsMock: NYPLAnnotationSyncing {
+  static var serverBookmarks: [String: [NYPLReadiumBookmark]] = [String: [NYPLReadiumBookmark]]()
+  static var readingPositions: [String: NYPLBookmarkSpec] = [String: NYPLBookmarkSpec]()
+  
+  // For generating unique annotation id
+  static private var annotationCounter: Int = 0
+  
+  // Server status
+  
+  static func requestServerSyncStatus(forAccount userAccount: NYPLUserAccount,
+                                      completion: @escaping (_ enableSync: Bool) -> ()) {
+    completion(true)
+  }
+  
+  static func updateServerSyncSetting(toEnabled enabled: Bool, completion:@escaping (Bool)->()) {
+    completion(false)
+  }
+  
+  // Reading position
+  
+  static func syncReadingPosition(ofBook bookID: String?,
+                                  publication: Publication?,
+                                  toURL url:URL?,
+                                  completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ()) {
+    guard let id = bookID, let bookmarkSpec = readingPositions[id] else {
+      completion(nil)
+      return
+    }
+    let bookmarkData = bookmarkSpec.dictionaryForJSONSerialization()
+    let bookmark = NYPLBookmarkFactory.make(fromServerAnnotation: bookmarkData,
+                                            annotationType: .readingProgress,
+                                            bookID: id,
+                                            publication: publication)
+    completion(bookmark)
+  }
+  
+  static func postReadingPosition(forBook bookID: String, selectorValue: String) {
+    let bookmarkSpec = NYPLBookmarkSpec(time: Date(),
+                                        device: "",
+                                        motivation: .readingProgress,
+                                        bookID: bookID,
+                                        selectorValue: selectorValue)
+    readingPositions[bookID] = bookmarkSpec
+  }
+  
+  // Bookmark
+  
+  static func getServerBookmarks(forBook bookID:String?,
+                                 publication: Publication?,
+                                 atURL annotationURL:URL?,
+                                 completion: @escaping (_ bookmarks: [NYPLReadiumBookmark]?) -> ()) {
+    guard let id = bookID else {
+      completion(nil)
+      return
+    }
+    completion(serverBookmarks[id])
+  }
+  
+  static func deleteBookmarks(_ bookmarks: [NYPLReadiumBookmark]) {
+    for bookmark in bookmarks {
+      if let annotationID = bookmark.annotationId {
+        deleteBookmark(annotationId: annotationID, completionHandler: {_ in })
+      }
+    }
+  }
+  
+  static func deleteBookmark(annotationId: String,
+                             completionHandler: @escaping (_ success: Bool) -> ()) {
+    let stringComponents = annotationId.components(separatedBy: "_")
+    guard let bookID = stringComponents.first,
+      let bookmarks = serverBookmarks[bookID] else {
+      completionHandler(false)
+      return
+    }
+    serverBookmarks[bookID] = bookmarks.filter{ $0.annotationId != annotationId }
+    completionHandler(true)
+  }
+  
+  static func uploadLocalBookmarks(_ bookmarks: [NYPLReadiumBookmark],
+                                   forBook bookID: String,
+                                   completion: @escaping ([NYPLReadiumBookmark], [NYPLReadiumBookmark])->()) {
+    var bookmarksUpdated = [NYPLReadiumBookmark]()
+    var bookmarksFailedToUpdate = [NYPLReadiumBookmark]()
+    for bookmark in bookmarks {
+      postBookmark(bookmark, forBookID: bookID) { serverID in
+        if let serverID = serverID {
+          bookmark.annotationId = serverID
+          bookmarksUpdated.append(bookmark)
+        } else {
+          bookmarksFailedToUpdate.append(bookmark)
+        }
+      }
+    }
+    completion(bookmarksUpdated, bookmarksFailedToUpdate)
+  }
+  
+  static func postBookmark(_ bookmark: NYPLReadiumBookmark,
+                           forBookID bookID: String,
+                           completion: @escaping (_ serverID: String?) -> ()) {
+    if let bookmarks = serverBookmarks[bookID],
+       bookmarks.contains(bookmark)
+    {
+      completion(nil)
+      return
+    }
+    let annotationID = generateAnnotationID(bookID)
+    bookmark.annotationId = annotationID
+    var currentBookmarks = serverBookmarks[bookID] ?? [NYPLReadiumBookmark]()
+    currentBookmarks.append(bookmark)
+    serverBookmarks[bookID] = currentBookmarks
+    completion(annotationID)
+  }
+  
+  // Permission
+  
+  static func syncIsPossibleAndPermitted() -> Bool {
+    return true
+  }
+  
+  // Helper
+  
+  /// Returns an unique string in the format of "[bookID]_number"
+  /// eg. BookID123_37
+  static func generateAnnotationID(_ bookID: String) -> String {
+    annotationCounter += 1
+    return "\(bookID)_\(annotationCounter)"
+  }
+}

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -253,6 +253,28 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       XCTAssertEqual(bookmarks, nil)
     }
   }
+  
+  func testAddBookmarkWithDuplicatedBookmarks() throws {
+    let firstBookmarkLoc = newBookmarkR2Location(href: "Intro", chapter: "1", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    guard let _ = bookmarkBusinessLogic.addBookmark(firstBookmarkLoc) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+    
+    // Adding bookmark with duplicated location
+    let firstDuplicatedBookmarkLoc = newBookmarkR2Location(href: "Intro", chapter: "1", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    XCTAssertNil(bookmarkBusinessLogic.addBookmark(firstDuplicatedBookmarkLoc))
+    
+    let secondBookmarkLoc = newBookmarkR2Location(href: "Chapter 1", chapter: "2", progressWithinChapter: 0.1, progressWithinBook: 0.2)
+    guard let _ = bookmarkBusinessLogic.addBookmark(secondBookmarkLoc) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+    
+    // Adding bookmark with matching href and progressWithinChatper
+    let secondDuplicatedBookmarkLoc = newBookmarkR2Location(href: "Chapter 1", chapter: "2", progressWithinChapter: 0.1, progressWithinBook: 0.2)
+    XCTAssertNil(bookmarkBusinessLogic.addBookmark(secondDuplicatedBookmarkLoc))
+  }
 
   // MARK: - Test deleteBookmark/didDeleteBookmark
   
@@ -263,7 +285,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       return
     }
     
-    let secondBookmarkLoc = newBookmarkR2Location(href: "Chapter 1", chapter: "2", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    let secondBookmarkLoc = newBookmarkR2Location(href: "Chapter 1", chapter: "2", progressWithinChapter: 0.1, progressWithinBook: 0.2)
     guard let _ = bookmarkBusinessLogic.addBookmark(secondBookmarkLoc) else {
       XCTFail("Failed to create new bookmark")
       return
@@ -289,41 +311,6 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
     }
   }
   
-  func testDeleteBookmarkWithMultipleMatchingBookmarks() throws {
-    let firstBookmarkLoc = newBookmarkR2Location(href: "Intro", chapter: "1", progressWithinChapter: 0.1, progressWithinBook: 0.1)
-    guard let firstBookmark = bookmarkBusinessLogic.addBookmark(firstBookmarkLoc),
-          let _ = bookmarkBusinessLogic.addBookmark(firstBookmarkLoc),
-          let _ = bookmarkBusinessLogic.addBookmark(firstBookmarkLoc) else {
-      XCTFail("Failed to create new bookmark")
-      return
-    }
-    
-    let secondBookmarkLoc = newBookmarkR2Location(href: "Chapter 1", chapter: "2", progressWithinChapter: 0.1, progressWithinBook: 0.1)
-    guard let _ = bookmarkBusinessLogic.addBookmark(secondBookmarkLoc) else {
-      XCTFail("Failed to create new bookmark")
-      return
-    }
-    
-    // Make sure we have the right amount of bookmarks in BookRegistry
-    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 4)
-    
-    // Deleting three matching bookmarks
-    bookmarkBusinessLogic.deleteBookmark(firstBookmark)
-    
-    // BookRegistry should have one bookmark after deletion
-    // Server should not contain the deleted bookmark
-    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
-    annotationsMock.getServerBookmarks(forBook: bookIdentifier,
-                                       publication: nil,
-                                       atURL: nil) { bookmarks in
-      guard let bookmarks = bookmarks else {
-        XCTFail("Failed to get bookmark from server")
-        return
-      }
-      XCTAssertFalse(bookmarks.contains(firstBookmark))
-    }
-  }
-  
   func testDeleteBookmarkWithValidIndex() throws {
     let firstBookmarkLoc = newBookmarkR2Location(href: "Intro", chapter: "1", progressWithinChapter: 0.1, progressWithinBook: 0.1)
     guard let _ = bookmarkBusinessLogic.addBookmark(firstBookmarkLoc) else {
@@ -331,7 +318,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       return
     }
     
-    let secondBookmarkLoc = newBookmarkR2Location(href: "Chapter 1", chapter: "2", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    let secondBookmarkLoc = newBookmarkR2Location(href: "Chapter 1", chapter: "2", progressWithinChapter: 0.1, progressWithinBook: 0.2)
     guard let secondBookmark = bookmarkBusinessLogic.addBookmark(secondBookmarkLoc) else {
       XCTFail("Failed to create new bookmark")
       return
@@ -370,7 +357,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       return
     }
     
-    let secondBookmarkLoc = newBookmarkR2Location(href: "Chapter 1", chapter: "2", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    let secondBookmarkLoc = newBookmarkR2Location(href: "Chapter 1", chapter: "2", progressWithinChapter: 0.1, progressWithinBook: 0.2)
     guard let _ = bookmarkBusinessLogic.addBookmark(secondBookmarkLoc) else {
       XCTFail("Failed to create new bookmark")
       return

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -17,7 +17,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
     var annotationsMock: NYPLAnnotationsMock.Type!
     var bookmarkCounter: Int = 0
     let bookIdentifier = "fakeEpub"
-    
+
     override func setUpWithError() throws {
       try super.setUpWithError()
       
@@ -55,6 +55,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       bookRegistryMock = NYPLBookRegistryMock()
       bookRegistryMock.addBook(book: fakeBook, state: .DownloadSuccessful)
       libraryAccountMock = NYPLLibraryAccountMock()
+      libraryAccountMock.currentAccount?.details?.syncPermissionGranted = true
       annotationsMock = NYPLAnnotationsMock.self
       let manifest = Manifest(metadata: Metadata(title: "fakeMetadata"))
       let pub = Publication(manifest: manifest)
@@ -75,10 +76,13 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       bookRegistryMock.identifiersToRecords.removeAll()
       bookRegistryMock = nil
       bookmarkCounter = 0
+      annotationsMock.serverBookmarks.removeAll()
+      annotationsMock.readingPositions.removeAll()
+      annotationsMock = nil
     }
 
     // MARK: - Test updateLocalBookmarks
-    
+
     func testUpdateLocalBookmarksWithNoLocalBookmarks() throws {
       var serverBookmarks = [NYPLReadiumBookmark]()
         
@@ -100,7 +104,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
         XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
       }
     }
-    
+
     func testUpdateLocalBookmarksWithDuplicatedLocalBookmarks() throws {
       var serverBookmarks = [NYPLReadiumBookmark]()
 
@@ -131,7 +135,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
         XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
       }
     }
-    
+
     func testUpdateLocalBookmarksWithExtraLocalBookmarks() throws {
       var serverBookmarks = [NYPLReadiumBookmark]()
 
@@ -163,7 +167,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
         XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
       }
     }
-    
+
     func testUpdateLocalBookmarksWithFailedUploadBookmarks() throws {
       var serverBookmarks = [NYPLReadiumBookmark]()
 
@@ -194,8 +198,206 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       }
     }
 
-    // MARK: Helper
+  // MARK: - Test addBookmark/postBookmark
+
+  func testAddBookmarkWithSucceededUpload() throws {
+    // Make sure server contains no bookmark
+    annotationsMock.getServerBookmarks(forBook: bookIdentifier,
+                                       publication: nil,
+                                       atURL: nil) { bookmarks in
+      XCTAssertEqual(bookmarks, nil)
+    }
     
+    let bookmarkLoc = newBookmarkR2Location(href: "Intro", chapter: "1", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    guard let _ = bookmarkBusinessLogic.addBookmark(bookmarkLoc) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+    
+    // There should be one bookmark uploaded
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
+    annotationsMock.getServerBookmarks(forBook: bookIdentifier,
+                                       publication: nil,
+                                       atURL: nil) { bookmarks in
+      guard let bookmarks = bookmarks else {
+        XCTFail("Failed to get bookmark from server")
+        return
+      }
+      XCTAssertEqual(bookmarks.count, 1)
+    }
+  }
+
+  func testAddBookmarkWithFailedUpload() throws {
+    // Make sure server contains no bookmark
+    annotationsMock.getServerBookmarks(forBook: bookIdentifier,
+                                       publication: nil,
+                                       atURL: nil) { bookmarks in
+      XCTAssertEqual(bookmarks, nil)
+    }
+    
+    let bookmarkLoc = newBookmarkR2Location(href: "Intro", chapter: "1", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    annotationsMock.failRequest = true
+    guard let _ = bookmarkBusinessLogic.addBookmark(bookmarkLoc) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+    
+    // BookRegistry should have one bookmark even upload failed
+    // While server should not have any bookmarks
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
+    
+    annotationsMock.failRequest = false
+    annotationsMock.getServerBookmarks(forBook: bookIdentifier,
+                                       publication: nil,
+                                       atURL: nil) { bookmarks in
+      XCTAssertEqual(bookmarks, nil)
+    }
+  }
+
+  // MARK: - Test deleteBookmark/didDeleteBookmark
+  
+  func testDeleteBookmarkWithMatchingBookmark() throws {
+    let firstBookmarkLoc = newBookmarkR2Location(href: "Intro", chapter: "1", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    guard let firstBookmark = bookmarkBusinessLogic.addBookmark(firstBookmarkLoc) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+    
+    let secondBookmarkLoc = newBookmarkR2Location(href: "Chapter 1", chapter: "2", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    guard let _ = bookmarkBusinessLogic.addBookmark(secondBookmarkLoc) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+    
+    // Make sure we have the right amount of bookmarks in BookRegistry
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
+    
+    // Deleting one matching bookmark
+    bookmarkBusinessLogic.deleteBookmark(firstBookmark)
+    
+    // BookRegistry should have one bookmark after deletion
+    // Server should not contain the deleted bookmark
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
+    annotationsMock.getServerBookmarks(forBook: bookIdentifier,
+                                       publication: nil,
+                                       atURL: nil) { bookmarks in
+      guard let bookmarks = bookmarks else {
+        XCTFail("Failed to get bookmark from server")
+        return
+      }
+      XCTAssertFalse(bookmarks.contains(firstBookmark))
+    }
+  }
+  
+  func testDeleteBookmarkWithMultipleMatchingBookmarks() throws {
+    let firstBookmarkLoc = newBookmarkR2Location(href: "Intro", chapter: "1", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    guard let firstBookmark = bookmarkBusinessLogic.addBookmark(firstBookmarkLoc),
+          let _ = bookmarkBusinessLogic.addBookmark(firstBookmarkLoc),
+          let _ = bookmarkBusinessLogic.addBookmark(firstBookmarkLoc) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+    
+    let secondBookmarkLoc = newBookmarkR2Location(href: "Chapter 1", chapter: "2", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    guard let _ = bookmarkBusinessLogic.addBookmark(secondBookmarkLoc) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+    
+    // Make sure we have the right amount of bookmarks in BookRegistry
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 4)
+    
+    // Deleting three matching bookmarks
+    bookmarkBusinessLogic.deleteBookmark(firstBookmark)
+    
+    // BookRegistry should have one bookmark after deletion
+    // Server should not contain the deleted bookmark
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
+    annotationsMock.getServerBookmarks(forBook: bookIdentifier,
+                                       publication: nil,
+                                       atURL: nil) { bookmarks in
+      guard let bookmarks = bookmarks else {
+        XCTFail("Failed to get bookmark from server")
+        return
+      }
+      XCTAssertFalse(bookmarks.contains(firstBookmark))
+    }
+  }
+  
+  func testDeleteBookmarkWithValidIndex() throws {
+    let firstBookmarkLoc = newBookmarkR2Location(href: "Intro", chapter: "1", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    guard let _ = bookmarkBusinessLogic.addBookmark(firstBookmarkLoc) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+    
+    let secondBookmarkLoc = newBookmarkR2Location(href: "Chapter 1", chapter: "2", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    guard let secondBookmark = bookmarkBusinessLogic.addBookmark(secondBookmarkLoc) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+    
+    // Make sure we have the right amount of bookmarks in BookRegistry
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
+    
+    // Deleting bookmark at index
+    guard let deletedBookmark = bookmarkBusinessLogic.deleteBookmark(at: 1) else {
+      XCTFail("Failed to delete bookmark")
+      return
+    }
+    
+    // The deleted bookmark should match the second bookmark
+    XCTAssertEqual(secondBookmark, deletedBookmark)
+    
+    // BookRegistry should have one bookmark after deletion
+    // Server should not contain the deleted bookmark
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
+    annotationsMock.getServerBookmarks(forBook: bookIdentifier,
+                                       publication: nil,
+                                       atURL: nil) { bookmarks in
+      guard let bookmarks = bookmarks else {
+        XCTFail("Failed to get bookmark from server")
+        return
+      }
+      XCTAssertFalse(bookmarks.contains(deletedBookmark))
+    }
+  }
+  
+  func testDeleteBookmarkWithInvalidIndex() throws {
+    let firstBookmarkLoc = newBookmarkR2Location(href: "Intro", chapter: "1", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    guard let _ = bookmarkBusinessLogic.addBookmark(firstBookmarkLoc) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+    
+    let secondBookmarkLoc = newBookmarkR2Location(href: "Chapter 1", chapter: "2", progressWithinChapter: 0.1, progressWithinBook: 0.1)
+    guard let _ = bookmarkBusinessLogic.addBookmark(secondBookmarkLoc) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+    
+    // Make sure we have the right amount of bookmarks in BookRegistry
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
+    
+    // Deleting bookmark at invalid index
+    if let _ = bookmarkBusinessLogic.deleteBookmark(at: -1) {
+      XCTFail("Deleted bookmark at invalid index")
+    }
+    
+    // Bookmarks in BookRegistry should remain unchanged
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
+    
+    // Deleting bookmark at invalid index
+    if let _ = bookmarkBusinessLogic.deleteBookmark(at: 3) {
+      XCTFail("Deleted bookmark at invalid index")
+    }
+    
+    // Bookmarks in BookRegistry should remain unchanged
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
+  }
+  
+    // MARK: Helper
+
     private func newBookmark(href: String,
                              chapter: String,
                              progressWithinChapter: Float,
@@ -215,4 +417,15 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
                                  creationTime: Date(),
                                  device:device)
     }
+    
+  private func newBookmarkR2Location(href: String,
+                                     chapter: String,
+                                     progressWithinChapter: Double,
+                                     progressWithinBook: Double) -> NYPLBookmarkR2Location {
+    let locations = Locator.Locations(progression: progressWithinChapter, totalProgression: progressWithinBook)
+    let locator = Locator(href: href,
+                          type: "text/html",
+                          locations: locations)
+    return NYPLBookmarkR2Location(resourceIndex: 0, locator: locator)
+  }
 }

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -14,6 +14,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
     var bookmarkBusinessLogic: NYPLReaderBookmarksBusinessLogic!
     var bookRegistryMock: NYPLBookRegistryMock!
     var libraryAccountMock: NYPLLibraryAccountMock!
+    var annotationsMock: NYPLAnnotationsMock.Type!
     var bookmarkCounter: Int = 0
     let bookIdentifier = "fakeEpub"
     
@@ -54,6 +55,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       bookRegistryMock = NYPLBookRegistryMock()
       bookRegistryMock.addBook(book: fakeBook, state: .DownloadSuccessful)
       libraryAccountMock = NYPLLibraryAccountMock()
+      annotationsMock = NYPLAnnotationsMock.self
       let manifest = Manifest(metadata: Metadata(title: "fakeMetadata"))
       let pub = Publication(manifest: manifest)
       bookmarkBusinessLogic = NYPLReaderBookmarksBusinessLogic(
@@ -61,7 +63,8 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
         r2Publication: pub,
         drmDeviceID: "fakeDeviceID",
         bookRegistryProvider: bookRegistryMock,
-        currentLibraryAccountProvider: libraryAccountMock)
+        currentLibraryAccountProvider: libraryAccountMock,
+        annotationsSynchronizer: annotationsMock)
       bookmarkCounter = 0
     }
 

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -11,192 +11,192 @@ import R2Shared
 @testable import SimplyE
 
 class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
-    var bookmarkBusinessLogic: NYPLReaderBookmarksBusinessLogic!
-    var bookRegistryMock: NYPLBookRegistryMock!
-    var libraryAccountMock: NYPLLibraryAccountMock!
-    var annotationsMock: NYPLAnnotationsMock.Type!
-    var bookmarkCounter: Int = 0
-    let bookIdentifier = "fakeEpub"
+  var bookmarkBusinessLogic: NYPLReaderBookmarksBusinessLogic!
+  var bookRegistryMock: NYPLBookRegistryMock!
+  var libraryAccountMock: NYPLLibraryAccountMock!
+  var annotationsMock: NYPLAnnotationsMock.Type!
+  var bookmarkCounter: Int = 0
+  let bookIdentifier = "fakeEpub"
 
-    override func setUpWithError() throws {
-      try super.setUpWithError()
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    
+    let emptyUrl = URL.init(fileURLWithPath: "")
+    let fakeAcquisition = NYPLOPDSAcquisition.init(
+      relation: .generic,
+      type: "application/epub+zip",
+      hrefURL: emptyUrl,
+      indirectAcquisitions: [NYPLOPDSIndirectAcquisition](),
+      availability: NYPLOPDSAcquisitionAvailabilityUnlimited.init()
+    )
+    let fakeBook = NYPLBook.init(
+      acquisitions: [fakeAcquisition],
+      bookAuthors: [NYPLBookAuthor](),
+      categoryStrings: [String](),
+      distributor: "",
+      identifier: bookIdentifier,
+      imageURL: emptyUrl,
+      imageThumbnailURL: emptyUrl,
+      published: Date.init(),
+      publisher: "",
+      subtitle: "",
+      summary: "",
+      title: "",
+      updated: Date.init(),
+      annotationsURL: emptyUrl,
+      analyticsURL: emptyUrl,
+      alternateURL: emptyUrl,
+      relatedWorksURL: emptyUrl,
+      seriesURL: emptyUrl,
+      revokeURL: emptyUrl,
+      report: emptyUrl
+    )
+    
+    bookRegistryMock = NYPLBookRegistryMock()
+    bookRegistryMock.addBook(book: fakeBook, state: .DownloadSuccessful)
+    libraryAccountMock = NYPLLibraryAccountMock()
+    libraryAccountMock.currentAccount?.details?.syncPermissionGranted = true
+    annotationsMock = NYPLAnnotationsMock.self
+    let manifest = Manifest(metadata: Metadata(title: "fakeMetadata"))
+    let pub = Publication(manifest: manifest)
+    bookmarkBusinessLogic = NYPLReaderBookmarksBusinessLogic(
+      book: fakeBook,
+      r2Publication: pub,
+      drmDeviceID: "fakeDeviceID",
+      bookRegistryProvider: bookRegistryMock,
+      currentLibraryAccountProvider: libraryAccountMock,
+      annotationsSynchronizer: annotationsMock)
+    bookmarkCounter = 0
+  }
+
+  override func tearDownWithError() throws {
+    try super.tearDownWithError()
+    bookmarkBusinessLogic = nil
+    libraryAccountMock = nil
+    bookRegistryMock.identifiersToRecords.removeAll()
+    bookRegistryMock = nil
+    bookmarkCounter = 0
+    annotationsMock.serverBookmarks.removeAll()
+    annotationsMock.readingPositions.removeAll()
+    annotationsMock = nil
+  }
+
+  // MARK: - Test updateLocalBookmarks
+
+  func testUpdateLocalBookmarksWithNoLocalBookmarks() throws {
+    var serverBookmarks = [NYPLReadiumBookmark]()
       
-      let emptyUrl = URL.init(fileURLWithPath: "")
-      let fakeAcquisition = NYPLOPDSAcquisition.init(
-        relation: .generic,
-        type: "application/epub+zip",
-        hrefURL: emptyUrl,
-        indirectAcquisitions: [NYPLOPDSIndirectAcquisition](),
-        availability: NYPLOPDSAcquisitionAvailabilityUnlimited.init()
-      )
-      let fakeBook = NYPLBook.init(
-        acquisitions: [fakeAcquisition],
-        bookAuthors: [NYPLBookAuthor](),
-        categoryStrings: [String](),
-        distributor: "",
-        identifier: bookIdentifier,
-        imageURL: emptyUrl,
-        imageThumbnailURL: emptyUrl,
-        published: Date.init(),
-        publisher: "",
-        subtitle: "",
-        summary: "",
-        title: "",
-        updated: Date.init(),
-        annotationsURL: emptyUrl,
-        analyticsURL: emptyUrl,
-        alternateURL: emptyUrl,
-        relatedWorksURL: emptyUrl,
-        seriesURL: emptyUrl,
-        revokeURL: emptyUrl,
-        report: emptyUrl
-      )
-      
-      bookRegistryMock = NYPLBookRegistryMock()
-      bookRegistryMock.addBook(book: fakeBook, state: .DownloadSuccessful)
-      libraryAccountMock = NYPLLibraryAccountMock()
-      libraryAccountMock.currentAccount?.details?.syncPermissionGranted = true
-      annotationsMock = NYPLAnnotationsMock.self
-      let manifest = Manifest(metadata: Metadata(title: "fakeMetadata"))
-      let pub = Publication(manifest: manifest)
-      bookmarkBusinessLogic = NYPLReaderBookmarksBusinessLogic(
-        book: fakeBook,
-        r2Publication: pub,
-        drmDeviceID: "fakeDeviceID",
-        bookRegistryProvider: bookRegistryMock,
-        currentLibraryAccountProvider: libraryAccountMock,
-        annotationsSynchronizer: annotationsMock)
-      bookmarkCounter = 0
+    // Make sure BookRegistry contains no bookmark
+    XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
+    
+    guard let firstBookmark = newBookmark(href: "Intro",
+                                          chapter: "1",
+                                          progressWithinChapter: 0.1,
+                                          progressWithinBook: 0.1) else {
+      XCTFail("Failed to create new bookmark")
+      return
     }
+    serverBookmarks.append(firstBookmark)
 
-    override func tearDownWithError() throws {
-      try super.tearDownWithError()
-      bookmarkBusinessLogic = nil
-      libraryAccountMock = nil
-      bookRegistryMock.identifiersToRecords.removeAll()
-      bookRegistryMock = nil
-      bookmarkCounter = 0
-      annotationsMock.serverBookmarks.removeAll()
-      annotationsMock.readingPositions.removeAll()
-      annotationsMock = nil
-    }
-
-    // MARK: - Test updateLocalBookmarks
-
-    func testUpdateLocalBookmarksWithNoLocalBookmarks() throws {
-      var serverBookmarks = [NYPLReadiumBookmark]()
-        
-      // Make sure BookRegistry contains no bookmark
-      XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
-      
-      guard let firstBookmark = newBookmark(href: "Intro",
-                                            chapter: "1",
-                                            progressWithinChapter: 0.1,
-                                            progressWithinBook: 0.1) else {
-        XCTFail("Failed to create new bookmark")
-        return
-      }
-      serverBookmarks.append(firstBookmark)
-
-      bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
-                                                 localBookmarks: bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier),
-                                                 bookmarksFailedToUpload: [NYPLReadiumBookmark]()) {
-        XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
-      }
-    }
-
-    func testUpdateLocalBookmarksWithDuplicatedLocalBookmarks() throws {
-      var serverBookmarks = [NYPLReadiumBookmark]()
-
-      // Make sure BookRegistry contains no bookmark
-      XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
-      
-      guard let firstBookmark = newBookmark(href: "Intro",
-                                            chapter: "1",
-                                            progressWithinChapter: 0.1,
-                                            progressWithinBook: 0.1),
-        let secondBookmark = newBookmark(href: "Intro",
-                                         chapter: "1",
-                                         progressWithinChapter: 0.2,
-                                         progressWithinBook: 0.1) else {
-        XCTFail("Failed to create new bookmark")
-        return
-      }
-        
-      serverBookmarks.append(firstBookmark)
-      serverBookmarks.append(secondBookmark)
-      bookRegistryMock.add(firstBookmark, forIdentifier: bookIdentifier)
+    bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
+                                               localBookmarks: bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier),
+                                               bookmarksFailedToUpload: [NYPLReadiumBookmark]()) {
       XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
-
-      // There are one duplicated bookmark and one non-synced (server) bookmark
-      bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
-                                                 localBookmarks: bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier),
-                                                 bookmarksFailedToUpload: [NYPLReadiumBookmark]()) {
-        XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
-      }
     }
+  }
 
-    func testUpdateLocalBookmarksWithExtraLocalBookmarks() throws {
-      var serverBookmarks = [NYPLReadiumBookmark]()
+  func testUpdateLocalBookmarksWithDuplicatedLocalBookmarks() throws {
+    var serverBookmarks = [NYPLReadiumBookmark]()
 
-      // Make sure BookRegistry contains no bookmark
-      XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
+    // Make sure BookRegistry contains no bookmark
+    XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
+    
+    guard let firstBookmark = newBookmark(href: "Intro",
+                                          chapter: "1",
+                                          progressWithinChapter: 0.1,
+                                          progressWithinBook: 0.1),
+      let secondBookmark = newBookmark(href: "Intro",
+                                       chapter: "1",
+                                       progressWithinChapter: 0.2,
+                                       progressWithinBook: 0.1) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
       
-      guard let firstBookmark = newBookmark(href: "Intro",
-                                            chapter: "1",
-                                            progressWithinChapter: 0.1,
-                                            progressWithinBook: 0.1),
-        let secondBookmark = newBookmark(href: "Intro",
-                                         chapter: "1",
-                                         progressWithinChapter: 0.2,
-                                         progressWithinBook: 0.1) else {
-        XCTFail("Failed to create new bookmark")
-        return
-      }
-        
-      serverBookmarks.append(firstBookmark)
-      bookRegistryMock.add(firstBookmark, forIdentifier: bookIdentifier)
-      bookRegistryMock.add(secondBookmark, forIdentifier: bookIdentifier)
+    serverBookmarks.append(firstBookmark)
+    serverBookmarks.append(secondBookmark)
+    bookRegistryMock.add(firstBookmark, forIdentifier: bookIdentifier)
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
+
+    // There are one duplicated bookmark and one non-synced (server) bookmark
+    bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
+                                               localBookmarks: bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier),
+                                               bookmarksFailedToUpload: [NYPLReadiumBookmark]()) {
       XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
-
-      // There are one duplicated bookmark and one extra (local) bookmark,
-      // which means it has been delete from another device and should be removed locally
-      bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
-                                                 localBookmarks: bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier),
-                                                 bookmarksFailedToUpload: [NYPLReadiumBookmark]()) {
-        XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
-      }
     }
+  }
 
-    func testUpdateLocalBookmarksWithFailedUploadBookmarks() throws {
-      var serverBookmarks = [NYPLReadiumBookmark]()
+  func testUpdateLocalBookmarksWithExtraLocalBookmarks() throws {
+    var serverBookmarks = [NYPLReadiumBookmark]()
 
-      // Make sure BookRegistry contains no bookmark
-      XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
+    // Make sure BookRegistry contains no bookmark
+    XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
+    
+    guard let firstBookmark = newBookmark(href: "Intro",
+                                          chapter: "1",
+                                          progressWithinChapter: 0.1,
+                                          progressWithinBook: 0.1),
+      let secondBookmark = newBookmark(href: "Intro",
+                                       chapter: "1",
+                                       progressWithinChapter: 0.2,
+                                       progressWithinBook: 0.1) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
       
-      guard let firstBookmark = newBookmark(href: "Intro",
-                                            chapter: "1",
-                                            progressWithinChapter: 0.1,
-                                            progressWithinBook: 0.1),
-        let secondBookmark = newBookmark(href: "Intro",
-                                         chapter: "1",
-                                         progressWithinChapter: 0.2,
-                                         progressWithinBook: 0.1) else {
-        XCTFail("Failed to create new bookmark")
-        return
-      }
-        
-      serverBookmarks.append(firstBookmark)
-      bookRegistryMock.add(firstBookmark, forIdentifier: bookIdentifier)
+    serverBookmarks.append(firstBookmark)
+    bookRegistryMock.add(firstBookmark, forIdentifier: bookIdentifier)
+    bookRegistryMock.add(secondBookmark, forIdentifier: bookIdentifier)
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
+
+    // There are one duplicated bookmark and one extra (local) bookmark,
+    // which means it has been delete from another device and should be removed locally
+    bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
+                                               localBookmarks: bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier),
+                                               bookmarksFailedToUpload: [NYPLReadiumBookmark]()) {
       XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
-        
-      // There are one duplicated bookmark and one failed-to-upload bookmark
-      bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
-                                                 localBookmarks: bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier),
-                                                 bookmarksFailedToUpload: [secondBookmark]) {
-        XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
-      }
     }
+  }
+
+  func testUpdateLocalBookmarksWithFailedUploadBookmarks() throws {
+    var serverBookmarks = [NYPLReadiumBookmark]()
+
+    // Make sure BookRegistry contains no bookmark
+    XCTAssertEqual(bookRegistryMock.readiumBookmarks(forIdentifier: bookIdentifier).count, 0)
+    
+    guard let firstBookmark = newBookmark(href: "Intro",
+                                          chapter: "1",
+                                          progressWithinChapter: 0.1,
+                                          progressWithinBook: 0.1),
+      let secondBookmark = newBookmark(href: "Intro",
+                                       chapter: "1",
+                                       progressWithinChapter: 0.2,
+                                       progressWithinBook: 0.1) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+      
+    serverBookmarks.append(firstBookmark)
+    bookRegistryMock.add(firstBookmark, forIdentifier: bookIdentifier)
+    XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 1)
+      
+    // There are one duplicated bookmark and one failed-to-upload bookmark
+    bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
+                                               localBookmarks: bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier),
+                                               bookmarksFailedToUpload: [secondBookmark]) {
+      XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
+    }
+  }
 
   // MARK: - Test addBookmark/postBookmark
 
@@ -396,27 +396,27 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
     XCTAssertEqual(self.bookRegistryMock.readiumBookmarks(forIdentifier: self.bookIdentifier).count, 2)
   }
   
-    // MARK: Helper
+  // MARK: Helper
 
-    private func newBookmark(href: String,
-                             chapter: String,
-                             progressWithinChapter: Float,
-                             progressWithinBook: Float,
-                             device: String? = nil) -> NYPLReadiumBookmark? {
-      // Annotation id needs to be unique
-      // contentCFI should be empty string for R2 bookmark
-      bookmarkCounter += 1
-      return NYPLReadiumBookmark(annotationId: "fakeAnnotationID\(bookmarkCounter)",
-                                 contentCFI: "",
-                                 href: href,
-                                 idref: nil,
-                                 chapter: chapter,
-                                 location: nil,
-                                 progressWithinChapter: progressWithinChapter,
-                                 progressWithinBook: NSNumber(value: progressWithinBook),
-                                 creationTime: Date(),
-                                 device:device)
-    }
+  private func newBookmark(href: String,
+                           chapter: String,
+                           progressWithinChapter: Float,
+                           progressWithinBook: Float,
+                           device: String? = nil) -> NYPLReadiumBookmark? {
+    // Annotation id needs to be unique
+    // contentCFI should be empty string for R2 bookmark
+    bookmarkCounter += 1
+    return NYPLReadiumBookmark(annotationId: "fakeAnnotationID\(bookmarkCounter)",
+                               contentCFI: "",
+                               href: href,
+                               idref: nil,
+                               chapter: chapter,
+                               location: nil,
+                               progressWithinChapter: progressWithinChapter,
+                               progressWithinBook: NSNumber(value: progressWithinBook),
+                               creationTime: Date(),
+                               device:device)
+  }
     
   private func newBookmarkR2Location(href: String,
                                      chapter: String,


### PR DESCRIPTION
**What's this do?**
Dependency inject NYPLAnnotations
Implement mocked NYPLAnnotations for unit testing
Update existing tests and add new test cases

**Why are we doing this? (w/ JIRA link if applicable)**
[iOS-148](https://jira.nypl.org/browse/IOS-148)

**How should this be tested? / Do these changes have associated tests?**
N/A

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 
