### PR TITLE
OE-216 Remove unused authentication logic

### DIFF
--- a/Simplified/Accounts/AgeCheck/NYPLAgeCheck.swift
+++ b/Simplified/Accounts/AgeCheck/NYPLAgeCheck.swift
@@ -73,7 +73,7 @@ protocol NYPLAgeCheckValidationDelegate: AnyObject {
         return
       }
       
-      if userAccountProvider.needsAuth == true || accountDetails.userAboveAgeLimit {
+      if userAccountProvider.requiresUserAuthentication || accountDetails.userAboveAgeLimit {
         completion?(true)
         return
       }

--- a/Simplified/Accounts/User/NYPLUserAccount.swift
+++ b/Simplified/Accounts/User/NYPLUserAccount.swift
@@ -32,7 +32,7 @@ private enum StorageKey: String {
 }
 
 @objc protocol NYPLUserAccountProvider: NSObjectProtocol {
-  var needsAuth:Bool { get }
+  var requiresUserAuthentication: Bool { get }
   
   static func sharedAccount(libraryUUID: String?) -> NYPLUserAccount
 }
@@ -310,12 +310,11 @@ private enum StorageKey: String {
     return nil
   }
 
-  var needsAuth:Bool {
-    let authType = authDefinition?.authType ?? .none
-    return authType == .basic || authType == .oauthIntermediary || authType == .saml
+  var requiresUserAuthentication: Bool {
+    return authDefinition?.requiresUserAuthentication ?? false
   }
 
-  var needsAgeCheck:Bool {
+  var needsAgeCheck: Bool {
     return authDefinition?.authType == .coppa
   }
 

--- a/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
@@ -39,7 +39,7 @@ extension NYPLAppDelegate {
       && NYPLSettings.shared.userHasSeenWelcomeScreen
       && !isSigningIn {
       
-      OETutorialChoiceViewController.showLoginPicker(handler: nil)
+      OETutorialChoiceViewController.showLoginPicker()
     }
   }
 

--- a/Simplified/Book/UI/NYPLBookButtonsView.m
+++ b/Simplified/Book/UI/NYPLBookButtonsView.m
@@ -183,8 +183,8 @@
       break;
     case NYPLBookButtonsStateDownloadNeeded:
     {
-      NSString *title = (self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.needsAuth) ? NSLocalizedString(@"Delete", nil) : NSLocalizedString(@"Return", nil);
-      NSString *hint = (self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.needsAuth) ? [NSString stringWithFormat:NSLocalizedString(@"Deletes %@", nil), self.book.title] : [NSString stringWithFormat:NSLocalizedString(@"Returns %@", nil), self.book.title];
+      NSString *title = (self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.requiresUserAuthentication) ? NSLocalizedString(@"Delete", nil) : NSLocalizedString(@"Return", nil);
+      NSString *hint = (self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.requiresUserAuthentication) ? [NSString stringWithFormat:NSLocalizedString(@"Deletes %@", nil), self.book.title] : [NSString stringWithFormat:NSLocalizedString(@"Returns %@", nil), self.book.title];
 
       visibleButtonInfo = @[@{ButtonKey: self.downloadButton,
                               TitleKey: NSLocalizedString(@"Download", nil),
@@ -219,8 +219,8 @@
           break;
       }
 
-      NSString *title = (self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.needsAuth) ? NSLocalizedString(@"Delete", nil) : NSLocalizedString(@"Return", nil);
-      NSString *hint = (self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.needsAuth) ? [NSString stringWithFormat:NSLocalizedString(@"Deletes %@", nil), self.book.title] : [NSString stringWithFormat:NSLocalizedString(@"Returns %@", nil), self.book.title];
+      NSString *title = (self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.requiresUserAuthentication) ? NSLocalizedString(@"Delete", nil) : NSLocalizedString(@"Return", nil);
+      NSString *hint = (self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.requiresUserAuthentication) ? [NSString stringWithFormat:NSLocalizedString(@"Deletes %@", nil), self.book.title] : [NSString stringWithFormat:NSLocalizedString(@"Returns %@", nil), self.book.title];
 
       visibleButtonInfo = @[buttonInfo,
                             @{ButtonKey: self.deleteButton,
@@ -271,7 +271,7 @@
   for (NSDictionary *buttonInfo in visibleButtonInfo) {
     NYPLRoundedButton *button = buttonInfo[ButtonKey];
     if(button == self.deleteButton && (!fulfillmentId && fulfillmentIdRequired) && !hasRevokeLink) {
-      if(!self.book.defaultAcquisitionIfOpenAccess && NYPLUserAccount.sharedAccount.authDefinition.needsAuth) {
+      if(!self.book.defaultAcquisitionIfOpenAccess && NYPLUserAccount.sharedAccount.authDefinition.requiresUserAuthentication) {
         continue;
       }
     }
@@ -361,13 +361,13 @@
     case NYPLBookStateDownloadFailed:
     case NYPLBookStateDownloadNeeded:
     case NYPLBookStateDownloadSuccessful:
-      title = ((self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.needsAuth)
+      title = ((self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.requiresUserAuthentication)
                ? NSLocalizedString(@"MyBooksDownloadCenterConfirmDeleteTitle", nil)
                : NSLocalizedString(@"MyBooksDownloadCenterConfirmReturnTitle", nil));
-      message = ((self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.needsAuth)
+      message = ((self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.requiresUserAuthentication)
                  ? NSLocalizedString(@"MyBooksDownloadCenterConfirmDeleteTitleMessageFormat", nil)
                  : NSLocalizedString(@"MyBooksDownloadCenterConfirmReturnTitleMessageFormat", nil));
-      confirmButtonTitle = ((self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.needsAuth)
+      confirmButtonTitle = ((self.book.defaultAcquisitionIfOpenAccess || !NYPLUserAccount.sharedAccount.authDefinition.requiresUserAuthentication)
                             ? NSLocalizedString(@"MyBooksDownloadCenterConfirmDeleteTitle", nil)
                             : NSLocalizedString(@"MyBooksDownloadCenterConfirmReturnTitle", nil));
       break;

--- a/Simplified/Book/UI/NYPLBookCellDelegate.m
+++ b/Simplified/Book/UI/NYPLBookCellDelegate.m
@@ -77,9 +77,8 @@
     // where the barcode and pin are entered but according to ADEPT the device
     // is not authorized. To be used, the account must have a barcode and pin."
     NYPLReauthenticator *reauthenticator = [[NYPLReauthenticator alloc] init];
-    [reauthenticator authenticateIfNeeded:user
-                 usingExistingCredentials:YES
-                 authenticationCompletion:^{
+    [reauthenticator authenticateIfNeededUsingExistingCredentials:YES
+                                         authenticationCompletion:^{
       dispatch_async(dispatch_get_main_queue(), ^{
         [self openBook:book successCompletion:successCompletion]; // with successful DRM activation
       });

--- a/Simplified/Holds/NYPLHoldsViewController.m
+++ b/Simplified/Holds/NYPLHoldsViewController.m
@@ -267,7 +267,7 @@ didSelectItemAtIndexPath:(NSIndexPath *const)indexPath
 
 - (void)didPullToRefresh
 {  
-  if ([NYPLUserAccount sharedAccount].needsAuth) {
+  if ([NYPLUserAccount sharedAccount].requiresUserAuthentication) {
     if([[NYPLUserAccount sharedAccount] hasCredentials]) {
       [[NYPLBookRegistry sharedRegistry] syncWithStandardAlertsOnCompletion];
     } else {

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -385,9 +385,8 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
           || (!hasCredentials && loginRequired)) {
 
         // re-auth so that when we "Try again" we won't fail for the same reason
-        [self.reauthenticator authenticateIfNeeded:NYPLUserAccount.sharedAccount
-                          usingExistingCredentials:hasCredentials
-                          authenticationCompletion:nil];
+        [self.reauthenticator authenticateIfNeededUsingExistingCredentials:hasCredentials
+                                                  authenticationCompletion:nil];
       }
 
       [self alertForProblemDocument:problemDoc error:failureError book:book];
@@ -731,9 +730,8 @@ didCompleteWithError:(NSError *)error
     } else if ([errorDict[@"type"] isEqualToString:NYPLProblemDocument.TypeInvalidCredentials]) {
       NYPLLOG(@"Invalid credentials problem when returning a book, present sign in VC");
       __weak __auto_type wSelf = self;
-      [self.reauthenticator authenticateIfNeeded:NYPLUserAccount.sharedAccount
-                        usingExistingCredentials:NO
-                        authenticationCompletion:^{
+      [self.reauthenticator authenticateIfNeededUsingExistingCredentials:NO
+                                                authenticationCompletion:^{
         [wSelf returnBookWithIdentifier:identifier];
       }];
     } else {
@@ -919,9 +917,8 @@ didCompleteWithError:(NSError *)error
           } else if ([errorDict[@"type"] isEqualToString:NYPLProblemDocument.TypeInvalidCredentials]) {
             NYPLLOG(@"Invalid credentials problem when borrowing a book, present sign in VC");
             __weak __auto_type wSelf = self;
-            [self.reauthenticator authenticateIfNeeded:NYPLUserAccount.sharedAccount
-                              usingExistingCredentials:NO
-                              authenticationCompletion:^{
+            [self.reauthenticator authenticateIfNeededUsingExistingCredentials:NO
+                                                      authenticationCompletion:^{
               [wSelf startDownloadForBook:book];
             }];
             return;
@@ -1159,9 +1156,8 @@ didCompleteWithError:(NSError *)error
             [[NYPLBookRegistry sharedRegistry] setState:NYPLBookStateDownloadNeeded forIdentifier:book.identifier];
 
             __weak __auto_type wSelf = self;
-            [self.reauthenticator authenticateIfNeeded:NYPLUserAccount.sharedAccount
-                              usingExistingCredentials:NO
-                              authenticationCompletion:^{
+            [self.reauthenticator authenticateIfNeededUsingExistingCredentials:NO
+                                                      authenticationCompletion:^{
               [wSelf startDownloadForBook:book];
             }];
           };
@@ -1555,9 +1551,8 @@ didFinishDownload:(BOOL)didFinishDownload
   // "This handles a bug that seems to occur when the user updates,
   // where the barcode and pin are entered but according to ADEPT the device
   // is not authorized. To be used, the account must have a barcode and pin."
-  [self.reauthenticator authenticateIfNeeded:[NYPLUserAccount sharedAccount]
-                    usingExistingCredentials:YES
-                    authenticationCompletion:nil];
+  [self.reauthenticator authenticateIfNeededUsingExistingCredentials:YES
+                                            authenticationCompletion:nil];
 }
 
 #endif

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -380,7 +380,7 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
   if (failureRequiringAlert) {
     dispatch_async(dispatch_get_main_queue(), ^{
       BOOL hasCredentials = [NYPLUserAccount.sharedAccount hasCredentials];
-      BOOL loginRequired = NYPLUserAccount.sharedAccount.authDefinition.needsAuth;
+      BOOL loginRequired = NYPLUserAccount.sharedAccount.authDefinition.requiresUserAuthentication;
       if ([downloadTask.response indicatesAuthenticationNeedsRefresh:problemDoc]
           || (!hasCredentials && loginRequired)) {
 
@@ -657,7 +657,7 @@ didCompleteWithError:(NSError *)error
 
   // ----------------------------------------------
 
-  if (fulfillmentId && NYPLUserAccount.sharedAccount.authDefinition.needsAuth) {
+  if (fulfillmentId && NYPLUserAccount.sharedAccount.requiresUserAuthentication) {
     NYPLLOG_F(@"Return attempt for book. userID: %@",[[NYPLUserAccount sharedAccount] userID]);
     [[NYPLADEPT sharedInstance] returnLoan:fulfillmentId
                                     userID:[[NYPLUserAccount sharedAccount] userID]
@@ -993,7 +993,7 @@ didCompleteWithError:(NSError *)error
   NYPLBookState state = [[NYPLBookRegistry sharedRegistry]
                          stateForIdentifier:book.identifier];
 
-  BOOL loginRequired = NYPLUserAccount.sharedAccount.authDefinition.needsAuth;
+  BOOL loginRequired = NYPLUserAccount.sharedAccount.requiresUserAuthentication;
 
   switch(state) {
     case NYPLBookStateUnregistered:

--- a/Simplified/MyBooks/NYPLMyBooksViewController.m
+++ b/Simplified/MyBooks/NYPLMyBooksViewController.m
@@ -366,7 +366,7 @@ OK:
 
 - (void)didPullToRefresh
 {
-  if ([NYPLUserAccount sharedAccount].needsAuth) {
+  if ([NYPLUserAccount sharedAccount].requiresUserAuthentication) {
     if([[NYPLUserAccount sharedAccount] hasCredentials]) {
       [[NYPLBookRegistry sharedRegistry] syncWithStandardAlertsOnCompletion];
     } else {

--- a/Simplified/Network/NYPLRemoteViewController.m
+++ b/Simplified/Network/NYPLRemoteViewController.m
@@ -211,11 +211,9 @@
         if (self.needsReauthentication) {
           self.needsReauthentication = NO;
 
-          NYPLUserAccount *user = [NYPLUserAccount sharedAccount];
           __block NYPLReauthenticator *reauthenticator = [[NYPLReauthenticator alloc] init];
-          [reauthenticator authenticateIfNeeded:user
-                       usingExistingCredentials:YES
-                       authenticationCompletion:^{
+          [reauthenticator authenticateIfNeededUsingExistingCredentials:YES
+                                               authenticationCompletion:^{
             // make sure to retain the reauthenticator until end of auth
             // flow and then break any possible retain cycle
             reauthenticator = nil;

--- a/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
@@ -382,7 +382,7 @@ Authenticating with any of those barcodes should work.
   NSMutableArray *workingSection = @[].mutableCopy;
   if (self.businessLogic.selectedAuthentication.needsAgeCheck) {
     workingSection = @[@(CellKindAgeCheck)].mutableCopy;
-  } else if (!self.businessLogic.selectedAuthentication.needsAuth) {
+  } else if (!self.businessLogic.selectedAuthentication.requiresUserAuthentication) {
     // no authentication needed, empty section
 
   } else if (self.businessLogic.selectedAuthentication && self.businessLogic.isSignedIn) {
@@ -390,7 +390,7 @@ Authenticating with any of those barcodes should work.
     // show only the selected auth method
 
     [workingSection addObjectsFromArray:[self cellsForAuthMethod:self.businessLogic.selectedAuthentication]];
-  } else if (!self.businessLogic.isSignedIn && self.businessLogic.userAccount.needsAuth) {
+  } else if (!self.businessLogic.isSignedIn && self.businessLogic.userAccount.requiresUserAuthentication) {
     // user needs to sign in
 
     if (self.businessLogic.isSamlPossible) {

--- a/Simplified/Settings/NYPLSettingsSplitViewController+OE.swift
+++ b/Simplified/Settings/NYPLSettingsSplitViewController+OE.swift
@@ -35,7 +35,7 @@ extension NYPLSettingsSplitViewController {
               sender: nil
             )
           } else {
-            OETutorialChoiceViewController.showLoginPicker(handler: nil)
+            OETutorialChoiceViewController.showLoginPicker()
           }
       }
       ),

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.m
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.m
@@ -606,7 +606,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
 
 - (NSArray *)accountInfoSection {
   NSMutableArray *workingSection = @[].mutableCopy;
-  if (!self.businessLogic.selectedAuthentication.needsAuth) {
+  if (!self.businessLogic.selectedAuthentication.requiresUserAuthentication) {
     // no authentication needed, empty section
 
   } else if (self.businessLogic.selectedAuthentication && self.businessLogic.isSignedIn) {
@@ -614,7 +614,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
     // show only the selected auth method
 
     [workingSection addObjectsFromArray:[self cellsForAuthMethod:self.businessLogic.selectedAuthentication]];
-  } else if (!self.businessLogic.isSignedIn && self.businessLogic.userAccount.needsAuth) {
+  } else if (!self.businessLogic.isSignedIn && self.businessLogic.userAccount.requiresUserAuthentication) {
     // user needs to sign in
 
     if (self.businessLogic.isSamlPossible) {

--- a/Simplified/SignInLogic/NYPLReauthenticator.swift
+++ b/Simplified/SignInLogic/NYPLReauthenticator.swift
@@ -27,14 +27,12 @@ import Foundation
   /// modal UI or not, depending on the sign-in business logic.
   ///
   /// - Parameters:
-  ///   - user: The current user.
   ///   - usingExistingCredentials: Use the existing credentials for `user`.
   ///   - authenticationCompletion: Code to run after the authentication
   ///   flow completes.
   /// - Returns: `true` if an authentication flow was started to refresh the
   /// credentials, `false` otherwise.
-  @objc func authenticateIfNeeded(_ user: NYPLUserAccount,
-                                  usingExistingCredentials: Bool,
+  @objc func authenticateIfNeeded(usingExistingCredentials: Bool,
                                   authenticationCompletion: (()-> Void)?) {
     NYPLMainThreadRun.asyncIfNeeded {
       let vc = NYPLAccountSignInViewController()

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogicUIDelegate.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogicUIDelegate.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 NYPL. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 /// The functionalities on the UI that the sign-in business logic requires.
 @objc protocol NYPLSignInBusinessLogicUIDelegate: NYPLBasicAuthCredentialsProvider, NYPLUserAccountInputProvider {

--- a/Simplified/WelcomeScreen/OETutorialChoiceViewController.swift
+++ b/Simplified/WelcomeScreen/OETutorialChoiceViewController.swift
@@ -9,8 +9,6 @@
 import UIKit
 
 class OETutorialChoiceViewController : UIViewController {
-  var completionHandler: (()->Void)?
-  
   var descriptionLabel: UILabel
   var firstBookLoginButton: UIButton
   var loginWithCleverButton: UIButton
@@ -18,7 +16,6 @@ class OETutorialChoiceViewController : UIViewController {
   var stackView: UIStackView
   
   init() {
-    completionHandler = nil
     descriptionLabel = UILabel(frame: CGRect.zero)
     firstBookLoginButton = UIButton(type: .custom)
     loginWithCleverButton = UIButton(type: .custom)
@@ -96,10 +93,6 @@ class OETutorialChoiceViewController : UIViewController {
       return
     }
     appWindow?.rootViewController = NYPLRootTabBarController.shared()
-    
-    let oldCompletionHandler = completionHandler
-    completionHandler = nil
-    oldCompletionHandler?.self()
   }
 
   @objc func didSelectFirstBook() {
@@ -139,9 +132,8 @@ class OETutorialChoiceViewController : UIViewController {
     UIApplication.shared.open(NYPLConfiguration.openEBooksRequestCodesURL)
   }
   
-  @objc class func showLoginPicker(handler: (()->Void)?) {
+  class func showLoginPicker() {
     let choiceVC = OETutorialChoiceViewController()
-    choiceVC.completionHandler = handler
     let cancelBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: choiceVC, action: #selector(didSelectCancel))
     choiceVC.navigationItem.leftBarButtonItem = cancelBarButtonItem
     let navVC = UINavigationController(rootViewController: choiceVC)

--- a/SimplifiedTests/Mocks/NYPLUserAccountProviderMock.swift
+++ b/SimplifiedTests/Mocks/NYPLUserAccountProviderMock.swift
@@ -12,14 +12,14 @@ import Foundation
 class NYPLUserAccountProviderMock: NSObject, NYPLUserAccountProvider {
   private static let userAccountMock = NYPLUserAccountMock()
   
-  var needsAuth: Bool
+  var requiresUserAuthentication: Bool
   
   static func sharedAccount(libraryUUID: String?) -> NYPLUserAccount {
     return userAccountMock
   }
   
   override init() {
-    needsAuth = false
+    requiresUserAuthentication = false
     
     super.init()
   }

--- a/SimplifiedTests/OPDS2CatalogsFeedTests.swift
+++ b/SimplifiedTests/OPDS2CatalogsFeedTests.swift
@@ -132,7 +132,7 @@ class OPDS2CatalogsFeedTests: XCTestCase {
       dpl.authenticationDocument = try OPDS2AuthenticationDocument.fromData(try Data(contentsOf: dplAuthUrl))
       nypl.authenticationDocument = try OPDS2AuthenticationDocument.fromData(try Data(contentsOf: nyplAuthUrl))
       
-      XCTAssertEqual(gpl.details?.defaultAuth?.needsAuth, true)
+      XCTAssertEqual(gpl.details?.defaultAuth?.requiresUserAuthentication, true)
       XCTAssertEqual(gpl.details?.uuid, gpl.uuid)
       XCTAssertEqual(gpl.details?.supportsReservations, true)
       XCTAssertEqual(gpl.details?.userProfileUrl, "http://califa108.simplye-ca.org/CAGLEN/patrons/me/")
@@ -150,7 +150,7 @@ class OPDS2CatalogsFeedTests: XCTestCase {
       XCTAssertEqual(gpl.details?.defaultAuth?.pinKeyboard, .numeric)
       XCTAssertEqual(gpl.details?.defaultAuth?.authPasscodeLength, 99)
       
-      XCTAssertEqual(acl.details?.defaultAuth?.needsAuth, true)
+      XCTAssertEqual(acl.details?.defaultAuth?.requiresUserAuthentication, true)
       XCTAssertEqual(acl.details?.uuid, acl.uuid)
       XCTAssertEqual(acl.details?.supportsReservations, true)
       XCTAssertEqual(acl.details?.userProfileUrl, "http://acl.simplye-ca.org/CALMDA/patrons/me/")
@@ -182,7 +182,7 @@ class OPDS2CatalogsFeedTests: XCTestCase {
       XCTAssertEqual(dpl.details?.getLicenseURL(.acknowledgements), nil)
       XCTAssertEqual(dpl.details?.mainColor, "cyan")
       
-      XCTAssertEqual(nypl.details?.defaultAuth?.needsAuth, true)
+      XCTAssertEqual(nypl.details?.defaultAuth?.requiresUserAuthentication, true)
       XCTAssertEqual(nypl.details?.uuid, nypl.uuid)
       XCTAssertEqual(nypl.details?.supportsReservations, true)
       XCTAssertEqual(nypl.details?.userProfileUrl, "https://circulation.librarysimplified.org/NYNYPL/patrons/me/")


### PR DESCRIPTION
**What's this do?**
- removes some unused authentication logic
- rename a few variables for clarity in authentication logic

**Why are we doing this? (w/ JIRA link if applicable)**
This is some preparatory work for OE-216. It's the first of 3 PRs.

**How should this be tested? / Do these changes have associated tests?**
too early to test

**Dependencies for merging? Releasing to production?**
This should be safe to merge, since it should have no changes in functionality.

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 