### PR TITLE
iOS-149 Use NYPLErrorLogger to log events in NYPLAnnotations

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -5534,7 +5534,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -5554,7 +5554,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.4;
+				MARKETING_VERSION = 3.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PRODUCT_NAME = "SimplyE-R2dev";
@@ -5585,7 +5585,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -5604,7 +5604,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.4;
+				MARKETING_VERSION = 3.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PRODUCT_NAME = "SimplyE-R2dev";
@@ -5635,7 +5635,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -5651,7 +5651,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.4;
+				MARKETING_VERSION = 3.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
@@ -5682,7 +5682,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -5697,7 +5697,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.4;
+				MARKETING_VERSION = 3.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
@@ -5953,7 +5953,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -5975,7 +5975,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.4;
+				MARKETING_VERSION = 3.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
 				PROVISIONING_PROFILE_SPECIFIER = "SimplyE Development";
@@ -6005,7 +6005,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -6026,7 +6026,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.4;
+				MARKETING_VERSION = 3.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.SimplyE;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
 				PROVISIONING_PROFILE_SPECIFIER = "SimplyE Distribution";

--- a/Simplified/Logging/NYPLErrorLogger.swift
+++ b/Simplified/Logging/NYPLErrorLogger.swift
@@ -83,10 +83,9 @@ fileprivate let nullString = "null"
   case libraryListLoadFail = 701
 
   // feeds
-  case opdsFeedNoData = 800
+  case noData = 800
   case invalidFeedType = 801
   case noAgeGateElement = 802
-  case annotationFeedNoData = 803
 
   // networking, generic
   case noURL = 900

--- a/Simplified/Logging/NYPLErrorLogger.swift
+++ b/Simplified/Logging/NYPLErrorLogger.swift
@@ -86,6 +86,7 @@ fileprivate let nullString = "null"
   case opdsFeedNoData = 800
   case invalidFeedType = 801
   case noAgeGateElement = 802
+  case annotationFeedNoData = 803
 
   // networking, generic
   case noURL = 900

--- a/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
@@ -498,7 +498,8 @@ protocol NYPLAnnotationSyncing: AnyObject {
                                       motivation: NYPLBookmarkSpec.Motivation,
                                       publication: Publication?,
                                       bookID: String) -> [NYPLReadiumBookmark]? {
-    let metadata: [String: Any] = ["bookID":bookID]
+    let metadata: [String: Any] = ["bookID": bookID,
+                                   "motivation": motivation]
     if let error = error as NSError? {
       NYPLErrorLogger.logError(error,
                                summary: "NYPLAnnotations::parseAnnotationsResponse error",
@@ -517,7 +518,7 @@ protocol NYPLAnnotationSyncing: AnyObject {
 
     guard let first = json["first"] as? [String: Any],
       let items = first["items"] as? [[String: Any]] else {
-        NYPLErrorLogger.logError(withCode: .annotationFeedNoData,
+        NYPLErrorLogger.logError(withCode: .noData,
                                  summary: "NYPLAnnotations::parseAnnotationsResponse error",
                                  metadata: metadata)
         return nil


### PR DESCRIPTION
**What's this do?**
Use NYPLErrorLogger to log events in NYPLAnnotations

**Why are we doing this? (w/ JIRA link if applicable)**
[ios-149](https://jira.nypl.org/browse/IOS-149)
[Previous PR on NYPLAnnotations](https://github.com/NYPL-Simplified/Simplified-iOS/pull/1232#discussion_r513035443)

**How should this be tested? / Do these changes have associated tests?**
No testing needed

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
N/A
