### PR TITLE
IOS-317 Add book info logging to diagnose crash

### DIFF
--- a/Simplified/Book/Models/NYPLBookRegistry.m
+++ b/Simplified/Book/Models/NYPLBookRegistry.m
@@ -757,11 +757,11 @@ genericBookmarks:(NSArray<NYPLBookLocation *> *)genericBookmarks
 {
   @synchronized(self) {
     [self.coverRegistry removePinnedThumbnailImageForBookIdentifier:identifier];
+
+    // somehow it is possible to get here with a nil book ID (see IOS-277) in
+    // which case the book has already been removed from the registry, but we
+    // still need to broadcast this removal event.
     if (identifier) {
-      // introduced for IOS-277. While it seems impossible for the app to
-      // create a book instance with a nil id or set the id to nil, somehow
-      // that is happening while returning the book. See other IOS-277 tags in
-      // the code base for more context.
       [self.identifiersToRecords removeObjectForKey:identifier];
     }
     [self broadcastChange];

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -655,21 +655,6 @@ didCompleteWithError:(NSError *)error
 #if defined(FEATURE_DRM_CONNECTOR)
   NSString *fulfillmentId = [[NYPLBookRegistry sharedRegistry] fulfillmentIdForIdentifier:identifier];
 
-  // -------- tmp code to diagnose IOS-277 --------
-  if (book.identifier == nil) {
-    [NYPLErrorLogger logErrorWithCode:NYPLErrorCodeAppLogicInconsistency
-                              summary:@"Attempting to returning book with nil id"
-                             metadata:@{
-                               @"book identifier var": identifier ?: @"N/A",
-                               @"book.revokeURL": book.revokeURL ?: @"N/A",
-                               @"book.title": book.title ?: @"N/A",
-                               @"book.distributor": book.distributor ?: @"N/A",
-                               @"book registry state": [NYPLBookStateHelper stringValueFromBookState:state] ?: @"N/A",
-                               @"book instance nil?": @(book == nil),
-                               @"fulfillmentId": fulfillmentId ?: @"N/A",
-                               @"needsAuth": @(NYPLUserAccount.sharedAccount.authDefinition.needsAuth),
-                             }];
-  }
   // ----------------------------------------------
 
   if (fulfillmentId && NYPLUserAccount.sharedAccount.authDefinition.needsAuth) {

--- a/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
@@ -558,7 +558,7 @@ protocol NYPLAnnotationSyncing: AnyObject {
 
     let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
       if let err = error as NSError? {
-        Log.error(#file, "Annotation POST error (nsCode: \(err.code) Description: \(err.localizedDescription))")
+        Log.error(#file, "Annotation POST for bookID \(bookID): Error (nsCode: \(err.code) Description: \(err.localizedDescription))")
         if NetworkQueue.StatusCodes.contains(err.code) && queueOffline {
           self.addToOfflineQueue(bookID, annotationsURL, parameters)
         }
@@ -579,7 +579,7 @@ protocol NYPLAnnotationSyncing: AnyObject {
         return
       }
 
-      Log.info(#file, "Annotation POST: Success 200.")
+      Log.info(#file, "Annotation POST for bookID \(bookID): Success 200.")
       let serverAnnotationID = annotationID(fromNetworkData: data)
       completionHandler(.success(serverAnnotationID))
     }

--- a/Simplified/Reader2/Bookmarks/NYPLBookmarkFactory.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLBookmarkFactory.swift
@@ -85,7 +85,7 @@ class NYPLBookmarkFactory {
       let motivation = annotation[NYPLBookmarkSpec.Motivation.key] as? String,
       let body = annotation[NYPLBookmarkSpec.Body.key] as? [String: Any]
     else {
-      Log.error(#file, "Error parsing required info (target, source, motivation, body) in annotation: \(annotation)")
+      Log.error(#file, "Error parsing required info (target, source, motivation, body) for bookID \(bookID) in annotation: \(annotation)")
       return nil
     }
 
@@ -99,12 +99,12 @@ class NYPLBookmarkFactory {
     }
 
     guard motivation.contains(annotationType.rawValue) else {
-      Log.error(#file, "Can't create bookmark, `\(motivation)` motivation does not match expected `\(annotationType.rawValue)` motivation.")
+      Log.error(#file, "Can't create bookmark for bookID \(bookID), `\(motivation)` motivation does not match expected `\(annotationType.rawValue)` motivation.")
       return nil
     }
 
     guard let device = body[NYPLBookmarkSpec.Body.Device.key] as? String else {
-      Log.error(#file, "Error reading `device` info from `body`:\(body)")
+      Log.error(#file, "Error reading `device` info for bookID \(bookID) from `body`:\(body)")
       return nil
     }
 
@@ -112,7 +112,7 @@ class NYPLBookmarkFactory {
       let selector = target[NYPLBookmarkSpec.Target.Selector.key] as? [String: Any],
       let selectorValueEscJSON = selector[NYPLBookmarkSpec.Target.Selector.Value.key] as? String
       else {
-        Log.error(#file, "Error reading required Selector Value from Target: \(target)")
+        Log.error(#file, "Error reading required Selector Value for bookID \(bookID) from Target: \(target)")
         return nil
     }
 
@@ -123,7 +123,7 @@ class NYPLBookmarkFactory {
 
     // if we can't derive the href, we cannot use this bookmark in R2
     guard href != nil else {
-      Log.error(#file, "Error reading chapter ID from server annotation. SelectorValue=\(selectorValueEscJSON)")
+      Log.error(#file, "Error reading chapter ID for bookID \(bookID) from server annotation. SelectorValue=\(selectorValueEscJSON)")
       return nil
     }
 

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -342,7 +342,8 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
 extension NYPLBaseReaderViewController: NavigatorDelegate {
 
   func navigator(_ navigator: Navigator, locationDidChange locator: Locator) {
-    Log.info(#function, "R2 locator changed to: \(locator)")
+    let bookInfo = bookmarksBusinessLogic.book.loggableShortString()
+    Log.info(#function, "R2 locator for \(bookInfo) changed to: \(locator)")
 
     lastReadPositionPoster.storeReadPosition(locator: locator)
 


### PR DESCRIPTION
**What's this do?**
Logs book information to log lines recorded before the crash described in IOS-316. Hopefully this can help us reproduce the crash by trying the same books where the crash happens.

I also added a commit to remove a log statement in relation to IOS-277, since we verified that things are good there. See IOS-277 for more details.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/IOS-317

**How should this be tested? / Do these changes have associated tests?**
no QA necessary beside the regression.

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no. These changes will be verified during regression.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ettore 