### PR TITLE
iOS-339 Fixes for hacks introduced by banned book feature

### DIFF
--- a/Simplified/AxisService/Read/NYPLAxisBookReadingAdapter.swift
+++ b/Simplified/AxisService/Read/NYPLAxisBookReadingAdapter.swift
@@ -52,6 +52,8 @@ struct NYPLAxisBookReadingAdapter {
     licenseService.extractAESKey { result in
       switch result {
       case .success(let key):
+        // If it succeeded and returned data is nil,
+        // the asset is not protected by AxisDRM.
         guard let keyData = key else {
           completion(.success(nil))
           return

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -1523,7 +1523,7 @@ didFinishDownload:(BOOL)didFinishDownload
   // See Container::Open(const string& path) in container.cpp.
   //
   if(![rightsData writeToFile:[[[self fileURLForBookIndentifier:book.identifier] path]
-                               stringByAppendingString:@"_rights.xml"]
+                               stringByAppendingString:RIGHTS_XML_SUFFIX]
                    atomically:YES]) {
     NYPLLOG(@"Failed to store rights data.");
   }

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -1523,7 +1523,7 @@ didFinishDownload:(BOOL)didFinishDownload
   // See Container::Open(const string& path) in container.cpp.
   //
   if(![rightsData writeToFile:[[[self fileURLForBookIndentifier:book.identifier] path]
-                               stringByAppendingString:RIGHTS_XML_SUFFIX]
+                               stringByAppendingString:ADOBE_RIGHTS_XML_SUFFIX]
                    atomically:YES]) {
     NYPLLOG(@"Failed to store rights data.");
   }

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContainer.h
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContainer.h
@@ -11,7 +11,7 @@
 
 #import <Foundation/Foundation.h>
 
-#define RIGHTS_XML_SUFFIX @"_rights.xml"
+#define ADOBE_RIGHTS_XML_SUFFIX @"_rights.xml"
 
 @interface AdobeDRMContainer : NSObject
 NS_ASSUME_NONNULL_BEGIN

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContainer.mm
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContainer.mm
@@ -42,7 +42,7 @@ static id acsdrm_lock = nil;
     }
 
     // *_rights.xml file contents
-    NSString *rightsPath = [NSString stringWithFormat:@"%@%@", path, RIGHTS_XML_SUFFIX];
+    NSString *rightsPath = [NSString stringWithFormat:@"%@%@", path, ADOBE_RIGHTS_XML_SUFFIX];
     NSData *rightsData = [NSData dataWithContentsOfFile:rightsPath];
     size_t rightsLen = rightsData.length;
     unsigned char *rightsContent = (unsigned char *)rightsData.bytes;

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
@@ -35,7 +35,7 @@ class AdobeDRMContentProtection: ContentProtection {
       return
     }
     
-    guard let encryptionData = fetcher.fetchAdobeEncryptionData() else {
+    guard let encryptionData = fetcher.fetchAdobeEncryptionData(from: fileAsset) else {
       // .success(nil) means it is not an asset protected with Adobe DRM
       // Streamer continues to iterate over available ContentProtections
       // Don't use .failure(...) in this case, it means .epub is protected with this type of Content Protection,
@@ -59,10 +59,19 @@ class AdobeDRMContentProtection: ContentProtection {
 }
 
 private extension Fetcher {
-  func fetchAdobeEncryptionData() -> Data? {
-    // Since publications protected by Axis DRM also contain the `META-INF` directory,
-    // we need to add another check to make sure this is not an AxisDRM protected file.
-    if let _ = try? get("/" + NYPLAxisKeysProvider().userKey).read().get() {
+  /// Fetch the encryption file data from the file asset.
+  ///
+  /// - Parameter asset: File asset containing the encryption file.
+  /// - Returns: Data of the encryption file if asset is protected by Adobe and file is found. Otherwise `nil`.
+  func fetchAdobeEncryptionData(from asset: FileAsset) -> Data? {
+    let lastComponent = asset.url.lastPathComponent as NSString
+    let rightsPath = asset.url.deletingLastPathComponent().absoluteString + lastComponent.deletingPathExtension
+    let rightsExtension = lastComponent.pathExtension + RIGHTS_XML_SUFFIX
+    
+    // If a '[file]_rights.xml' file exists, the asset is protected by AdobeDRM and we proceed forward.
+    // Otherwise, we return nil
+    guard let rightsURL = URL(string: rightsPath)?.appendingPathExtension(rightsExtension),
+          FileManager.default.fileExists(atPath: rightsURL.path) else {
       return nil
     }
     

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMContentProtection.swift
@@ -66,7 +66,7 @@ private extension Fetcher {
   func fetchAdobeEncryptionData(from asset: FileAsset) -> Data? {
     let lastComponent = asset.url.lastPathComponent as NSString
     let rightsPath = asset.url.deletingLastPathComponent().absoluteString + lastComponent.deletingPathExtension
-    let rightsExtension = lastComponent.pathExtension + RIGHTS_XML_SUFFIX
+    let rightsExtension = lastComponent.pathExtension + ADOBE_RIGHTS_XML_SUFFIX
     
     // If a '[file]_rights.xml' file exists, the asset is protected by AdobeDRM and we proceed forward.
     // Otherwise, we return nil

--- a/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMLibraryService.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/AdobeDRM/AdobeDRMLibraryService.swift
@@ -21,7 +21,7 @@ class AdobeDRMLibraryService: DRMLibraryService {
   /// - Parameter file: file URL
   /// - Returns: `true` if file contains Adobe DRM license information.
   func canFulfill(_ file: URL) -> Bool {
-    return file.path.hasSuffix(RIGHTS_XML_SUFFIX)
+    return file.path.hasSuffix(ADOBE_RIGHTS_XML_SUFFIX)
   }
   
   /// Fulfills the given file to the fully protected publication.

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+Axis.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+Axis.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import NYPLCardCreator
 
 #if AXIS
 
@@ -20,7 +21,7 @@ extension NYPLSignInBusinessLogic {
   ///   - loggingContext: Information to report when logging errors.
   func drmAuthorizeAxis(username: String,
                         password: String?,
-                        loggingContext: [String: Any]) {
+                        completion: @escaping ((Bool, Error?, String?, String?) -> Void)) {
     
     let vendor = userAccount.licensor?["vendor"] as? String
     
@@ -31,61 +32,10 @@ extension NYPLSignInBusinessLogic {
       VendorID: \(vendor ?? "N/A")
       """)
     
-    drmAuthorizerAxis?
-      .authorize(
-        withVendorID: vendor,
-        username: username,
-        password: password
-      ) { [weak self] success, error, deviceID, userID in
-        
-        guard let self = self else {
-          
-          let error = NSError(
-            domain: "NYPLSignInBusinessLogic deallocated prematurely",
-            code: 418, userInfo: nil)
-          
-          NYPLErrorLogger.logLocalAuthFailed(error: error,
-                                             library: nil,
-                                             metadata: loggingContext)
-        
-          return
-        }
-        
-        Log.info(#file, """
-          Activation success: \(success)
-          Error: \(error?.localizedDescription ?? "N/A")
-          DeviceID: \(deviceID ?? "N/A")
-          UserID: \(userID ?? "N/A")
-          ***DRM Auth/Activation completion***
-          """)
-        
-        var success = success
-        
-        if success, userID != nil, deviceID != nil {
-          Log.info(#function, "Axis authorized successfully")
-//          NYPLMainThreadRun.asyncIfNeeded {
-//            //TODO: IOS-336
-//            self.userAccount.setUserID(userID)
-//            self.userAccount.setDeviceID(deviceID)
-//          }
-        } else {
-          success = false
-          NYPLErrorLogger.logLocalAuthFailed(error: error as NSError?,
-                                             library: self.libraryAccount,
-                                             metadata: loggingContext)
-        }
-
-        // when we are building with Axis AND Adobe DRM, the
-        // `drmAuthorizeAxis(username:password:loggingContext:)` implementation
-        // always end up reaching this point (unless `self` went away, in which
-        // case everything is moot). Therefore, since we will need to call
-        // `finalizeSignIn(forDRMAuthorization:error:)` for the Adobe case,
-        // we can just skip it here.
-#if !FEATURE_DRM_CONNECTOR
-        self.finalizeSignIn(forDRMAuthorization: success,
-                            error: error as NSError?)
-#endif
-    }
+    drmAuthorizerAxis?.authorize(withVendorID: vendor,
+                                 username: username,
+                                 password: password,
+                                 completion: completion)
   }
   
 }

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+DRM.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+DRM.swift
@@ -45,13 +45,27 @@ extension NYPLSignInBusinessLogic {
 #if AXIS
     drmAuthorizeAxis(username: profileDoc.authorizationIdentifier ?? "",
                      password: profileDoc.authorizationIdentifier,
-                     completion: axisAuthorizationCompletion(loggingContext))
+                     loggingContext: loggingContext) { [weak self] success, error in
+      guard let self = self else {
+        return
+      }
+#if !FEATURE_DRM_CONNECTOR
+      // finalizeSignIn should only be called once,
+      // so here we are calling it if only AXIS is the available DRM
+      self.finalizeSignIn(forDRMAuthorization: success,
+                          error: error as NSError?)
 #endif
+    }
+#endif // AXIS
 
 #if FEATURE_DRM_CONNECTOR
     authorizeWithAdobe(userProfile: profileDoc,
-                       loggingContext: loggingContext,
-                       completion: adobeAuthorizationCompletion(loggingContext))
+                       loggingContext: loggingContext) { [weak self] success, error in
+      guard let self = self else {
+        return
+      }
+      self.finalizeSignIn(forDRMAuthorization: success, error: error)
+    }
 #endif
   }
 
@@ -76,115 +90,5 @@ extension NYPLSignInBusinessLogic {
                                                     completion: nil)
     }
   }
-  
-  // MARK: - Helper
-    
-#if FEATURE_DRM_CONNECTOR
-  /// A completion block that logs error (if available), update user info
-  /// and finalize sign in process after DRM authorization is completed,
-  /// designated for Adobe DRM.
-  private func adobeAuthorizationCompletion(_ loggingContext: [String: Any]) -> (
-    (Bool, Error?, String?, String?) -> Void
-  ) {
-    return { [weak self] success, error, deviceID, userID in
-      // make sure to cancel the previously scheduled selector
-      // from the same thread it was scheduled on
-      NYPLMainThreadRun.asyncIfNeeded {
-        if let self = self {
-          NSObject.cancelPreviousPerformRequests(withTarget: self)
-        }
-      }
-      
-      guard let self = self else {
-        
-        let error = NSError(
-          domain: "NYPLSignInBusinessLogic deallocated prematurely",
-          code: 418, userInfo: nil)
-        
-        NYPLErrorLogger.logLocalAuthFailed(error: error,
-                                           library: nil,
-                                           metadata: loggingContext)
-      
-        return
-      }
-      
-      Log.info(#file, """
-        Activation success: \(success)
-        Error: \(error?.localizedDescription ?? "N/A")
-        DeviceID: \(deviceID ?? "N/A")
-        UserID: \(userID ?? "N/A")
-        ***DRM Auth/Activation completion***
-        """)
-
-      var success = success
-
-      if success, let userID = userID, let deviceID = deviceID {
-        NYPLMainThreadRun.asyncIfNeeded {
-          self.userAccount.setUserID(userID)
-          self.userAccount.setDeviceID(deviceID)
-        }
-      } else {
-        success = false
-        NYPLErrorLogger.logLocalAuthFailed(error: error as NSError?,
-                                           library: self.libraryAccount,
-                                           metadata: loggingContext)
-      }
-      
-      Log.info(#file, "Finalizing sign in for Adobe")
-      self.finalizeSignIn(forDRMAuthorization: success,
-                          error: error as NSError?)
-    }
-  }
-#endif // FEATURE_DRM_CONNECTOR
-  
-#if AXIS
-  /// A completion block that logs error (if available) and finalize sign in process
-  /// after DRM authorization is completed, designated for AxisDRM.
-  /// While it is very similar to the one for Adobe,
-  /// it does not update the `userID` and `deviceID` because
-  /// the AxisDRM does not return valid values of these parameters.
-  /// It also avoid calling finalizeSignIn twice when both Adobe and Axis exist.
-  private func axisAuthorizationCompletion(_ loggingContext: [String: Any]) -> (
-    (Bool, Error?, String?, String?) -> Void
-  ) {
-    return { [weak self] success, error, deviceID, userID in
-      guard let self = self else {
-        
-        let error = NSError(
-          domain: "NYPLSignInBusinessLogic deallocated prematurely",
-          code: 418, userInfo: nil)
-        
-        NYPLErrorLogger.logLocalAuthFailed(error: error,
-                                           library: nil,
-                                           metadata: loggingContext)
-      
-        return
-      }
-      
-      Log.info(#file, """
-        Activation success: \(success)
-        Error: \(error?.localizedDescription ?? "N/A")
-        DeviceID: \(deviceID ?? "N/A")
-        UserID: \(userID ?? "N/A")
-        ***DRM Auth/Activation completion***
-        """)
-
-      let success = success && userID != nil && deviceID != nil
-
-      if !success {
-        NYPLErrorLogger.logLocalAuthFailed(error: error as NSError?,
-                                           library: self.libraryAccount,
-                                           metadata: loggingContext)
-      }
-
-#if !FEATURE_DRM_CONNECTOR
-      // finalizeSignIn should only be called once,
-      // so here we are calling it if only AXIS is the available DRM
-      self.finalizeSignIn(forDRMAuthorization: success,
-                          error: error as NSError?)
-#endif
-    }
-  }
-#endif // AXIS
 }
 #endif // FEATURE_DRM_CONNECTOR || AXIS


### PR DESCRIPTION
**What's this do?**
Encapsulate content protection and sign-in process for each DRMs

**Why are we doing this? (w/ JIRA link if applicable)**
[iOS-339](https://jira.nypl.org/browse/IOS-339)
[Banned Books PR](https://github.com/NYPL-Simplified/Simplified-iOS/pull/1532)

**How should this be tested? / Do these changes have associated tests?**
Regression testing for account sign-in and sign-out on SE and OE
Open and read publications protected by each DRMs or without DRM

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
Yes, will do before merge

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@ErnestFan 
