### PR TITLE
IOS-335 Use network layer for annotations calls

### DIFF
--- a/Simplified/Book/UI/NYPLBookDetailViewController.m
+++ b/Simplified/Book/UI/NYPLBookDetailViewController.m
@@ -43,6 +43,7 @@
   self.executor = [[NYPLNetworkExecutor alloc]
                    initWithCredentialsProvider:NYPLUserAccount.sharedAccount
                    cachingStrategy:NYPLCachingStrategyEphemeral
+                   waitsForConnectivity:YES
                    delegateQueue:nil];
 
   self.title = book.title;

--- a/Simplified/Logging/NYPLCirculationAnalytics.swift
+++ b/Simplified/Logging/NYPLCirculationAnalytics.swift
@@ -14,24 +14,23 @@ import Foundation
   
   private class func post(_ event: String, withURL url: URL) -> Void
   {
-    var request = URLRequest(url: url)
-    request.httpMethod = "GET"
-
-    let dataTask = URLSession.shared.dataTask(with: request) { (data, response, error) in
-      
-      if let response = response as? HTTPURLResponse {
-        if response.statusCode == 200 {
-          debugPrint(#file, "Analytics Upload: Success")
-        }
-      } else {
-        guard let error = error as NSError? else { return }
+    NYPLNetworkExecutor.shared.GET(url) { result in
+      switch result {
+      case .success(_, _):
+        debugPrint(#file, "Analytics Upload: Success")
+      case .failure(let err, let response):
+        let error = err as NSError
         if NetworkQueue.StatusCodes.contains(error.code) {
           self.addToOfflineAnalyticsQueue(event, url)
         }
-        Log.error(#file, "URLRequest Error: \(error.code). Description: \(error.localizedDescription)")
+        NYPLErrorLogger.logError(error,
+                                 summary: "Circulation analytics error",
+                                 metadata: [
+                                  "response": response ?? "",
+                                  "event": event,
+                                  "url": url])
       }
     }
-    dataTask.resume()
   }
   
   private class func addToOfflineAnalyticsQueue(_ event: String, _ bookURL: URL) -> Void

--- a/Simplified/Logging/NYPLCirculationAnalytics.swift
+++ b/Simplified/Logging/NYPLCirculationAnalytics.swift
@@ -37,6 +37,6 @@ import Foundation
   private class func addToOfflineAnalyticsQueue(_ event: String, _ bookURL: URL) -> Void
   {
     let libraryID = AccountsManager.shared.currentAccount?.uuid ?? ""
-    NetworkQueue.shared().addRequest(libraryID, nil, bookURL, .GET, nil, NYPLAnnotations.headers)
+    NetworkQueue.shared.addRequest(libraryID, nil, bookURL, .GET, nil)
   }
 }

--- a/Simplified/Logging/NYPLErrorLogger.swift
+++ b/Simplified/Logging/NYPLErrorLogger.swift
@@ -21,6 +21,10 @@ fileprivate let nullString = "null"
   }
 }
 
+//
+// ** Make sure these error codes do not coincide with NSError error codes, **
+// ** in particular the ones listed at `NYPLNetworkQueue.StatusCodes`.      **
+//
 /// Detailed error codes that span across different error reports.
 /// E.g. you could have a `invalidURLSession` for a number of different api
 /// calls, happening in catalog loading, sign-in, etc. So the `summary` of

--- a/Simplified/Migrations/OEMigrations.swift
+++ b/Simplified/Migrations/OEMigrations.swift
@@ -23,7 +23,11 @@ extension NYPLMigrationManager {
     #if AXIS
     migrate_2_1_1(ifNeededFrom: versionComponents)
     #endif
+
+    // Migrate (or create if missing) Network Queue DB
+    NetworkQueue.shared.migrateOrSetUpIfNeeded()
   }
+
   #if FEATURE_DRM_CONNECTOR
   /// v1.8.1
   /// Adept API changed to allow multiple accounts

--- a/Simplified/Migrations/SEMigrations.swift
+++ b/Simplified/Migrations/SEMigrations.swift
@@ -21,8 +21,8 @@ extension NYPLMigrationManager {
       migrate2();
     }
 
-    // Migrate Network Queue DB
-    NetworkQueue.sharedInstance.migrate()
+    // Migrate (or create if missing) Network Queue DB 
+    NetworkQueue.shared.migrateOrSetUpIfNeeded()
   }
 
   // v3.2.0

--- a/Simplified/Network/NYPLCaching.swift
+++ b/Simplified/Network/NYPLCaching.swift
@@ -196,8 +196,13 @@ class NYPLCaching {
   /// Note that regardless of these caching strategies, the request caching
   /// policy will always follow the one defined in the request protocol
   /// implementation.
+  /// - Parameter waitsForConnectivity: Determines if the urlSession should
+  /// wait for connectivity to become available or instead fail immediately.
+  /// - Parameter requestTimeout: This is also used, with a multiplier, to
+  /// set up the resource timeout.
   /// - Returns: A configuration with 8 max connections per host.
   class func makeURLSessionConfiguration(caching: NYPLCachingStrategy,
+                                         waitsForConnectivity: Bool,
                                          requestTimeout: TimeInterval) -> URLSessionConfiguration {
     guard caching != .ephemeral else {
       return .ephemeral
@@ -213,7 +218,7 @@ class NYPLCaching {
     config.urlCache = makeCache()
 
     if #available(iOS 11.0, *) {
-      config.waitsForConnectivity = true
+      config.waitsForConnectivity = waitsForConnectivity
     }
 
     if #available(iOS 13.0, *) {

--- a/Simplified/Network/NYPLRequestExecuting.swift
+++ b/Simplified/Network/NYPLRequestExecuting.swift
@@ -37,6 +37,29 @@ extension NYPLRequestExecuting {
   }
 }
 
+protocol NYPLHTTPRequestExecuting: NYPLRequestExecuting {
+  func GET(_ reqURL: URL,
+           cachePolicy: URLRequest.CachePolicy?,
+           completion: @escaping (_ result: NYPLResult<Data>) -> Void)
+
+  func POST(_ reqURL: URL,
+            additionalHeaders: [String: String]?,
+            httpBody: Data?,
+            completion: @escaping (_ result: NYPLResult<Data>) -> Void)
+
+  func DELETE(_ reqURL: URL,
+              completion: @escaping (_ result: NYPLResult<Data>) -> Void)
+}
+
+/// Protocol for Objective-C compatibility.
+@objc protocol NYPLHTTPRequestExecutingBasic {
+  func GET(_ reqURL: URL,
+           cachePolicy: NSURLRequest.CachePolicy,
+           completion: @escaping (_ result: Data?,
+                                  _ response: URLResponse?,
+                                  _ error: Error?) -> Void) -> URLSessionDataTask
+}
+
 protocol NYPLOAuthTokenFetching {
   func fetchAndStoreShortLivedOAuthToken(
     at url: URL,
@@ -44,11 +67,3 @@ protocol NYPLOAuthTokenFetching {
 
   func resetLibrarySpecificInfo()
 }
-
-/// Protocol for Objective-C compatibility.
-@objc protocol NYPLRequestExecutingObjC {
-  func GET(_ reqURL: URL,
-           cachePolicy: NSURLRequest.CachePolicy,
-           completion: @escaping (_ result: Data?, _ response: URLResponse?,  _ error: Error?) -> Void) -> URLSessionDataTask
-}
-

--- a/Simplified/Network/NYPLSession.m
+++ b/Simplified/Network/NYPLSession.m
@@ -127,6 +127,8 @@ completionHandler:(void (^)(NSData *data,
   NSString *lpe = [URL lastPathComponent];
   if ([lpe isEqualToString:@"borrow"]) {
     [NYPLNetworkExecutor.shared PUT:URL
+                  additionalHeaders:nil
+                           httpBody:nil
                          completion:completionWrapper];
   } else {
     (void)[NYPLNetworkExecutor.shared GET:URL

--- a/Simplified/OPDS/NYPLOPDSFeedFetcher.swift
+++ b/Simplified/OPDS/NYPLOPDSFeedFetcher.swift
@@ -21,7 +21,7 @@ import Foundation
   ///   - Parameter completion: Always invoked at the end no matter what,
   ///   providing an ungrouped feed object in case of success and nil otherwise.
   class func fetchCatalogUngroupedFeed(url: URL?,
-                                       networkExecutor: NYPLRequestExecutingObjC,
+                                       networkExecutor: NYPLHTTPRequestExecutingBasic,
                                        retryCount: Int = 0,
                                        completion: @escaping (_ feed: NYPLCatalogUngroupedFeed?) -> Void) {
     guard let url = url else {
@@ -68,7 +68,7 @@ import Foundation
   ///   - Parameter completion: Always invoked at the end no matter what,
   ///   providing an OPDS feed object in case of success and an dictionary containing error information otherwise.
   class func fetchOPDSFeed(url: URL?,
-                           networkExecutor: NYPLRequestExecutingObjC,
+                           networkExecutor: NYPLHTTPRequestExecutingBasic,
                            shouldResetCache: Bool,
                            completion: @escaping (_ feed: NYPLOPDSFeed?, _ error: [String: Any]?) -> Void) {
     guard let url = url else {

--- a/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
@@ -13,7 +13,8 @@ protocol NYPLAnnotationSyncing: AnyObject {
   
   static func syncReadingPosition(ofBook bookID: String?,
                                   publication: Publication?,
-                                  toURL url:URL?,
+                                  toURL url: URL?,
+                                  usingNetworkExecutor executor: NYPLHTTPRequestExecutingBasic,
                                   completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ())
   
   static func postReadingPosition(forBook bookID: String, selectorValue: String)
@@ -43,7 +44,7 @@ protocol NYPLAnnotationSyncing: AnyObject {
   static func syncIsPossibleAndPermitted() -> Bool
 }
 
-@objcMembers final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
+final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
   // MARK: - Sync Settings
 
   /// Shows (if needed) the opt-in flow for syncing the user bookmarks and
@@ -57,11 +58,9 @@ protocol NYPLAnnotationSyncing: AnyObject {
   /// - Note: This flow will be run only for the user account on the currently
   /// selected library. Anything else will result in a no-op.
   /// - Parameters:
-  ///   - userAccount: the account to attempt to enable annotations-syncing on.
-  ///   - completion: if a network request is actually performed, this block
-  /// is guaranteed to be called on the Main queue. Otherwise, this is called
-  /// either on the same thread the function was invoked on or on the main
-  /// thread.
+  ///   - userAccount: The account to attempt to enable annotations-syncing on.
+  ///   - completion: Handler always called at the end of the process.
+  @objc
   class func requestServerSyncStatus(forAccount userAccount: NYPLUserAccount,
                                      completion: @escaping (_ enableSync: Bool) -> ()) {
     
@@ -79,36 +78,40 @@ protocol NYPLAnnotationSyncing: AnyObject {
       return
     }
 
-    self.permissionUrlRequest { (initialized, syncIsPermitted) in
+    self.fetchSyncStatus { (initialized, syncIsPermitted) in
 
       if (initialized && syncIsPermitted) {
         completion(true)
         settings.userHasSeenFirstTimeSyncMessage = true;
         Log.debug(#file, "Sync has already been enabled on the server. Enable here as well.")
         return
-      } else if (!initialized && settings.userHasSeenFirstTimeSyncMessage == false) {
+      }
+
+      if (!initialized && settings.userHasSeenFirstTimeSyncMessage == false) {
         Log.debug(#file, "Sync has never been initialized for the patron. Showing UIAlertController flow.")
+        NYPLMainThreadRun.asyncIfNeeded {
         #if OPENEBOOKS
-        let title = "Open eBooks Sync"
+          let title = "Open eBooks Sync"
         #else
-        let title = "SimplyE Sync"
+          let title = "SimplyE Sync"
         #endif
-        let message = "Enable sync to save your reading position and bookmarks to your other devices.\n\nYou can change this any time in Settings."
-        let alertController = UIAlertController.init(title: title, message: message, preferredStyle: .alert)
-        let notNowAction = UIAlertAction.init(title: "Not Now", style: .default, handler: { action in
-          completion(false)
-          settings.userHasSeenFirstTimeSyncMessage = true;
-        })
-        let enableSyncAction = UIAlertAction.init(title: "Enable Sync", style: .default, handler: { action in
-          self.updateServerSyncSetting(toEnabled: true) { success in
-            completion(success)
+          let message = "Enable sync to save your reading position and bookmarks to your other devices.\n\nYou can change this any time in Settings."
+          let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+          let notNowAction = UIAlertAction(title: "Not Now", style: .default) { action in
+            completion(false)
             settings.userHasSeenFirstTimeSyncMessage = true;
           }
-        })
-        alertController.addAction(notNowAction)
-        alertController.addAction(enableSyncAction)
-        alertController.preferredAction = enableSyncAction
-        NYPLAlertUtils.presentFromViewControllerOrNil(alertController: alertController, viewController: nil, animated: true, completion: nil)
+          let enableSyncAction = UIAlertAction(title: "Enable Sync", style: .default) { action in
+            self.updateServerSyncSetting(toEnabled: true) { success in
+              completion(success)
+              settings.userHasSeenFirstTimeSyncMessage = true;
+            }
+          }
+          alertController.addAction(notNowAction)
+          alertController.addAction(enableSyncAction)
+          alertController.preferredAction = enableSyncAction
+          NYPLAlertUtils.presentFromViewControllerOrNil(alertController: alertController, viewController: nil, animated: true, completion: nil)
+        }
       } else {
         completion(false)
       }
@@ -134,7 +137,7 @@ protocol NYPLAnnotationSyncing: AnyObject {
         return
       }
       let parameters = ["settings": ["simplified:synchronize_annotations": enabled]] as [String : Any]
-      syncSettingUrlRequest(userProfileUrl, parameters, 20, { success in
+      updateSyncSettings(at: userProfileUrl, parameters, { success in
         if !success {
           handleSyncSettingError()
         }
@@ -143,113 +146,74 @@ protocol NYPLAnnotationSyncing: AnyObject {
     }
   }
 
-
   /// - Parameter successHandler: Called only if the request succeeds.
-  /// Always called on the main thread.
-  private class func permissionUrlRequest(successHandler: @escaping (_ initialized: Bool, _ syncIsPermitted: Bool) -> ()) {
+  private class func fetchSyncStatus(successHandler: @escaping (_ initialized: Bool, _ syncIsPermitted: Bool) -> ()) {
 
     guard let userProfileUrl = URL(string: AccountsManager.shared.currentAccount?.details?.userProfileUrl ?? "") else {
       Log.error(#file, "Failed to create user profile URL from string. Abandoning attempt to retrieve sync setting.")
       return
     }
 
-    var request = URLRequest.init(url: userProfileUrl,
-                                  cachePolicy: .reloadIgnoringLocalCacheData,
-                                  timeoutInterval: 60)
-    request.httpMethod = "GET"
-    setDefaultAnnotationHeaders(forRequest: &request)
-
-    let dataTask = URLSession.shared.dataTask(with: request) { (data, response, error) in
-
-      DispatchQueue.main.async {
-
-        if let error = error as NSError? {
-          Log.error(#file, "Request Error Code: \(error.code). Description: \(error.localizedDescription)")
-          return
-        }
-        guard let data = data,
-          let response = (response as? HTTPURLResponse) else {
-            Log.error(#file, "No Data or No Server Response present after request.")
-            return
-        }
-
-        if response.statusCode == 200 {
-          if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String:Any],
-            let settings = json["settings"] as? [String:Any],
-            let syncSetting = settings["simplified:synchronize_annotations"] {
-            if syncSetting is NSNull {
-              successHandler(false, false)
-            } else {
-              successHandler(true, syncSetting as? Bool ?? false)
-            }
+    NYPLNetworkExecutor.shared.GET(userProfileUrl, cachePolicy: .reloadIgnoringCacheData) { result in
+      switch result {
+      case .success(let data, _):
+        if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String:Any],
+           let settings = json["settings"] as? [String:Any],
+           let syncSetting = settings["simplified:synchronize_annotations"] {
+          if syncSetting is NSNull {
+            successHandler(false, false)
           } else {
-            Log.error(#file, "Error parsing JSON or finding sync-setting key/value.")
+            successHandler(true, syncSetting as? Bool ?? false)
           }
         } else {
-          Log.error(#file, "Server response returned error code: \(response.statusCode))")
+          Log.error(#file, "Error parsing JSON or finding sync-setting key/value.")
         }
+      case .failure(let error, let response):
+        let httpStatus = (response as? HTTPURLResponse)?.statusCode ?? -1
+        Log.error(#file, "Error fetching annotations permissions: \(httpStatus); error: \(error)")
       }
     }
-    dataTask.resume()
   }
 
   /// - parameter completion: if a network request is actually performed, this
   /// is guaranteed to be called on the Main queue. Otherwise, this is called
   /// on the same thread the function was invoked on.
-  private class func syncSettingUrlRequest(_ url: URL,
-                                           _ parameters: [String:Any],
-                                           _ timeout: Double?,
-                                           _ completion: @escaping (Bool)->()) {
+  private class func updateSyncSettings(at url: URL,
+                                        _ parameters: [String:Any],
+                                        _ completion: @escaping (Bool)->()) {
     guard let jsonData = makeSubmissionData(fromRepresentation: parameters) else {
       Log.error(#file, "Network request abandoned. Could not create JSON from given parameters.")
       completion(false)
       return
     }
-    
-    var request = URLRequest(url: url)
-    request.httpMethod = "PUT"
-    request.httpBody = jsonData
-    setDefaultAnnotationHeaders(forRequest: &request)
-    request.setValue("vnd.librarysimplified/user-profile+json", forHTTPHeaderField: "Content-Type")
-    if let timeout = timeout {
-      request.timeoutInterval = timeout
-    }
-    
-    let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
 
-      DispatchQueue.main.async {
-
-        if let error = error as NSError? {
-          Log.error(#file, "Request Error Code: \(error.code). Description: \(error.localizedDescription)")
-          if NetworkQueue.StatusCodes.contains(error.code) {
-            self.addToOfflineQueue(nil, url, parameters)
-          }
-          completion(false)
-          return
+    NYPLNetworkExecutor.shared.PUT(url,
+                                   additionalHeaders: ["Content-Type": "vnd.librarysimplified/user-profile+json"],
+                                   httpBody: jsonData) { data, response, error in
+      if let error = error as NSError? {
+        let httpStatus = (response as? HTTPURLResponse)?.statusCode ?? -1
+        Log.error(#file, "Error updating sync settings, server returned: \(httpStatus)")
+        if NetworkQueue.StatusCodes.contains(error.code) {
+          self.addRequestToOfflineQueue(httpMethod: .PUT,
+                                        url: url,
+                                        parameters: parameters)
         }
-        guard let statusCode = (response as? HTTPURLResponse)?.statusCode else {
-          Log.error(#file, "No response received from server")
-          completion(false)
-          return
-        }
-
-        if statusCode == 200 {
-          completion(true)
-        } else {
-          Log.error(#file, "Server Response Error. Status Code: \(statusCode)")
-          completion(false)
-        }
+        completion(false)
+        return
       }
+
+      completion(true)
     }
-    task.resume()
   }
 
-  class func handleSyncSettingError() {
-    let title = NSLocalizedString("Error Changing Sync Setting", comment: "")
-    let message = NSLocalizedString("There was a problem contacting the server.\nPlease make sure you are connected to the internet, or try again later.", comment: "")
-    let alert = UIAlertController.init(title: title, message: message, preferredStyle: .alert)
-    alert.addAction(UIAlertAction.init(title: NSLocalizedString("OK", comment: ""), style: .default, handler: nil))
-    NYPLAlertUtils.presentFromViewControllerOrNil(alertController: alert, viewController: nil, animated: true, completion: nil)
+  private class func handleSyncSettingError() {
+    NYPLMainThreadRun.asyncIfNeeded {
+      let title = NSLocalizedString("Error Changing Sync Setting", comment: "")
+      let message = NSLocalizedString("There was a problem contacting the server.\nPlease make sure you are connected to the internet, or try again later.", comment: "")
+      let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+      alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default, handler: nil))
+      NYPLAlertUtils.presentFromViewControllerOrNil(alertController: alert, viewController: nil, animated: true, completion: nil)
+    }
   }
 
   // MARK: - Reading Position
@@ -259,6 +223,7 @@ protocol NYPLAnnotationSyncing: AnyObject {
   class func syncReadingPosition(ofBook bookID: String?,
                                  publication: Publication?,
                                  toURL url:URL?,
+                                 usingNetworkExecutor executor: NYPLHTTPRequestExecutingBasic,
                                  completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ()) {
 
     guard syncIsPossibleAndPermitted() else {
@@ -273,12 +238,8 @@ protocol NYPLAnnotationSyncing: AnyObject {
       return
     }
 
-    var request = URLRequest(url: url,
-                             cachePolicy: .reloadIgnoringLocalCacheData,
-                             timeoutInterval: NYPLDefaultRequestTimeout)
-    setDefaultAnnotationHeaders(forRequest: &request)
-
-    let dataTask = URLSession.shared.dataTask(with: request) { (data, _, error) in
+    _ = executor.GET(url,
+                     cachePolicy: .reloadIgnoringLocalCacheData) { data, _, error in
       let bookmarks = parseAnnotationsResponse(data,
                                                error: error,
                                                motivation: .readingProgress,
@@ -287,7 +248,6 @@ protocol NYPLAnnotationSyncing: AnyObject {
       let readPos = bookmarks?.first
       completion(readPos)
     }
-    dataTask.resume()
   }
 
   class func postReadingPosition(forBook bookID: String, selectorValue: String) {
@@ -338,12 +298,7 @@ protocol NYPLAnnotationSyncing: AnyObject {
       return
     }
 
-    var request = URLRequest(url: annotationURL,
-                             cachePolicy: .reloadIgnoringLocalCacheData,
-                             timeoutInterval: NYPLDefaultRequestTimeout)
-    setDefaultAnnotationHeaders(forRequest: &request)
-
-    let dataTask = URLSession.shared.dataTask(with: request) { (data, response, error) in
+    NYPLNetworkExecutor.shared.GET(annotationURL, cachePolicy: .reloadIgnoringLocalCacheData) { data, _, error in
       let bookmarks = parseAnnotationsResponse(data,
                                                error: error,
                                                motivation: .bookmark,
@@ -351,7 +306,6 @@ protocol NYPLAnnotationSyncing: AnyObject {
                                                bookID: bookID)
       completion(bookmarks)
     }
-    dataTask.resume()
   }
 
   class func deleteBookmarks(_ bookmarks: [NYPLReadiumBookmark]) {
@@ -389,32 +343,21 @@ protocol NYPLAnnotationSyncing: AnyObject {
       return
     }
 
-    var request = URLRequest(url: url)
-    request.httpMethod = "DELETE"
-    setDefaultAnnotationHeaders(forRequest: &request)
-    request.timeoutInterval = NYPLDefaultRequestTimeout
-    
-    let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
-      guard let statusCode = (response as? HTTPURLResponse)?.statusCode,
-            statusCode == 200
-      else {
-        let metadata: [String: Any] = ["annotationId": annotationId]
-        NYPLErrorLogger.logNetworkError(error,
-                                        code: .responseFail,
-                                        summary: "NYPLAnnotations::deleteBookmark error",
-                                        request: request,
-                                        response: response,
-                                        metadata: metadata)
+    NYPLNetworkExecutor.shared.DELETE(url) { result in
+      switch result {
+      case .success(_, _):
+        Log.info(#file, "200: DELETE bookmark success")
+        completionHandler(true)
+      case .failure(let error, let response):
+        NYPLErrorLogger.logError(error,
+                                 summary: "NYPLAnnotations::deleteBookmark error",
+                                 metadata: ["annotationId": annotationId,
+                                            "DELETE url": url,
+                                            "response": response ?? ""])
         completionHandler(false)
-        return
       }
-      
-      Log.info(#file, "200: DELETE bookmark success")
-      completionHandler(true)
     }
-    task.resume()
   }
-
 
   // Method is called when the SyncManager is syncing bookmarks
   // If an existing local bookmark is missing an annotationID, assume it still needs to be uploaded.
@@ -491,13 +434,13 @@ protocol NYPLAnnotationSyncing: AnyObject {
     }
   }
 
-  // MARK:- Helpers / Private methods
+  // MARK: - Helpers / Private methods
 
-  class func parseAnnotationsResponse(_ data: Data?,
-                                      error: Error?,
-                                      motivation: NYPLBookmarkSpec.Motivation,
-                                      publication: Publication?,
-                                      bookID: String) -> [NYPLReadiumBookmark]? {
+  private class func parseAnnotationsResponse(_ data: Data?,
+                                              error: Error?,
+                                              motivation: NYPLBookmarkSpec.Motivation,
+                                              publication: Publication?,
+                                              bookID: String) -> [NYPLReadiumBookmark]? {
     let metadata: [String: Any] = ["bookID": bookID,
                                    "motivation": motivation]
     if let error = error as NSError? {
@@ -538,18 +481,16 @@ protocol NYPLAnnotationSyncing: AnyObject {
   ///
   /// - Note: Does not log error reports to Crashlytics. That responsibility is
   /// left to the caller.
-  private class func postAnnotation(
-    forBook bookID: String,
-    withParameters parameters: [String: Any],
-    timeout: TimeInterval = NYPLDefaultRequestTimeout,
-    queueOffline: Bool,
-    _ completionHandler: @escaping (_ result: Result<String?, Error>) -> ()) {
+  private class func postAnnotation(forBook bookID: String,
+                                    withParameters parameters: [String: Any],
+                                    queueOffline: Bool,
+                                    _ completion: @escaping (_ result: Result<String?, Error>) -> ()) {
 
     guard let annotationsURL = NYPLAnnotations.annotationsURL else {
       let err = NSError(domain: "Error posting annotation",
                         code: NYPLErrorCode.appLogicInconsistency.rawValue,
                         userInfo: ["Reason": "annotationsURL is nil"])
-      completionHandler(.failure(err))
+      completion(.failure(err))
       return
     }
 
@@ -558,44 +499,29 @@ protocol NYPLAnnotationSyncing: AnyObject {
                         code: NYPLErrorCode.serializationFail.rawValue,
                         userInfo: ["Reason": "Could not create JSON body from input params",
                                    "Serializable annotation params": parameters])
-      completionHandler(.failure(err))
+      completion(.failure(err))
       return
     }
 
-    var request = URLRequest(url: annotationsURL)
-    request.httpMethod = "POST"
-    request.httpBody = jsonData
-    setDefaultAnnotationHeaders(forRequest: &request)
-    request.timeoutInterval = timeout
-
-    let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
-      if let err = error as NSError? {
+    NYPLNetworkExecutor.shared.POST(annotationsURL,
+                                    httpBody: jsonData) { result in
+      switch result {
+      case .success(let data, _):
+        Log.info(#file, "Annotation POST for bookID \(bookID): Success 200.")
+        let serverAnnotationID = annotationID(fromNetworkData: data)
+        completion(.success(serverAnnotationID))
+      case .failure(let error, _):
+        let err = error as NSError
         Log.error(#file, "Annotation POST for bookID \(bookID): Error (nsCode: \(err.code) Description: \(err.localizedDescription))")
         if NetworkQueue.StatusCodes.contains(err.code) && queueOffline {
-          self.addToOfflineQueue(bookID, annotationsURL, parameters)
+          self.addRequestToOfflineQueue(httpMethod: .POST,
+                                        url: annotationsURL,
+                                        bookID: bookID,
+                                        parameters: parameters)
         }
-        completionHandler(.failure(err))
-        return
+        completion(.failure(err))
       }
-
-      guard let statusCode = (response as? HTTPURLResponse)?.statusCode,
-            statusCode == 200
-      else {
-        let err = NSError(domain: "Error posting annotation",
-                          code: NYPLErrorCode.responseFail.rawValue,
-                          userInfo: [
-                            "Serializable annotation params": parameters,
-                            NSError.httpResponseKey: response ?? "N/A"
-                          ])
-        completionHandler(.failure(err))
-        return
-      }
-
-      Log.info(#file, "Annotation POST for bookID \(bookID): Success 200.")
-      let serverAnnotationID = annotationID(fromNetworkData: data)
-      completionHandler(.success(serverAnnotationID))
     }
-    task.resume()
   }
 
   private class func annotationID(fromNetworkData data: Data?) -> String? {
@@ -631,41 +557,28 @@ protocol NYPLAnnotationSyncing: AnyObject {
     return NYPLConfiguration.mainFeedURL()?.appendingPathComponent("annotations/")
   }
 
-  private class func setDefaultAnnotationHeaders(forRequest request: inout URLRequest) {
-    for (headerKey, headerValue) in NYPLAnnotations.headers {
-      request.setValue(headerValue, forHTTPHeaderField: headerKey)
-    }
-  }
-
-  class var headers: [String:String] {
-    if let barcode = NYPLUserAccount.sharedAccount().barcode, let pin = NYPLUserAccount.sharedAccount().PIN {
-      let authenticationString = "\(barcode):\(pin)"
-      if let authenticationData = authenticationString.data(using: String.Encoding.ascii) {
-        let authenticationValue = "Basic \(authenticationData.base64EncodedString(options: .lineLength64Characters))"
-        return ["Authorization" : "\(authenticationValue)",
-                "Content-Type" : "application/json"]
-      } else {
-        Log.error(#file, "Error formatting auth headers.")
-      }
-    } else if let authToken = NYPLUserAccount.sharedAccount().authToken {
-        let authenticationValue = "Bearer \(authToken)"
-        return ["Authorization" : "\(authenticationValue)",
-            "Content-Type" : "application/json"]
-    } else {
-      Log.error(#file, "Attempted to create authorization header with neither an oauth token nor a barcode and pin pair.")
-    }
-    return ["Authorization" : "",
-            "Content-Type" : "application/json"]
-  }
-
   class func makeSubmissionData(fromRepresentation dict: [String: Any]) -> Data? {
     return try? JSONSerialization.data(withJSONObject: dict,
                                        options: [.prettyPrinted])
   }
 
-  private class func addToOfflineQueue(_ bookID: String?, _ url: URL, _ parameters: [String:Any]) {
+  private class func addRequestToOfflineQueue(httpMethod: NetworkQueue.HTTPMethodType,
+                                              url: URL,
+                                              bookID: String? = nil,
+                                              parameters: [String:Any]) {
     let libraryID = AccountsManager.shared.currentAccount?.uuid ?? ""
     let parameterData = makeSubmissionData(fromRepresentation: parameters)
-    NetworkQueue.shared().addRequest(libraryID, bookID, url, .POST, parameterData, headers)
+    NetworkQueue.shared.addRequest(libraryID, bookID, url, httpMethod, parameterData)
+  }
+}
+
+extension NYPLAnnotations {
+  class func test_parseAnnotationsResponse(_ data: Data?,
+                                           error: Error?,
+                                           motivation: NYPLBookmarkSpec.Motivation,
+                                           publication: Publication?,
+                                           bookID: String) -> [NYPLReadiumBookmark]? {
+    parseAnnotationsResponse(data, error: error, motivation: motivation,
+                             publication: publication, bookID: bookID)
   }
 }

--- a/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionPoster.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionPoster.swift
@@ -107,11 +107,13 @@ class NYPLLastReadPositionPoster {
 
   /// Wrapper for actual api call.
   private func postQueuedReadPosition() {
-    if self.queuedReadPosition != "" {
-      annotationsSynchronizer.postReadingPosition(forBook: book.identifier,
-                                          selectorValue: self.queuedReadPosition)
-      self.queuedReadPosition = ""
-      self.lastReadPositionUploadDate = Date()
+    guard self.queuedReadPosition != "" else {
+      return
     }
+
+    annotationsSynchronizer.postReadingPosition(forBook: book.identifier,
+                                                selectorValue: queuedReadPosition)
+    self.queuedReadPosition = ""
+    self.lastReadPositionUploadDate = Date()
   }
 }

--- a/Simplified/Reader2/UI/NYPLReaderPositionsVC.swift
+++ b/Simplified/Reader2/UI/NYPLReaderPositionsVC.swift
@@ -240,8 +240,10 @@ class NYPLReaderPositionsVC: UIViewController, UITableViewDataSource, UITableVie
       }
       
       if let removedBookmark = bookmarksBusinessLogic?.deleteBookmark(at: indexPath.row) {
-        delegate?.positionsVC(self, didDeleteBookmark: removedBookmark)
-        tableView.deleteRows(at: [indexPath], with: .fade)
+        NYPLMainThreadRun.asyncIfNeeded {
+          self.delegate?.positionsVC(self, didDeleteBookmark: removedBookmark)
+          self.tableView.deleteRows(at: [indexPath], with: .fade)
+        }
       }
     }
   }

--- a/Simplified/Settings/NYPLSettingsAdvancedViewController.swift
+++ b/Simplified/Settings/NYPLSettingsAdvancedViewController.swift
@@ -65,14 +65,16 @@ import UIKit
     alert.view.addSubview(loadingIndicator)
     present(alert, animated: true, completion: nil)
 
-    NYPLAnnotations.updateServerSyncSetting(toEnabled: false, completion: { success in
-      self.dismiss(animated: true, completion: nil)
-      if (success) {
-        self.account.details?.syncPermissionGranted = false;
-        NYPLSettings.shared.userHasSeenFirstTimeSyncMessage = false;
-        self.navigationController?.popViewController(animated: true)
+    NYPLAnnotations.updateServerSyncSetting(toEnabled: false) { success in
+      NYPLMainThreadRun.asyncIfNeeded {
+        self.dismiss(animated: true, completion: nil)
+        if success {
+          self.account.details?.syncPermissionGranted = false
+          NYPLSettings.shared.userHasSeenFirstTimeSyncMessage = false
+          self.navigationController?.popViewController(animated: true)
+        }
       }
-    })
+    }
   }
   
   // MARK: - UITableViewDataSource

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
@@ -24,13 +24,16 @@ extension NYPLSignInBusinessLogic {
   /// - Parameters:
   ///   - granted: Whether the user is granting sync permission or not.
   ///   - postServerSyncCompletion: Only run when granting sync permission.
+  ///   This closure is run on the main thread.
   @objc func changeSyncPermission(to granted: Bool,
                                   postServerSyncCompletion: @escaping (Bool) -> Void) {
     if granted {
       // When granting, attempt to enable on the server.
       NYPLAnnotations.updateServerSyncSetting(toEnabled: true) { success in
         self.libraryAccount?.details?.syncPermissionGranted = success
-        postServerSyncCompletion(success)
+        NYPLMainThreadRun.asyncIfNeeded {
+          postServerSyncCompletion(success)
+        }
       }
     } else {
       // When revoking, just ignore the server's annotations.

--- a/SimplifiedTests/Bookmarks/NYPLAnnotationResponseTests.swift
+++ b/SimplifiedTests/Bookmarks/NYPLAnnotationResponseTests.swift
@@ -35,11 +35,12 @@ class NYPLAnnotationResponseTests: XCTestCase {
 
   func testParseAnnotationsResponseForReadingProgress() throws {
     // test
-    let annotations = NYPLAnnotations.parseAnnotationsResponse(responseData,
-                                                               error: nil,
-                                                               motivation: .readingProgress,
-                                                               publication: publication,
-                                                               bookID: bookID)
+    let annotations = NYPLAnnotations.test_parseAnnotationsResponse(
+      responseData,
+      error: nil,
+      motivation: .readingProgress,
+      publication: publication,
+      bookID: bookID)
 
     // verify
     XCTAssertNotNil(annotations)
@@ -57,11 +58,12 @@ class NYPLAnnotationResponseTests: XCTestCase {
 
   func testParseAnnotationsResponseForBookmarks() throws {
     // test
-    let annotations = NYPLAnnotations.parseAnnotationsResponse(responseData,
-                                                               error: nil,
-                                                               motivation: .bookmark,
-                                                               publication: publication,
-                                                               bookID: bookID)
+    let annotations = NYPLAnnotations.test_parseAnnotationsResponse(
+      responseData,
+      error: nil,
+      motivation: .bookmark,
+      publication: publication,
+      bookID: bookID)
 
     // verify
     XCTAssertNotNil(annotations)

--- a/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
+++ b/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
@@ -34,6 +34,7 @@ class NYPLAnnotationsMock: NYPLAnnotationSyncing {
   static func syncReadingPosition(ofBook bookID: String?,
                                   publication: Publication?,
                                   toURL url:URL?,
+                                  usingNetworkExecutor: NYPLHTTPRequestExecutingBasic,
                                   completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ()) {
     guard !failRequest,
           let id = bookID,

--- a/SimplifiedTests/Mocks/NYPLOPDSFeedFetcherMock.swift
+++ b/SimplifiedTests/Mocks/NYPLOPDSFeedFetcherMock.swift
@@ -45,7 +45,7 @@ class NYPLOPDSFeedFetcherMock: NYPLOPDSFeedFetcher {
   
   // Overriding this function in order to mimick the response from server
   override class func fetchOPDSFeed(url: URL?,
-                                    networkExecutor: NYPLRequestExecutingObjC,
+                                    networkExecutor: NYPLHTTPRequestExecutingBasic,
                                     shouldResetCache: Bool,
                                     completion: @escaping (NYPLOPDSFeed?, [String : Any]?) -> Void) {
     var requestURL = url

--- a/SimplifiedTests/NYPLCatalogUngroupedFeedTests.swift
+++ b/SimplifiedTests/NYPLCatalogUngroupedFeedTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class NYPLCatalogUngroupedFeedTests: XCTestCase {
   
   var feedFetcher: NYPLOPDSFeedFetcherMock.Type!
-  var networkExecutor: NYPLRequestExecutingObjC!
+  var networkExecutor: NYPLHTTPRequestExecutingBasic!
   
   override func setUpWithError() throws {
     try super.setUpWithError()


### PR DESCRIPTION
**What's this do?**
Routes all annotations calls to our centralized network layer so that they can take advantage of caching, bearer token refresh, etc.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/IOS-335

**How should this be tested? / Do these changes have associated tests?**
I think a regression focused on bookmarks and reading position should cover this. There are no user-level changes.

**Dependencies for merging? Releasing to production?**
required for 2.4.0 release.

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
not yet. There's another PR I will submit after this.

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 