### PR TITLE
Fix readme and copyright notices on all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ cd Simplified-iOS
 
 Unless the DRM dependencies change (which is very seldom) you shouldn't need to run the `bootstrap-drm.sh` script more than once.
 
-Other dependencies are managed via Carthage and a few git submodules. To rebuild them you can use the following idempotent script:
+First party dependencies are managed via Swift Package Manager. Most of these dependencies are managed via local Swift packages, given by the git submodules checkouts. They are built automatically when you build the `Simplified` Xcode project targets.
+
+Other 3rd party dependencies are managed via Carthage. To rebuild them you can use the following idempotent script:
 ```bash
 cd Simplified-iOS #repo root
 ./scripts/build-dependencies.sh

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -3725,7 +3725,7 @@
 				CLASSPREFIX = NYPL;
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 1310;
-				ORGANIZATIONNAME = "NYPL Labs";
+				ORGANIZATIONNAME = NYPL;
 				TargetAttributes = {
 					2D2B47711D08F807007F7764 = {
 						CreatedOnToolsVersion = 7.3.1;

--- a/Simplified.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplified.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/NYPL-Simplified/iOS-Utilities",
         "state": {
           "branch": "main",
-          "revision": "ae41a6a2468b49c44320be310053b249ddc6993b",
+          "revision": "dda470221a5e6eca49e1acef8bd2c08bebbeebe1",
           "version": null
         }
       },

--- a/Simplified/Accounts/AgeCheck/NYPLAgeCheckViewController.swift
+++ b/Simplified/Accounts/AgeCheck/NYPLAgeCheckViewController.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ernest Fan on 2021-02-22.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import UIKit

--- a/Simplified/Accounts/Library/NYPLLibrariesListVC.swift
+++ b/Simplified/Accounts/Library/NYPLLibrariesListVC.swift
@@ -2,7 +2,7 @@
 //  NYPLLibrariesListVC.swift
 //
 //  Created by Greg O'Neill on 11/10/2016.
-//  Copyright © 2016 NYPL Labs. All rights reserved.
+//  Copyright © 2016 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Accounts/Library/NYPLLibraryAccountURLsProvider.swift
+++ b/Simplified/Accounts/Library/NYPLLibraryAccountURLsProvider.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Ettore Pasquini on 9/30/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Accounts/User/NYPLCredentials.swift
+++ b/Simplified/Accounts/User/NYPLCredentials.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Jacek Szyja on 22/05/2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AppInfrastructure/NSNotification+NYPL.swift
+++ b/Simplified/AppInfrastructure/NSNotification+NYPL.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 9/14/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Ettore Pasquini on 9/17/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AppInfrastructure/NYPLAppDelegate+SE.swift
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate+SE.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 9/17/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AppInfrastructure/NYPLConfiguration+Color.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+Color.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ernest Fan on 2021-09-16.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+OE.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Ettore Pasquini on 9/9/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AppInfrastructure/NYPLConfiguration+SE.swift
+++ b/Simplified/AppInfrastructure/NYPLConfiguration+SE.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 9/9/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AppInfrastructure/NYPLLibraryNavigationController.h
+++ b/Simplified/AppInfrastructure/NYPLLibraryNavigationController.h
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 9/18/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/Simplified/AppInfrastructure/NYPLLibraryNavigationController.m
+++ b/Simplified/AppInfrastructure/NYPLLibraryNavigationController.m
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 9/18/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 #import "SimplyE-Swift.h"

--- a/Simplified/AppInfrastructure/NYPLRootTabBarController+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLRootTabBarController+OE.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 9/10/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AppInfrastructure/NYPLRootTabBarController+SE.swift
+++ b/Simplified/AppInfrastructure/NYPLRootTabBarController+SE.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 9/14/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Audiobooks/AudioBookVendors+Extensions.swift
+++ b/Simplified/Audiobooks/AudioBookVendors+Extensions.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Vladimir Fedorov on 03.09.2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 #if FEATURE_AUDIOBOOKS

--- a/Simplified/Audiobooks/AudioBookVendorsHelper.swift
+++ b/Simplified/Audiobooks/AudioBookVendorsHelper.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Vladimir Fedorov on 10.09.2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 #if FEATURE_AUDIOBOOKS

--- a/Simplified/Audiobooks/DPLA/DPLAAudiobooks.swift
+++ b/Simplified/Audiobooks/DPLA/DPLAAudiobooks.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Vladimir Fedorov on 01.09.2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 #if FEATURE_AUDIOBOOKS

--- a/Simplified/Audiobooks/DPLA/JWKResponse.swift
+++ b/Simplified/Audiobooks/DPLA/JWKResponse.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Vladimir Fedorov on 31.08.2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 #if FEATURE_AUDIOBOOKS

--- a/Simplified/Audiobooks/LCP/LCPAudiobooks.swift
+++ b/Simplified/Audiobooks/LCP/LCPAudiobooks.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Vladimir Fedorov on 16.11.2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 #if LCP && FEATURE_AUDIOBOOKS

--- a/Simplified/Audiobooks/NYPLReturnPromptHelper.swift
+++ b/Simplified/Audiobooks/NYPLReturnPromptHelper.swift
@@ -1,6 +1,6 @@
 //
 //  SimplyE
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 @objcMembers final class NYPLReturnPromptHelper: NSObject {

--- a/Simplified/AxisService/Download/NYPLAxisBookDownloadMediator.swift
+++ b/Simplified/AxisService/Download/NYPLAxisBookDownloadMediator.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-06-23.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AxisService/Download/NYPLAxisContentDownloader.swift
+++ b/Simplified/AxisService/Download/NYPLAxisContentDownloader.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Raman Singh on 2021-04-22.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AxisService/Download/NYPLAxisDRMAuthorizer.swift
+++ b/Simplified/AxisService/Download/NYPLAxisDRMAuthorizer.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Raman Singh on 2021-04-13.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AxisService/Download/NYPLAxisNetworkExecutor.swift
+++ b/Simplified/AxisService/Download/NYPLAxisNetworkExecutor.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-06-23.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AxisService/NYPLAxisServiceAdapter.swift
+++ b/Simplified/AxisService/NYPLAxisServiceAdapter.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-06-23.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AxisService/Read/NYPLAxisBookContentDecryptionAdapter.swift
+++ b/Simplified/AxisService/Read/NYPLAxisBookContentDecryptionAdapter.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-06-23.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AxisService/Read/NYPLAxisBookReadingAdapter.swift
+++ b/Simplified/AxisService/Read/NYPLAxisBookReadingAdapter.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-06-23.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AxisService/Read/NYPLAxisDecompressionAdapter.swift
+++ b/Simplified/AxisService/Read/NYPLAxisDecompressionAdapter.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-06-23.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AxisService/Read/NYPLFullAxisNowResourceAdapter.swift
+++ b/Simplified/AxisService/Read/NYPLFullAxisNowResourceAdapter.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-06-23.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AxisService/Utilities/NYPLAxisErrorLogsAdapter.swift
+++ b/Simplified/AxisService/Utilities/NYPLAxisErrorLogsAdapter.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-06-23.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AxisService/Utilities/NYPLAxisXMLCreator.swift
+++ b/Simplified/AxisService/Utilities/NYPLAxisXMLCreator.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-06-23.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/AxisService/Utilities/NYPLAxisXMLRepresentation.swift
+++ b/Simplified/AxisService/Utilities/NYPLAxisXMLRepresentation.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Raman Singh on 2021-04-06.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Book/Models/NYPLBookContentTypeConverter.swift
+++ b/Simplified/Book/Models/NYPLBookContentTypeConverter.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 8/17/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Book/UI/NYPLBookButtonsState.h
+++ b/Simplified/Book/UI/NYPLBookButtonsState.h
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 3/18/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 @import Foundation;

--- a/Simplified/Book/UI/NYPLBookButtonsState.m
+++ b/Simplified/Book/UI/NYPLBookButtonsState.m
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 3/18/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 #import "NYPLBookButtonsState.h"

--- a/Simplified/Book/UI/NYPLBookButtonsView.m
+++ b/Simplified/Book/UI/NYPLBookButtonsView.m
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ben Anderman on 8/27/15.
-//  Copyright (c) 2015 NYPL Labs. All rights reserved.
+//  Copyright (c) 2015 NYPL. All rights reserved.
 //
 
 @import PureLayout;

--- a/Simplified/Book/UI/NYPLBookCellDelegate+Audiobooks.h
+++ b/Simplified/Book/UI/NYPLBookCellDelegate+Audiobooks.h
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/19/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 #if FEATURE_AUDIOBOOKS

--- a/Simplified/Book/UI/NYPLBookCellDelegate+Audiobooks.m
+++ b/Simplified/Book/UI/NYPLBookCellDelegate+Audiobooks.m
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/19/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 #if FEATURE_AUDIOBOOKS

--- a/Simplified/Book/UI/NYPLBookDetailView+Accessibility.swift
+++ b/Simplified/Book/UI/NYPLBookDetailView+Accessibility.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ernest Fan on 2021-07-21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import UIKit

--- a/Simplified/Book/UI/NYPLProblemReportViewController.h
+++ b/Simplified/Book/UI/NYPLProblemReportViewController.h
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Sam Tarakajian on 10/29/15.
-//  Copyright © 2015 NYPL Labs. All rights reserved.
+//  Copyright © 2015 NYPL. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/Simplified/Book/UI/NYPLProblemReportViewController.m
+++ b/Simplified/Book/UI/NYPLProblemReportViewController.m
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Sam Tarakajian on 10/29/15.
-//  Copyright © 2015 NYPL Labs. All rights reserved.
+//  Copyright © 2015 NYPL. All rights reserved.
 //
 
 @import MessageUI;

--- a/Simplified/Catalog/NYPLCatalogs+OE.swift
+++ b/Simplified/Catalog/NYPLCatalogs+OE.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Ettore Pasquini on 9/14/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Catalog/NYPLCatalogs+SE.swift
+++ b/Simplified/Catalog/NYPLCatalogs+SE.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 9/14/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/ErrorHandling/NSError+NYPLAdditions.swift
+++ b/Simplified/ErrorHandling/NSError+NYPLAdditions.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 5/22/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/ErrorHandling/NYPLPresentationUtils.swift
+++ b/Simplified/ErrorHandling/NYPLPresentationUtils.swift
@@ -2,7 +2,7 @@
 //  NYPLPresentationUtils.swift
 //  SimplyE / Open eBooks
 //
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 class NYPLPresentationUtils: NSObject {

--- a/Simplified/ErrorHandling/NYPLUserFriendlyError.swift
+++ b/Simplified/ErrorHandling/NYPLUserFriendlyError.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 7/15/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Keychain/NYPLKeychainStoredVariable.swift
+++ b/Simplified/Keychain/NYPLKeychainStoredVariable.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Jacek Szyja on 22/05/2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Logging/NYPLBook+Logging.swift
+++ b/Simplified/Logging/NYPLBook+Logging.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Ettore Pasquini on 7/9/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Logging/NYPLErrorLogger.swift
+++ b/Simplified/Logging/NYPLErrorLogger.swift
@@ -1,6 +1,6 @@
 //
 //  SimplyE
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import CFNetwork

--- a/Simplified/Logging/URLRequest+Logging.swift
+++ b/Simplified/Logging/URLRequest+Logging.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Ettore Pasquini on 4/8/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Migrations/OEMigrations.swift
+++ b/Simplified/Migrations/OEMigrations.swift
@@ -2,7 +2,7 @@
 //  OEMigrations.swift
 //  Simplified
 //
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Migrations/SEMigrations.swift
+++ b/Simplified/Migrations/SEMigrations.swift
@@ -2,7 +2,7 @@
 //  SEMigrations.swift
 //  Simplified
 //
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/MyBooks/NYPLBook+DistributorChecks.swift
+++ b/Simplified/MyBooks/NYPLBook+DistributorChecks.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/6/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/MyBooks/NYPLMyBooksNotifier.swift
+++ b/Simplified/MyBooks/NYPLMyBooksNotifier.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/13/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import UIKit

--- a/Simplified/Network/NYPLCaching.swift
+++ b/Simplified/Network/NYPLCaching.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Ettore Pasquini on 3/19/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Network/NYPLNetworkExecutor.swift
+++ b/Simplified/Network/NYPLNetworkExecutor.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Ettore Pasquini on 3/19/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Ettore Pasquini on 3/22/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Network/NYPLRequestExecuting.swift
+++ b/Simplified/Network/NYPLRequestExecuting.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 3/24/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/OPDS2/OPDS2AuthenticationDocument.swift
+++ b/Simplified/OPDS2/OPDS2AuthenticationDocument.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Benjamin Anderman on 5/10/19.
-//  Copyright © 2019 NYPL Labs. All rights reserved.
+//  Copyright © 2019 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/OPDS2/OPDS2CatalogsFeed.swift
+++ b/Simplified/OPDS2/OPDS2CatalogsFeed.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Benjamin Anderman on 5/10/19.
-//  Copyright © 2019 NYPL Labs. All rights reserved.
+//  Copyright © 2019 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/OPDS2/OPDS2Link.swift
+++ b/Simplified/OPDS2/OPDS2Link.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Benjamin Anderman on 5/10/19.
-//  Copyright © 2019 NYPL Labs. All rights reserved.
+//  Copyright © 2019 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/OPDS2/OPDS2Publication.swift
+++ b/Simplified/OPDS2/OPDS2Publication.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Benjamin Anderman on 5/10/19.
-//  Copyright © 2019 NYPL Labs. All rights reserved.
+//  Copyright © 2019 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/Bookmarks/NYPLBookLocation+Locator.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLBookLocation+Locator.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ernest Fan on 2020-11-09.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/Bookmarks/NYPLBookmarkFactory.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLBookmarkFactory.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 3/22/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/Bookmarks/NYPLBookmarkR2Location.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLBookmarkR2Location.swift
@@ -2,7 +2,7 @@
 //  NYPLBookmarkR2Location.swift
 //
 //  Created by Ettore Pasquini on 4/23/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/Bookmarks/NYPLBookmarkSpec.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLBookmarkSpec.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 3/24/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 /// A type representing the [format](https://git.io/JYEkT) of bookmark data

--- a/Simplified/Reader2/Bookmarks/NYPLReadiumBookmark+Compare.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLReadiumBookmark+Compare.swift
@@ -2,7 +2,7 @@
 //  NYPLReadiumBookmark+R2.swift
 //
 //  Created by Ettore Pasquini on 4/23/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionPoster.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionPoster.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 3/9/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionSynchronizer.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionSynchronizer.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 3/9/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/BusinessLogic/NYPLR1R2UserSettings.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLR1R2UserSettings.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Ettore Pasquini on 3/27/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 5/1/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/BusinessLogic/NYPLReaderSettings+Conversions.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLReaderSettings+Conversions.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 7/14/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/BusinessLogic/NYPLReaderTOCBusinessLogic.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLReaderTOCBusinessLogic.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 4/23/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/Internal/Publication+NYPLAdditions.swift
+++ b/Simplified/Reader2/Internal/Publication+NYPLAdditions.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 6/11/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/ReaderPresentation/NYPLRootTabBarController+R2.swift
+++ b/Simplified/Reader2/ReaderPresentation/NYPLRootTabBarController+R2.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Ettore Pasquini on 3/4/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContainer.h
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContainer.h
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Vladimir Fedorov on 13.05.2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 #ifndef AdobeDRMContainer_h

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContainer.mm
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContainer.mm
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Vladimir Fedorov on 13.05.2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 #ifdef FEATURE_DRM_CONNECTOR

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Vladimir Fedorov on 20.01.2021.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 #if FEATURE_DRM_CONNECTOR

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMFetcher.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMFetcher.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Vladimir Fedorov on 10.02.2021.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 #if FEATURE_DRM_CONNECTOR

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMLibraryService.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMLibraryService.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Vladimir Fedorov on 13.05.2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/NYPLAdobeContentProtectionService.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/NYPLAdobeContentProtectionService.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 5/11/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 #if FEATURE_DRM_CONNECTOR

--- a/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisContentDecryptor.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisContentDecryptor.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-05-18.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisContentProtection.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisContentProtection.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-05-18.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisDecompressor.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisDecompressor.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-05-18.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisLibraryService.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisLibraryService.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Raman Singh on 2021-05-18.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisProtectedAssetHandler.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisProtectedAssetHandler.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-05-18.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLFullAxisNowResource.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLFullAxisNowResource.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Raman Singh on 2021-05-18.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/ReaderStackConfiguration/LCP/LCPPassphraseAuthenticationService.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/LCP/LCPPassphraseAuthenticationService.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ernest Fan on 2021-02-08.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 #if LCP

--- a/Simplified/Reader2/ReaderStackConfiguration/LCP/NYPLLCPClientFacade.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/LCP/NYPLLCPClientFacade.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 4/27/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 #if LCP

--- a/Simplified/Reader2/UI/NYPLReaderPositionsVC.swift
+++ b/Simplified/Reader2/UI/NYPLReaderPositionsVC.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 4/23/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import UIKit

--- a/Simplified/Reader2/UI/NYPLReaderSettingsView.swift
+++ b/Simplified/Reader2/UI/NYPLReaderSettingsView.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ernest Fan on 2021-09-01.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Reader2/UI/NYPLReaderTOCCell.swift
+++ b/Simplified/Reader2/UI/NYPLReaderTOCCell.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 4/23/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import UIKit

--- a/Simplified/Reader2/UI/NYPLUserSettingsVC.swift
+++ b/Simplified/Reader2/UI/NYPLUserSettingsVC.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Ettore Pasquini on 3/26/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import UIKit

--- a/Simplified/Settings/NYPLSettings+OE.swift
+++ b/Simplified/Settings/NYPLSettings+OE.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Kyle Sakai.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 extension NYPLSettings: NYPLUniversalLinksSettings {

--- a/Simplified/Settings/NYPLSettings+SE.swift
+++ b/Simplified/Settings/NYPLSettings+SE.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 9/17/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 extension NYPLSettings: NYPLUniversalLinksSettings {

--- a/Simplified/Settings/NYPLSettingsPrimaryTableItem.swift
+++ b/Simplified/Settings/NYPLSettingsPrimaryTableItem.swift
@@ -3,7 +3,7 @@
 //  SimplyE / Open eBooks
 //
 //  Created by Kyle Sakai.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 class NYPLSettingsPrimaryTableItem {

--- a/Simplified/Settings/NYPLSettingsPrimaryTableViewController.swift
+++ b/Simplified/Settings/NYPLSettingsPrimaryTableViewController.swift
@@ -3,7 +3,7 @@
 //  SimplyE / Open eBooks
 //
 //  Created by Kyle Sakai.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 class NYPLSettingsPrimaryTableViewController : UITableViewController {

--- a/Simplified/Settings/NYPLSettingsSplitViewController+OE.swift
+++ b/Simplified/Settings/NYPLSettingsSplitViewController+OE.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Kyle Sakai.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Settings/NYPLSettingsSplitViewController.swift
+++ b/Simplified/Settings/NYPLSettingsSplitViewController.swift
@@ -3,7 +3,7 @@
 //  SimplyE / Open eBooks
 //
 //  Created by Kyle Sakai.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 /// Currently used only by Open eBooks, but extendable for use in SimplyE.

--- a/Simplified/Settings/SettingsCells/NYPLLibraryDescriptionCell.swift
+++ b/Simplified/Settings/SettingsCells/NYPLLibraryDescriptionCell.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Jacek Szyja on 29/06/2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import UIKit

--- a/Simplified/Settings/SettingsCells/NYPLLoginCellTypes.swift
+++ b/Simplified/Settings/SettingsCells/NYPLLoginCellTypes.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Jacek Szyja on 23/06/2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Settings/SettingsCells/NYPLSamlIDPCell.swift
+++ b/Simplified/Settings/SettingsCells/NYPLSamlIDPCell.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Jacek Szyja on 29/06/2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import UIKit

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController+OESelectAuth.swift
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController+OESelectAuth.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/8/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/SignInLogic/NYPLBasicAuth.swift
+++ b/Simplified/SignInLogic/NYPLBasicAuth.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Jacek Szyja on 02/07/2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/SignInLogic/NYPLCookiesWebViewController.swift
+++ b/Simplified/SignInLogic/NYPLCookiesWebViewController.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Jacek Szyja on 17/06/2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import UIKit

--- a/Simplified/SignInLogic/NYPLReauthenticator.swift
+++ b/Simplified/SignInLogic/NYPLReauthenticator.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 11/18/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/SignInLogic/NYPLSAMLHelper.h
+++ b/Simplified/SignInLogic/NYPLSAMLHelper.h
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/21/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Simplified/SignInLogic/NYPLSAMLHelper.m
+++ b/Simplified/SignInLogic/NYPLSAMLHelper.m
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/21/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 #import "SimplyE-Swift.h"

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+Adept.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+Adept.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Raman Singh on 2021-04-14.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+Axis.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+Axis.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Raman Singh on 2021-04-14.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 11/4/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+CardCreation.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+CardCreation.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 11/2/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+DRM.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+DRM.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/28/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+OAuth.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+OAuth.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/9/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+OE.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+OE.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Ettore Pasquini on 10/28/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+SignOut.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+SignOut.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 11/3/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+UI.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+UI.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/26/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import UIKit

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 5/5/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 @objc enum NYPLAuthRequestType: Int {

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogicUIDelegate.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogicUIDelegate.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/13/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/SignInLogic/NYPLUserAccountFrontEndValidation.swift
+++ b/Simplified/SignInLogic/NYPLUserAccountFrontEndValidation.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Jacek Szyja on 26/05/2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import UIKit

--- a/Simplified/SignInLogic/URLResponse+NYPLAuthentication.swift
+++ b/Simplified/SignInLogic/URLResponse+NYPLAuthentication.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 11/18/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Utilities/Concurrency/NYPLBackgroundExecutor.swift
+++ b/Simplified/Utilities/Concurrency/NYPLBackgroundExecutor.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Ettore Pasquini on 2/6/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import UIKit

--- a/Simplified/Utilities/Concurrency/NYPLMainThreadChecker.swift
+++ b/Simplified/Utilities/Concurrency/NYPLMainThreadChecker.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Ettore Pasquini on 2/7/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Utilities/Date-Time/Date+NYPLAdditions.swift
+++ b/Simplified/Utilities/Date-Time/Date+NYPLAdditions.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Ettore Pasquini on 3/25/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Utilities/Float+NYPLAdditions.swift
+++ b/Simplified/Utilities/Float+NYPLAdditions.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 6/17/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Utilities/Networking/NSURL+NYPLURLAdditions.h
+++ b/Simplified/Utilities/Networking/NSURL+NYPLURLAdditions.h
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Sam Tarakajian on 9/24/15.
-//  Copyright © 2015 NYPL Labs. All rights reserved.
+//  Copyright © 2015 NYPL. All rights reserved.
 //
 
 @interface NSURL (NYPLURLAdditions)

--- a/Simplified/Utilities/Networking/NSURL+NYPLURLAdditions.m
+++ b/Simplified/Utilities/Networking/NSURL+NYPLURLAdditions.m
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Sam Tarakajian on 9/24/15.
-//  Copyright © 2015 NYPL Labs. All rights reserved.
+//  Copyright © 2015 NYPL. All rights reserved.
 //
 
 #import "NSURL+NYPLURLAdditions.h"

--- a/Simplified/Utilities/Networking/NSURLRequest+NYPLURLRequestAdditions.h
+++ b/Simplified/Utilities/Networking/NSURLRequest+NYPLURLRequestAdditions.h
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Sam Tarakajian on 10/30/15.
-//  Copyright © 2015 NYPL Labs. All rights reserved.
+//  Copyright © 2015 NYPL. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Simplified/Utilities/Networking/NSURLRequest+NYPLURLRequestAdditions.m
+++ b/Simplified/Utilities/Networking/NSURLRequest+NYPLURLRequestAdditions.m
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Sam Tarakajian on 10/30/15.
-//  Copyright © 2015 NYPL Labs. All rights reserved.
+//  Copyright © 2015 NYPL. All rights reserved.
 //
 
 #import "NSURLRequest+NYPLURLRequestAdditions.h"

--- a/Simplified/Utilities/Networking/URLResponse+NYPL.swift
+++ b/Simplified/Utilities/Networking/URLResponse+NYPL.swift
@@ -3,7 +3,7 @@
 //  SimplyE
 //
 //  Created by Ettore Pasquini on 7/9/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Utilities/Strings/NSString+JSONParse.swift
+++ b/Simplified/Utilities/Strings/NSString+JSONParse.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Jacek Szyja on 10/07/2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/Simplified/Utilities/UI/UIButton+NYPLAppearanceAdditions.h
+++ b/Simplified/Utilities/UI/UIButton+NYPLAppearanceAdditions.h
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Sam Tarakajian on 10/7/15.
-//  Copyright © 2015 NYPL Labs. All rights reserved.
+//  Copyright © 2015 NYPL. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/Simplified/Utilities/UI/UIButton+NYPLAppearanceAdditions.m
+++ b/Simplified/Utilities/UI/UIButton+NYPLAppearanceAdditions.m
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Sam Tarakajian on 10/7/15.
-//  Copyright © 2015 NYPL Labs. All rights reserved.
+//  Copyright © 2015 NYPL. All rights reserved.
 //
 
 #import "UIButton+NYPLAppearanceAdditions.h"

--- a/Simplified/Utilities/UI/UILabel+NYPLAppearanceAdditions.h
+++ b/Simplified/Utilities/UI/UILabel+NYPLAppearanceAdditions.h
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Sam Tarakajian on 10/7/15.
-//  Copyright © 2015 NYPL Labs. All rights reserved.
+//  Copyright © 2015 NYPL. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/Simplified/Utilities/UI/UILabel+NYPLAppearanceAdditions.m
+++ b/Simplified/Utilities/UI/UILabel+NYPLAppearanceAdditions.m
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Sam Tarakajian on 10/7/15.
-//  Copyright © 2015 NYPL Labs. All rights reserved.
+//  Copyright © 2015 NYPL. All rights reserved.
 //
 
 #import "UILabel+NYPLAppearanceAdditions.h"

--- a/Simplified/Views/NYPLRoundedButton.swift
+++ b/Simplified/Views/NYPLRoundedButton.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ernest Fan on 2021-03-31.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import UIKit

--- a/Simplified/WelcomeScreen/OETutorialChoiceViewController.swift
+++ b/Simplified/WelcomeScreen/OETutorialChoiceViewController.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Kyle Sakai.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 class OETutorialChoiceViewController : UIViewController {

--- a/Simplified/WelcomeScreen/OETutorialViewController.swift
+++ b/Simplified/WelcomeScreen/OETutorialViewController.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Kyle Sakai.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 class OETutorialViewController : UIPageViewController, UIPageViewControllerDataSource {

--- a/Simplified/WelcomeScreen/OETutorialWelcomeViewController.swift
+++ b/Simplified/WelcomeScreen/OETutorialWelcomeViewController.swift
@@ -3,7 +3,7 @@
 //  Open eBooks
 //
 //  Created by Kyle Sakai.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 class OETutorialWelcomeViewController : UIViewController {

--- a/SimplifiedTests/Bookmarks/NYPLAnnotationResponseTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLAnnotationResponseTests.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 4/14/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/Bookmarks/NYPLBookmarkDeserializationTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLBookmarkDeserializationTests.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 3/31/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/Bookmarks/NYPLBookmarkSerializationTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLBookmarkSerializationTests.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 4/9/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/Bookmarks/NYPLBookmarkSpecTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLBookmarkSpecTests.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 3/22/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/Bookmarks/NYPLR1BookmarkDeserializationTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLR1BookmarkDeserializationTests.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 4/7/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/Date+NYPLAdditionsTests.swift
+++ b/SimplifiedTests/Date+NYPLAdditionsTests.swift
@@ -3,7 +3,7 @@
 //  SimplyETests
 //
 //  Created by Ettore Pasquini on 3/25/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/Mocks/NYPLAgeCheckChoiceStorageMock.swift
+++ b/SimplifiedTests/Mocks/NYPLAgeCheckChoiceStorageMock.swift
@@ -3,7 +3,7 @@
 //  SimplyETests
 //
 //  Created by Ernest Fan on 2021-03-11.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
+++ b/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
@@ -3,7 +3,7 @@
 //  SimplyETests
 //
 //  Created by Ernest Fan on 2021-12-07.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/SimplifiedTests/Mocks/NYPLBookRegistryMock.swift
+++ b/SimplifiedTests/Mocks/NYPLBookRegistryMock.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/14/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/SimplifiedTests/Mocks/NYPLCurrentLibraryAccountProviderMock.swift
+++ b/SimplifiedTests/Mocks/NYPLCurrentLibraryAccountProviderMock.swift
@@ -3,7 +3,7 @@
 //  SimplyETests
 //
 //  Created by Ernest Fan on 2021-03-11.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/SimplifiedTests/Mocks/NYPLDRMAuthorizingMock.swift
+++ b/SimplifiedTests/Mocks/NYPLDRMAuthorizingMock.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/14/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/SimplifiedTests/Mocks/NYPLLibraryAccountsProviderMock.swift
+++ b/SimplifiedTests/Mocks/NYPLLibraryAccountsProviderMock.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/14/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/SimplifiedTests/Mocks/NYPLMyBooksDownloadsCenterMock.swift
+++ b/SimplifiedTests/Mocks/NYPLMyBooksDownloadsCenterMock.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 11/3/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/SimplifiedTests/Mocks/NYPLNetworkExecutorMock.swift
+++ b/SimplifiedTests/Mocks/NYPLNetworkExecutorMock.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 2/3/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/SimplifiedTests/Mocks/NYPLSignInOutBusinessLogicUIDelegateMock.swift
+++ b/SimplifiedTests/Mocks/NYPLSignInOutBusinessLogicUIDelegateMock.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 2/3/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/SimplifiedTests/Mocks/NYPLURLSettingsProviderMock.swift
+++ b/SimplifiedTests/Mocks/NYPLURLSettingsProviderMock.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/14/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/SimplifiedTests/Mocks/NYPLUserAccountMock.swift
+++ b/SimplifiedTests/Mocks/NYPLUserAccountMock.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/14/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/SimplifiedTests/Mocks/NYPLUserAccountProviderMock.swift
+++ b/SimplifiedTests/Mocks/NYPLUserAccountProviderMock.swift
@@ -3,7 +3,7 @@
 //  SimplyETests
 //
 //  Created by Ernest Fan on 2021-03-11.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/SimplifiedTests/NYPLAgeCheckTests.swift
+++ b/SimplifiedTests/NYPLAgeCheckTests.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ernest Fan on 2021-03-09.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/NYPLAxisTests/NYPLAxisXMLTests/NYPLAxisXMLTests.swift
+++ b/SimplifiedTests/NYPLAxisTests/NYPLAxisXMLTests/NYPLAxisXMLTests.swift
@@ -3,7 +3,7 @@
 //  OpenEbooksTests
 //
 //  Created by Raman Singh on 2021-05-18.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/NYPLBookCreationTests.swift
+++ b/SimplifiedTests/NYPLBookCreationTests.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/27/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/NYPLBookCreationTestsObjc.m
+++ b/SimplifiedTests/NYPLBookCreationTestsObjc.m
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/28/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 @import XCTest;

--- a/SimplifiedTests/NYPLCachingTests.swift
+++ b/SimplifiedTests/NYPLCachingTests.swift
@@ -3,7 +3,7 @@
 //  SimplyETests
 //
 //  Created by Ettore Pasquini on 3/25/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/NYPLFake.swift
+++ b/SimplifiedTests/NYPLFake.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 10/27/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import Foundation

--- a/SimplifiedTests/NYPLJWKConversionTest.swift
+++ b/SimplifiedTests/NYPLJWKConversionTest.swift
@@ -3,7 +3,7 @@
 //  SimplyETests
 //
 //  Created by Vladimir Fedorov on 31.08.2020.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/NYPLOpenSearchDescriptionTests.swift
+++ b/SimplifiedTests/NYPLOpenSearchDescriptionTests.swift
@@ -3,7 +3,7 @@
 //  SimplyETests
 //
 //  Created by Ettore Pasquini on 2/20/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -3,7 +3,7 @@
 //  SimplyETests
 //
 //  Created by Ernest Fan on 2020-10-29.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/NYPLReaderSettingsTests.swift
+++ b/SimplifiedTests/NYPLReaderSettingsTests.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 7/14/21.
-//  Copyright © 2021 NYPL Labs. All rights reserved.
+//  Copyright © 2021 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/NYPLSignInBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLSignInBusinessLogicTests.swift
@@ -3,7 +3,7 @@
 //  SimplyETests
 //
 //  Created by Ettore Pasquini on 10/14/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/OPDS2CatalogsFeedTests.swift
+++ b/SimplifiedTests/OPDS2CatalogsFeedTests.swift
@@ -3,7 +3,7 @@
 //  SimplyETests
 //
 //  Created by Benjamin Anderman on 5/10/19.
-//  Copyright © 2019 NYPL Labs. All rights reserved.
+//  Copyright © 2019 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/String+NYPLAdditionsTests.swift
+++ b/SimplifiedTests/String+NYPLAdditionsTests.swift
@@ -3,7 +3,7 @@
 //  SimplyETests
 //
 //  Created by Ettore Pasquini on 4/8/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/UIColor+NYPLAdditionsTests.swift
+++ b/SimplifiedTests/UIColor+NYPLAdditionsTests.swift
@@ -3,7 +3,7 @@
 //  Simplified
 //
 //  Created by Ettore Pasquini on 9/28/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import XCTest

--- a/SimplifiedTests/URLRequest+NYPLTests.swift
+++ b/SimplifiedTests/URLRequest+NYPLTests.swift
@@ -3,7 +3,7 @@
 //  SimplyETests
 //
 //  Created by Ettore Pasquini on 6/10/20.
-//  Copyright © 2020 NYPL Labs. All rights reserved.
+//  Copyright © 2020 NYPL. All rights reserved.
 //
 
 import XCTest


### PR DESCRIPTION
**What's this do?**
updates the copyright notices at the top of every source file.

**Why are we doing this? (w/ JIRA link if applicable)**
following up on discussion on slack

**How should this be tested? / Do these changes have associated tests?**
as long as it builds... this has nothing to do with UI changes

**Dependencies for merging? Releasing to production?**
I'll need to update submodules refs after we merge
https://github.com/NYPL-Simplified/iOS-Utilities/pull/6
https://github.com/NYPL-Simplified/NYPLAudiobookToolkit/pull/159
https://github.com/NYPL-Simplified/CardCreator-iOS/pull/49
https://github.com/NYPL-Simplified/Axis-iOS/pull/11

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 