### PR TITLE
Print Fastlane version before archive-and-upload

### DIFF
--- a/.github/workflows/archive-and-upload.yml
+++ b/.github/workflows/archive-and-upload.yml
@@ -17,6 +17,8 @@ jobs:
         run: echo "FULL_EVENT=$FULL_EVENT"
       - name: Print System Info
         run: uname -a
+      - name: Print Fastlane version
+        run: fastlane -v
       - name: Check Carthage version
         run: command -v carthage && carthage version
       - name: Checkout main repo

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "fastlane"
+gem "fastlane", "2.205.0"
 


### PR DESCRIPTION
**What's this do?**
Print Fastlane version before upload

**Why are we doing this? (w/ JIRA link if applicable)**
Fastlane version is buried in the CI log and hard to find

**How should this be tested? / Do these changes have associated tests?**
N/A

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
N/A
