### PR TITLE
iOS-390/391 Implement audiobook download in background

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -138,6 +138,9 @@
 		17843D1E278527B2000D488E /* NYPLCatalogUngroupedFeedWithSupportedBooks.xml in Resources */ = {isa = PBXBuildFile; fileRef = 17843D1C278527B2000D488E /* NYPLCatalogUngroupedFeedWithSupportedBooks.xml */; };
 		17843D2327853914000D488E /* NYPLOPDSFeedFetcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17843D2227853914000D488E /* NYPLOPDSFeedFetcherMock.swift */; };
 		17843D2427853914000D488E /* NYPLOPDSFeedFetcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17843D2227853914000D488E /* NYPLOPDSFeedFetcherMock.swift */; };
+		1785228C27F52B58004445ED /* AudiobookManifestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1785228B27F52B58004445ED /* AudiobookManifestHelper.swift */; };
+		1785228D27F52B59004445ED /* AudiobookManifestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1785228B27F52B58004445ED /* AudiobookManifestHelper.swift */; };
+		1785228E27F52B59004445ED /* AudiobookManifestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1785228B27F52B58004445ED /* AudiobookManifestHelper.swift */; };
 		178AD3E8276053BE003A6C12 /* NYPLAnnotationsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178AD3E7276053BE003A6C12 /* NYPLAnnotationsMock.swift */; };
 		178AD3F8276C7638003A6C12 /* NYPLAnnotationsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178AD3E7276053BE003A6C12 /* NYPLAnnotationsMock.swift */; };
 		1798538B255A4092009F94D9 /* NYPLBookLocation+Locator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1798538A255A4092009F94D9 /* NYPLBookLocation+Locator.swift */; };
@@ -1798,6 +1801,7 @@
 		17843D1927851853000D488E /* NYPLCatalogUngroupedFeedWithUnsupportedBooks.xml */ = {isa = PBXFileReference; explicitFileType = text.xml; path = NYPLCatalogUngroupedFeedWithUnsupportedBooks.xml; sourceTree = "<group>"; };
 		17843D1C278527B2000D488E /* NYPLCatalogUngroupedFeedWithSupportedBooks.xml */ = {isa = PBXFileReference; explicitFileType = text.xml; path = NYPLCatalogUngroupedFeedWithSupportedBooks.xml; sourceTree = "<group>"; };
 		17843D2227853914000D488E /* NYPLOPDSFeedFetcherMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLOPDSFeedFetcherMock.swift; sourceTree = "<group>"; };
+		1785228B27F52B58004445ED /* AudiobookManifestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookManifestHelper.swift; sourceTree = "<group>"; };
 		178AD3E7276053BE003A6C12 /* NYPLAnnotationsMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAnnotationsMock.swift; sourceTree = "<group>"; };
 		1798538A255A4092009F94D9 /* NYPLBookLocation+Locator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLBookLocation+Locator.swift"; sourceTree = "<group>"; };
 		17A5AB4E25D201BD005DFF05 /* LCPPassphraseAuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPPassphraseAuthenticationService.swift; sourceTree = "<group>"; };
@@ -2526,6 +2530,7 @@
 				A92FB0F821CDCE3D004740F4 /* NYPLReturnPromptHelper.swift */,
 				21EC1B8E2501538600A12384 /* AudioBookVendors+Extensions.swift */,
 				2198F90F250A90EE000D9DAB /* AudioBookVendorsHelper.swift */,
+				1785228B27F52B58004445ED /* AudiobookManifestHelper.swift */,
 			);
 			path = Audiobooks;
 			sourceTree = "<group>";
@@ -4356,6 +4361,7 @@
 				7327528E2578D69300A073E2 /* URLResponse+NYPLAuthentication.swift in Sources */,
 				739E6070244A0D8600D00301 /* OPDS2CatalogsFeed.swift in Sources */,
 				739E6071244A0D8600D00301 /* BundledHTMLViewController.swift in Sources */,
+				1785228D27F52B59004445ED /* AudiobookManifestHelper.swift in Sources */,
 				739E6072244A0D8600D00301 /* NYPLBookDetailView.m in Sources */,
 				739E6073244A0D8600D00301 /* UIButton+NYPLAppearanceAdditions.m in Sources */,
 				21DDE32925D2CEFC002CBCE3 /* AdobeDRMContentProtection.swift in Sources */,
@@ -4688,6 +4694,7 @@
 				73EB0ACD25821DF4006BC997 /* NYPLMyBooksDownloadInfo.m in Sources */,
 				73EB0ACE25821DF4006BC997 /* NYPLBookLocation.m in Sources */,
 				73EB0ACF25821DF4006BC997 /* NYPLFacetView.m in Sources */,
+				1785228E27F52B59004445ED /* AudiobookManifestHelper.swift in Sources */,
 				2126FE3C25C059810095C45C /* ReaderError.swift in Sources */,
 				73EB0AD125821DF4006BC997 /* ProblemReportEmail.swift in Sources */,
 				73EB0AD225821DF4006BC997 /* NYPLBookCellDelegate.m in Sources */,
@@ -5109,6 +5116,7 @@
 				73A794A625477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift in Sources */,
 				B51C1DFA2285FDF9003B49A5 /* OPDS2CatalogsFeed.swift in Sources */,
 				2D62568B1D412BCB0080A81F /* BundledHTMLViewController.swift in Sources */,
+				1785228C27F52B58004445ED /* AudiobookManifestHelper.swift in Sources */,
 				110AF8961961D94D004887C3 /* NYPLBookDetailView.m in Sources */,
 				21DDE32825D2CEFC002CBCE3 /* AdobeDRMContentProtection.swift in Sources */,
 				73B80BAB25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift in Sources */,

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -123,6 +123,9 @@
 		17536B9F26A8CDF00089C40F /* NYPLBookDetailView+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17536B9D26A8CDF00089C40F /* NYPLBookDetailView+Accessibility.swift */; };
 		17536BA026A8CDF00089C40F /* NYPLBookDetailView+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17536B9D26A8CDF00089C40F /* NYPLBookDetailView+Accessibility.swift */; };
 		17536BA126A8CDF00089C40F /* NYPLBookDetailView+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17536B9D26A8CDF00089C40F /* NYPLBookDetailView+Accessibility.swift */; };
+		175B91E527FE7693007EB7BB /* NYPLMyBooksDownloadCenter+AudiobooksDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175B91E427FE7693007EB7BB /* NYPLMyBooksDownloadCenter+AudiobooksDownload.swift */; };
+		175B91E627FE7693007EB7BB /* NYPLMyBooksDownloadCenter+AudiobooksDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175B91E427FE7693007EB7BB /* NYPLMyBooksDownloadCenter+AudiobooksDownload.swift */; };
+		175B91E727FE7693007EB7BB /* NYPLMyBooksDownloadCenter+AudiobooksDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175B91E427FE7693007EB7BB /* NYPLMyBooksDownloadCenter+AudiobooksDownload.swift */; };
 		175E480824EF36520066A6CF /* NYPLAnnouncementBusinessLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175E480724EF36520066A6CF /* NYPLAnnouncementBusinessLogic.swift */; };
 		17631AED25E488CD006079C4 /* NYPLAgeCheckViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17631AEC25E488CD006079C4 /* NYPLAgeCheckViewController.swift */; };
 		17631AEE25E488CD006079C4 /* NYPLAgeCheckViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17631AEC25E488CD006079C4 /* NYPLAgeCheckViewController.swift */; };
@@ -138,9 +141,12 @@
 		17843D1E278527B2000D488E /* NYPLCatalogUngroupedFeedWithSupportedBooks.xml in Resources */ = {isa = PBXBuildFile; fileRef = 17843D1C278527B2000D488E /* NYPLCatalogUngroupedFeedWithSupportedBooks.xml */; };
 		17843D2327853914000D488E /* NYPLOPDSFeedFetcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17843D2227853914000D488E /* NYPLOPDSFeedFetcherMock.swift */; };
 		17843D2427853914000D488E /* NYPLOPDSFeedFetcherMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17843D2227853914000D488E /* NYPLOPDSFeedFetcherMock.swift */; };
-		1785228C27F52B58004445ED /* AudiobookManifestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1785228B27F52B58004445ED /* AudiobookManifestHelper.swift */; };
-		1785228D27F52B59004445ED /* AudiobookManifestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1785228B27F52B58004445ED /* AudiobookManifestHelper.swift */; };
-		1785228E27F52B59004445ED /* AudiobookManifestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1785228B27F52B58004445ED /* AudiobookManifestHelper.swift */; };
+		1785228C27F52B58004445ED /* AudiobookManifestAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1785228B27F52B58004445ED /* AudiobookManifestAdapter.swift */; };
+		1785228D27F52B59004445ED /* AudiobookManifestAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1785228B27F52B58004445ED /* AudiobookManifestAdapter.swift */; };
+		1785228E27F52B59004445ED /* AudiobookManifestAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1785228B27F52B58004445ED /* AudiobookManifestAdapter.swift */; };
+		1785229427F7B955004445ED /* NYPLAudiobookDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1785229327F7B955004445ED /* NYPLAudiobookDownloader.swift */; };
+		1785229527F7B955004445ED /* NYPLAudiobookDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1785229327F7B955004445ED /* NYPLAudiobookDownloader.swift */; };
+		1785229627F7B955004445ED /* NYPLAudiobookDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1785229327F7B955004445ED /* NYPLAudiobookDownloader.swift */; };
 		178AD3E8276053BE003A6C12 /* NYPLAnnotationsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178AD3E7276053BE003A6C12 /* NYPLAnnotationsMock.swift */; };
 		178AD3F8276C7638003A6C12 /* NYPLAnnotationsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178AD3E7276053BE003A6C12 /* NYPLAnnotationsMock.swift */; };
 		1798538B255A4092009F94D9 /* NYPLBookLocation+Locator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1798538A255A4092009F94D9 /* NYPLBookLocation+Locator.swift */; };
@@ -1792,6 +1798,7 @@
 		172F410926F3BAF70017476A /* NYPLConfiguration+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLConfiguration+Color.swift"; sourceTree = "<group>"; };
 		173F0822241AAA4E00A64658 /* NYPLBookStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBookStateTests.swift; sourceTree = "<group>"; };
 		17536B9D26A8CDF00089C40F /* NYPLBookDetailView+Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLBookDetailView+Accessibility.swift"; sourceTree = "<group>"; };
+		175B91E427FE7693007EB7BB /* NYPLMyBooksDownloadCenter+AudiobooksDownload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLMyBooksDownloadCenter+AudiobooksDownload.swift"; sourceTree = "<group>"; };
 		175E480724EF36520066A6CF /* NYPLAnnouncementBusinessLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAnnouncementBusinessLogic.swift; sourceTree = "<group>"; };
 		17631AEC25E488CD006079C4 /* NYPLAgeCheckViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAgeCheckViewController.swift; sourceTree = "<group>"; };
 		1763C0D524F460FE00A4D0E2 /* NYPLAnnouncementManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAnnouncementManagerTests.swift; sourceTree = "<group>"; };
@@ -1801,7 +1808,8 @@
 		17843D1927851853000D488E /* NYPLCatalogUngroupedFeedWithUnsupportedBooks.xml */ = {isa = PBXFileReference; explicitFileType = text.xml; path = NYPLCatalogUngroupedFeedWithUnsupportedBooks.xml; sourceTree = "<group>"; };
 		17843D1C278527B2000D488E /* NYPLCatalogUngroupedFeedWithSupportedBooks.xml */ = {isa = PBXFileReference; explicitFileType = text.xml; path = NYPLCatalogUngroupedFeedWithSupportedBooks.xml; sourceTree = "<group>"; };
 		17843D2227853914000D488E /* NYPLOPDSFeedFetcherMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLOPDSFeedFetcherMock.swift; sourceTree = "<group>"; };
-		1785228B27F52B58004445ED /* AudiobookManifestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookManifestHelper.swift; sourceTree = "<group>"; };
+		1785228B27F52B58004445ED /* AudiobookManifestAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookManifestAdapter.swift; sourceTree = "<group>"; };
+		1785229327F7B955004445ED /* NYPLAudiobookDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAudiobookDownloader.swift; sourceTree = "<group>"; };
 		178AD3E7276053BE003A6C12 /* NYPLAnnotationsMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAnnotationsMock.swift; sourceTree = "<group>"; };
 		1798538A255A4092009F94D9 /* NYPLBookLocation+Locator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLBookLocation+Locator.swift"; sourceTree = "<group>"; };
 		17A5AB4E25D201BD005DFF05 /* LCPPassphraseAuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPPassphraseAuthenticationService.swift; sourceTree = "<group>"; };
@@ -2530,7 +2538,8 @@
 				A92FB0F821CDCE3D004740F4 /* NYPLReturnPromptHelper.swift */,
 				21EC1B8E2501538600A12384 /* AudioBookVendors+Extensions.swift */,
 				2198F90F250A90EE000D9DAB /* AudioBookVendorsHelper.swift */,
-				1785228B27F52B58004445ED /* AudiobookManifestHelper.swift */,
+				1785228B27F52B58004445ED /* AudiobookManifestAdapter.swift */,
+				1785229327F7B955004445ED /* NYPLAudiobookDownloader.swift */,
 			);
 			path = Audiobooks;
 			sourceTree = "<group>";
@@ -2958,6 +2967,7 @@
 				2DEF10B9201ECCEA0082843A /* NYPLMyBooksSimplifiedBearerToken.m */,
 				116A5EB1194767DC00491A21 /* NYPLMyBooksViewController.h */,
 				116A5EB2194767DC00491A21 /* NYPLMyBooksViewController.m */,
+				175B91E427FE7693007EB7BB /* NYPLMyBooksDownloadCenter+AudiobooksDownload.swift */,
 			);
 			path = MyBooks;
 			sourceTree = "<group>";
@@ -4361,7 +4371,7 @@
 				7327528E2578D69300A073E2 /* URLResponse+NYPLAuthentication.swift in Sources */,
 				739E6070244A0D8600D00301 /* OPDS2CatalogsFeed.swift in Sources */,
 				739E6071244A0D8600D00301 /* BundledHTMLViewController.swift in Sources */,
-				1785228D27F52B59004445ED /* AudiobookManifestHelper.swift in Sources */,
+				1785228D27F52B59004445ED /* AudiobookManifestAdapter.swift in Sources */,
 				739E6072244A0D8600D00301 /* NYPLBookDetailView.m in Sources */,
 				739E6073244A0D8600D00301 /* UIButton+NYPLAppearanceAdditions.m in Sources */,
 				21DDE32925D2CEFC002CBCE3 /* AdobeDRMContentProtection.swift in Sources */,
@@ -4413,6 +4423,7 @@
 				73A172FB27ADA6FA005E7BCF /* NYPLAxisBookReadingAdapter.swift in Sources */,
 				739E6093244A0D8600D00301 /* NYPLBookDownloadingCell.m in Sources */,
 				730B7869249AB9D7008F28B3 /* Float+NYPLAdditions.swift in Sources */,
+				1785229527F7B955004445ED /* NYPLAudiobookDownloader.swift in Sources */,
 				2171ADA3251E38150003CABA /* LCPLibraryService.swift in Sources */,
 				739E6094244A0D8600D00301 /* NYPLTenPrintCoverView+NYPLImageAdditions.m in Sources */,
 				7353D3F7253E115F00EA2C46 /* NYPLSignInBusinessLogicUIDelegate.swift in Sources */,
@@ -4533,6 +4544,7 @@
 				73BF0CCE245769D80009FC61 /* NYPLReaderTOCCell.swift in Sources */,
 				739E60E9244A0D8600D00301 /* NYPLMyBooksSimplifiedBearerToken.m in Sources */,
 				739E60EA244A0D8600D00301 /* NYPLAnnotations.swift in Sources */,
+				175B91E627FE7693007EB7BB /* NYPLMyBooksDownloadCenter+AudiobooksDownload.swift in Sources */,
 				739E60EB244A0D8600D00301 /* RemoteHTMLViewController.swift in Sources */,
 				2126FE6325C0890E0095C45C /* ReaderFormatModule.swift in Sources */,
 				7342702424DCB26700A4F605 /* URLResponse+NYPL.swift in Sources */,
@@ -4687,6 +4699,7 @@
 				73EB0AC725821DF4006BC997 /* AudioBookVendorsHelper.swift in Sources */,
 				73D8D28025A68D4300DF5F69 /* NYPLBookLocation+Locator.swift in Sources */,
 				73EB0AC925821DF4006BC997 /* NYPLBarcode.swift in Sources */,
+				1785229627F7B955004445ED /* NYPLAudiobookDownloader.swift in Sources */,
 				73EB0ACA25821DF4006BC997 /* NYPLSession.m in Sources */,
 				73EB0ACB25821DF4006BC997 /* NYPLSettingsEULAViewController.m in Sources */,
 				73EB0ACC25821DF4006BC997 /* NYPLPresentationUtils.swift in Sources */,
@@ -4694,7 +4707,7 @@
 				73EB0ACD25821DF4006BC997 /* NYPLMyBooksDownloadInfo.m in Sources */,
 				73EB0ACE25821DF4006BC997 /* NYPLBookLocation.m in Sources */,
 				73EB0ACF25821DF4006BC997 /* NYPLFacetView.m in Sources */,
-				1785228E27F52B59004445ED /* AudiobookManifestHelper.swift in Sources */,
+				1785228E27F52B59004445ED /* AudiobookManifestAdapter.swift in Sources */,
 				2126FE3C25C059810095C45C /* ReaderError.swift in Sources */,
 				73EB0AD125821DF4006BC997 /* ProblemReportEmail.swift in Sources */,
 				73EB0AD225821DF4006BC997 /* NYPLBookCellDelegate.m in Sources */,
@@ -4705,6 +4718,7 @@
 				73EB0AD725821DF4006BC997 /* NYPLMigrationManager.swift in Sources */,
 				73EB0AD825821DF4006BC997 /* NYPLSettingsSplitViewController.m in Sources */,
 				73EB0AD925821DF4006BC997 /* Date+NYPLAdditions.swift in Sources */,
+				175B91E727FE7693007EB7BB /* NYPLMyBooksDownloadCenter+AudiobooksDownload.swift in Sources */,
 				73EB0ADA25821DF4006BC997 /* NYPLBasicAuth.swift in Sources */,
 				73EB0ADB25821DF4006BC997 /* OPDS2AuthenticationDocument.swift in Sources */,
 				73EB0ADC25821DF4006BC997 /* NYPLCatalogs+SE.swift in Sources */,
@@ -5116,7 +5130,7 @@
 				73A794A625477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift in Sources */,
 				B51C1DFA2285FDF9003B49A5 /* OPDS2CatalogsFeed.swift in Sources */,
 				2D62568B1D412BCB0080A81F /* BundledHTMLViewController.swift in Sources */,
-				1785228C27F52B58004445ED /* AudiobookManifestHelper.swift in Sources */,
+				1785228C27F52B58004445ED /* AudiobookManifestAdapter.swift in Sources */,
 				110AF8961961D94D004887C3 /* NYPLBookDetailView.m in Sources */,
 				21DDE32825D2CEFC002CBCE3 /* AdobeDRMContentProtection.swift in Sources */,
 				73B80BAB25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift in Sources */,
@@ -5168,6 +5182,7 @@
 				73A172E527ADA6F9005E7BCF /* NYPLAxisBookReadingAdapter.swift in Sources */,
 				11B6020519806CD300800DA9 /* NYPLBookDownloadingCell.m in Sources */,
 				114B7F161A3644CF00B8582B /* NYPLTenPrintCoverView+NYPLImageAdditions.m in Sources */,
+				1785229427F7B955004445ED /* NYPLAudiobookDownloader.swift in Sources */,
 				7364D69C2492A38C0087B056 /* Publication+NYPLAdditions.swift in Sources */,
 				733875652423E1B0000FEB67 /* NYPLNetworkExecutor.swift in Sources */,
 				733FF9BE2530F9E700CDAA13 /* NYPLSignInBusinessLogic+OAuth.swift in Sources */,
@@ -5288,6 +5303,7 @@
 				21EC1B8F2501538600A12384 /* AudioBookVendors+Extensions.swift in Sources */,
 				730EE001251567820038DD9F /* NYPLLibraryNavigationController.m in Sources */,
 				E6BA02B81DE4B6F600F76404 /* RemoteHTMLViewController.swift in Sources */,
+				175B91E527FE7693007EB7BB /* NYPLMyBooksDownloadCenter+AudiobooksDownload.swift in Sources */,
 				2126FE6225C0890E0095C45C /* ReaderFormatModule.swift in Sources */,
 				8CE9C471237F84820072E964 /* NYPLBookDetailsProblemDocumentViewController.swift in Sources */,
 				73A2299B240F3B9B006B9EAD /* NYPLR2Owner.swift in Sources */,

--- a/Simplified/Audiobooks/AudiobookManifestAdapter.swift
+++ b/Simplified/Audiobooks/AudiobookManifestAdapter.swift
@@ -9,8 +9,11 @@
 
 import Foundation
 import NYPLAudiobookToolkit
-import OverdriveProcessor
 import UIKit
+
+#if FEATURE_OVERDRIVE_AUTH
+import OverdriveProcessor
+#endif
 
 @objc enum AudiobookManifestError: Int {
   case none

--- a/Simplified/Audiobooks/AudiobookManifestAdapter.swift
+++ b/Simplified/Audiobooks/AudiobookManifestAdapter.swift
@@ -18,11 +18,11 @@ import UIKit
   case corrupted
 }
 
-@objc class AudiobookManifestHelper: NSObject {
-  @objc class func parseAudiobookManifest(book: NYPLBook,
-                                          completion: @escaping (_ manifest: [String: Any]?,
-                                                                 _ decryptor: DRMDecryptor?,
-                                                                 _ error: AudiobookManifestError) -> Void)
+@objc class AudiobookManifestAdapter: NSObject {
+  @objc class func transformAudiobookManifest(book: NYPLBook,
+                                              completion: @escaping (_ manifest: [String: Any]?,
+                                                                     _ decryptor: DRMDecryptor?,
+                                                                     _ error: AudiobookManifestError) -> Void)
   {
     guard let url = NYPLMyBooksDownloadCenter.shared().fileURL(forBookIndentifier: book.identifier),
           let data = try? Data.init(contentsOf: url),

--- a/Simplified/Audiobooks/AudiobookManifestAdapter.swift
+++ b/Simplified/Audiobooks/AudiobookManifestAdapter.swift
@@ -22,17 +22,22 @@ import OverdriveProcessor
 }
 
 @objc class AudiobookManifestAdapter: NSObject {
-  @objc class func transformAudiobookManifest(book: NYPLBook,
-                                              completion: @escaping (_ manifest: [String: Any]?,
-                                                                     _ decryptor: DRMDecryptor?,
-                                                                     _ error: AudiobookManifestError) -> Void)
+  /// Transform the book manifest into a dictionary for creating an audiobook object,
+  /// and add needed information for the dedicated DRM method.
+  @objc class func transformManifestToDictionary(for audiobook: NYPLBook?,
+                                                 fileURL: URL?,
+                                                 completion: @escaping (_ manifest: [String: Any]?,
+                                                                        _ decryptor: DRMDecryptor?,
+                                                                        _ error: AudiobookManifestError) -> Void)
   {
-    guard let url = NYPLMyBooksDownloadCenter.shared().fileURL(forBookIndentifier: book.identifier),
+    guard let book = audiobook,
+          let url = fileURL,
           let data = try? Data.init(contentsOf: url),
           let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
             completion(nil, nil, .corrupted)
             return
           }
+    
     var dict: [String: Any] = json
 #if FEATURE_OVERDRIVE_AUTH
     if (book.distributor == OverdriveAPI.distributorKey) {

--- a/Simplified/Audiobooks/AudiobookManifestHelper.swift
+++ b/Simplified/Audiobooks/AudiobookManifestHelper.swift
@@ -1,0 +1,61 @@
+//
+//  AudiobookManifestHelper.swift
+//  Simplified
+//
+//  Created by Ernest Fan on 2022-03-30.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+#if FEATURE_AUDIOBOOKS
+
+import Foundation
+import NYPLAudiobookToolkit
+import OverdriveProcessor
+import UIKit
+
+@objc enum AudiobookManifestError: Int {
+  case none
+  case unsupported
+  case corrupted
+}
+
+@objc class AudiobookManifestHelper: NSObject {
+  @objc class func parseAudiobookManifest(book: NYPLBook,
+                                          completion: @escaping (_ manifest: [String: Any]?,
+                                                                 _ decryptor: DRMDecryptor?,
+                                                                 _ error: AudiobookManifestError) -> Void)
+  {
+    guard let url = NYPLMyBooksDownloadCenter.shared().fileURL(forBookIndentifier: book.identifier),
+          let data = try? Data.init(contentsOf: url),
+          let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+            completion(nil, nil, .corrupted)
+            return
+          }
+    var dict: [String: Any] = json
+#if FEATURE_OVERDRIVE_AUTH
+    if (book.distributor == OverdriveAPI.distributorKey) {
+      dict["id"] = book.identifier
+    }
+#endif
+    
+#if LCP
+    if LCPAudiobooks.canOpenBook(book) {
+      let lcpAudiobook = LCPAudiobooks.init(for: url)
+      lcpAudiobook?.contentDictionary(completion: { dict, error in
+        if (error) {
+          completion(nil, nil, .unsupported)
+        }
+        
+        if dict != nil {
+          var updatedManifest = dict
+          updatedManifest["id"] = book.identifier
+          completion(updatedManifest, lcpAudiobook, .none)
+        }
+      })
+    }
+#endif
+    
+    completion(dict, nil, .none)
+  }
+}
+
+#endif

--- a/Simplified/Audiobooks/NYPLAudiobookDownloader.swift
+++ b/Simplified/Audiobooks/NYPLAudiobookDownloader.swift
@@ -1,0 +1,141 @@
+//
+//  NYPLAudiobooksDownloader.swift
+//  Simplified
+//
+//  Created by Ernest Fan on 2022-04-01.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+#if FEATURE_AUDIOBOOKS
+import Foundation
+import NYPLAudiobookToolkit
+
+@objc protocol NYPLAudiobookDownloadStatusDelegate {
+  func audiobookDidUpdateDownloadProgress(progress: Float, bookID: String)
+  func audiobookDidCompleteDownload(bookID: String)
+  func audiobookDidCompleteDownloadFirstElement(bookID: String)
+  func audiobookDidReceiveDownloadError(error: NSError?, bookID: String)
+}
+
+class NYPLAudiobookDownloadObject {
+  var bookID: String
+  var audiobookManager: DefaultAudiobookManager
+  
+  init(bookID: String, audiobookManager: DefaultAudiobookManager) {
+    self.bookID = bookID
+    self.audiobookManager = audiobookManager
+  }
+}
+
+@objcMembers class NYPLAudiobookDownloader: NSObject {
+  weak var delegate: NYPLAudiobookDownloadStatusDelegate?
+  
+  private var queue: DispatchQueue = DispatchQueue(label: "org.nypl.labs.NYPLAudiobooksDownloader")
+  private var downloadObjects: [NYPLAudiobookDownloadObject] = []
+  private var currentDownloadObject: NYPLAudiobookDownloadObject?
+  
+  @objc(downloadAudiobookForBookID:audiobookManager:)
+  func downloadAudiobook(for bookID: String,
+                         audiobookManager: DefaultAudiobookManager) {
+    guard downloadObject(for: bookID) == nil else {
+      return
+    }
+    
+    queue.sync {
+      downloadObjects.append(NYPLAudiobookDownloadObject(bookID: bookID, audiobookManager: audiobookManager))
+    }
+    fetchNext()
+  }
+  
+  @objc func cancelDownload(for bookID: String) {
+    if let downloadObject = currentDownloadObject,
+       downloadObject.bookID == bookID {
+      cancelDownload(for: downloadObject)
+      releaseCurrentDownloadObject()
+      fetchNext()
+    } else if let index = downloadObjects.firstIndex(where: { $0.bookID == bookID }) {
+      cancelDownload(for: downloadObjects[index])
+      queue.sync {
+        _ = downloadObjects.remove(at: index)
+      }
+    }
+  }
+  
+  func audiobookManager(for bookID: String) -> DefaultAudiobookManager? {
+    return downloadObject(for: bookID)?.audiobookManager
+  }
+  
+  // MARK: - Helper
+  
+  private func releaseCurrentDownloadObject() {
+    queue.sync {
+      currentDownloadObject = nil
+    }
+  }
+  
+  private func fetchNext() {
+    guard currentDownloadObject == nil else {
+      return
+    }
+    
+    queue.sync {
+      if let downloadObject = downloadObjects.popFirst() {
+        Log.debug(#file, "Fetch initiated for \(downloadObject.bookID)")
+        downloadObject.audiobookManager.networkService.registerDelegate(self)
+        downloadObject.audiobookManager.networkService.fetch()
+        currentDownloadObject = downloadObject
+      }
+    }
+  }
+  
+  private func cancelDownload(for downloadObject: NYPLAudiobookDownloadObject) {
+    downloadObject.audiobookManager.networkService.cancelFetch()
+    downloadObject.audiobookManager.networkService.removeDelegate(self)
+    Log.debug(#file, "Fetch cancelled for \(downloadObject.bookID)")
+  }
+  
+  private func downloadObject(for bookID: String) -> NYPLAudiobookDownloadObject? {
+    if let downloadObject = currentDownloadObject,
+       downloadObject.bookID == bookID {
+      return downloadObject
+    } else if let index = downloadObjects.firstIndex(where: { $0.bookID == bookID }) {
+      return downloadObjects[index]
+    }
+    return nil
+  }
+}
+
+extension NYPLAudiobookDownloader: AudiobookNetworkServiceDelegate {
+  func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService, didCompleteDownloadFor spineElement: SpineElement) {
+    if let downloadObject = currentDownloadObject {
+      delegate?.audiobookDidUpdateDownloadProgress(progress: audiobookNetworkService.downloadProgress,
+                                                   bookID: downloadObject.bookID)
+    }
+  }
+  
+  func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService, didUpdateProgressFor spineElement: SpineElement) {}
+  
+  func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService, didUpdateOverallDownloadProgress progress: Float) {
+    if progress == 1,
+      let downloadObject = currentDownloadObject
+    {
+      delegate?.audiobookDidCompleteDownload(bookID: downloadObject.bookID)
+      downloadObject.audiobookManager.networkService.removeDelegate(self)
+      Log.debug(#file, "\(downloadObject.bookID) download completed and removed")
+
+      releaseCurrentDownloadObject()
+      fetchNext()
+    }
+  }
+  
+  func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService, didDeleteFileFor spineElement: SpineElement) {}
+  
+  func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService, didReceive error: NSError?, for spineElement: SpineElement) {
+    audiobookNetworkService.cancelFetch()
+    if let downloadObject = currentDownloadObject {
+      delegate?.audiobookDidReceiveDownloadError(error: error, bookID: downloadObject.bookID)
+      releaseCurrentDownloadObject()
+      fetchNext()
+    }
+  }
+}
+#endif

--- a/Simplified/Book/UI/NYPLBookCellCollectionViewController.m
+++ b/Simplified/Book/UI/NYPLBookCellCollectionViewController.m
@@ -79,8 +79,15 @@
         if([cell isKindOfClass:[NYPLBookDownloadingCell class]]) {
           NYPLBookDownloadingCell *const downloadingCell = (NYPLBookDownloadingCell *)cell;
           NSString *const bookIdentifier = downloadingCell.book.identifier;
-          downloadingCell.downloadProgress = [[NYPLMyBooksDownloadCenter sharedDownloadCenter]
-                                              downloadProgressForBookIdentifier:bookIdentifier];
+          double downloadProgress = [[NYPLMyBooksDownloadCenter sharedDownloadCenter]
+                                     downloadProgressForBookIdentifier:bookIdentifier];
+          downloadingCell.downloadProgress = downloadProgress;
+#if FEATURE_AUDIOBOOKS
+          if (downloadingCell.book.defaultBookContentType == NYPLBookContentTypeAudiobook
+              && downloadProgress > 0.1) {
+            [downloadingCell enableListenButton];
+          }
+#endif
         }
       }
     }]];

--- a/Simplified/Book/UI/NYPLBookCellDelegate+Audiobooks.m
+++ b/Simplified/Book/UI/NYPLBookCellDelegate+Audiobooks.m
@@ -25,10 +25,10 @@
 #pragma mark - Audiobook Methods
 
 - (void)openAudiobook:(NYPLBook *)book {
-  [AudiobookManifestHelper parseAudiobookManifestWithBook:book
-                                               completion:^(NSDictionary<NSString *,id> * _Nullable json,
-                                                            id<DRMDecryptor> _Nullable decryptor,
-                                                            enum AudiobookManifestError error) {
+  [AudiobookManifestAdapter transformAudiobookManifestWithBook:book
+                                                    completion:^(NSDictionary<NSString *,id> * _Nullable json,
+                                                                 id<DRMDecryptor> _Nullable decryptor,
+                                                                 enum AudiobookManifestError error) {
     if (error == AudiobookManifestErrorCorrupted) {
       NSURL *url = [[NYPLMyBooksDownloadCenter sharedDownloadCenter] fileURLForBookIndentifier:book.identifier];
       [self presentCorruptedItemErrorWithLog:@{

--- a/Simplified/Book/UI/NYPLBookCellDelegate.m
+++ b/Simplified/Book/UI/NYPLBookCellDelegate.m
@@ -192,5 +192,9 @@
    cancelDownloadForBookIdentifier:cell.book.identifier];
 }
 
+- (void)didSelectListenForBookDownloadingCell:(NYPLBookDownloadingCell *)cell
+{
+  [self didSelectReadForBook:cell.book successCompletion:nil];
+}
 
 @end

--- a/Simplified/Book/UI/NYPLBookDownloadingCell.h
+++ b/Simplified/Book/UI/NYPLBookDownloadingCell.h
@@ -6,6 +6,7 @@
 @protocol NYPLBookDownloadingCellDelegate
 
 - (void)didSelectCancelForBookDownloadingCell:(NYPLBookDownloadingCell *)cell;
+- (void)didSelectListenForBookDownloadingCell:(NYPLBookDownloadingCell *)cell;
 
 @end
 
@@ -14,5 +15,8 @@
 @property (nonatomic) NYPLBook *book;
 @property (nonatomic, weak) id<NYPLBookDownloadingCellDelegate> delegate;
 @property (nonatomic) double downloadProgress;
+#if FEATURE_AUDIOBOOKS
+- (void)enableListenButton;
+#endif
 
 @end

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter+AudiobooksDownload.swift
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter+AudiobooksDownload.swift
@@ -9,8 +9,54 @@
 import Foundation
 import NYPLAudiobookToolkit
 
+extension NYPLMyBooksDownloadCenter {
+  /// Create an audiobook object and add to download queue
+  @objc(downloadAudiobookForBook:)
+  func downloadAudiobook(for book: NYPLBook?) {
+    guard let book = book,
+          let url = self.fileURL(forBookIndentifier: book.identifier) else {
+      return
+    }
+    
+    AudiobookManifestAdapter.transformManifestToDictionary(for: book,
+                                                              fileURL: url) { json, decryptor, error in
+      if error == .none {
+        guard let audiobook = AudiobookFactory.audiobook(json, decryptor: decryptor) else {
+          Log.info(#file, "Audiobook initiate failed for book id - \(book.identifier)")
+          // TODO: Handle Error
+          self.broadcastUpdate(book.identifier)
+          return
+        }
+        
+        let metadata = AudiobookMetadata(title: book.title, authors: [(book.authors ?? "")])
+        let manager = DefaultAudiobookManager(metadata: metadata, audiobook: audiobook)
+        
+        NYPLBookRegistry.shared().setStateWithCode(NYPLBookState.Downloading.rawValue, forIdentifier: book.identifier)
+        
+        self.downloadProgressDidUpdate(to: Double(manager.networkService.downloadProgress),
+                                       forBookIdentifier: book.identifier)
+        
+        self.audiobookDownloader.downloadAudiobook(for: book.identifier, audiobookManager: manager)
+      } else {
+        Log.info(#file, "Audiobook manifest corrupted/unsupported")
+        // TODO: Handle Error
+        self.broadcastUpdate(book.identifier)
+      }
+    }
+  }
+  
+  @objc(audiobookManagerForBookID:)
+  func audiobookManager(for bookID: String?) -> DefaultAudiobookManager? {
+    guard let bookID = bookID else {
+      return nil
+    }
+    
+    return self.audiobookDownloader.audiobookManager(for: bookID)
+  }
+}
+
 extension NYPLMyBooksDownloadCenter: NYPLAudiobookDownloadStatusDelegate {
-  func audiobookDidUpdateDownloadProgress(progress: Float, bookID: String) {
+  func audiobookDidUpdateDownloadProgress(_ progress: Float, bookID: String) {
     downloadProgressDidUpdate(to: Double(progress), forBookIdentifier: bookID)
   }
   

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter+AudiobooksDownload.swift
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter+AudiobooksDownload.swift
@@ -1,0 +1,31 @@
+//
+//  NYPLMyBooksDownloadCenter+AudiobooksDownload.swift
+//  Simplified
+//
+//  Created by Ernest Fan on 2022-04-06.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+#if FEATURE_AUDIOBOOKS
+import Foundation
+import NYPLAudiobookToolkit
+
+extension NYPLMyBooksDownloadCenter: NYPLAudiobookDownloadStatusDelegate {
+  func audiobookDidUpdateDownloadProgress(progress: Float, bookID: String) {
+    downloadProgressDidUpdate(to: Double(progress), forBookIdentifier: bookID)
+  }
+  
+  func audiobookDidCompleteDownload(bookID: String) {
+    NYPLBookRegistry.shared().setStateWithCode(NYPLBookState.DownloadSuccessful.rawValue,
+                                               forIdentifier: bookID)
+    NYPLBookRegistry.shared().save()
+  }
+  
+  func audiobookDidCompleteDownloadFirstElement(bookID: String) {
+    // Update UI to present listen button
+  }
+  
+  func audiobookDidReceiveDownloadError(error: NSError?, bookID: String) {
+    // Update book registry and update UI
+  }
+}
+#endif

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.h
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.h
@@ -53,6 +53,8 @@
 - (NSURL *)fileURLForBookIndentifier:(NSString *)identifier;
 
 #if FEATURE_AUDIOBOOKS
+- (id)audiobookManagerForBookID:(NSString *)bookID;
+
 - (void)downloadProgressDidUpdateTo:(double)progress forBookIdentifier:(NSString *)bookID;
 #endif
 

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.h
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.h
@@ -52,4 +52,8 @@
 // This returns a URL even if the book is not on-disk. Returns nil if |identifier| is nil.
 - (NSURL *)fileURLForBookIndentifier:(NSString *)identifier;
 
+#if FEATURE_AUDIOBOOKS
+- (void)downloadProgressDidUpdateTo:(double)progress forBookIdentifier:(NSString *)bookID;
+#endif
+
 @end

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.h
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.h
@@ -1,7 +1,12 @@
 @class NYPLBook;
 @class NYPLMyBooksDownloadInfo;
+@class NYPLAudiobookDownloader;
 
 @interface NYPLMyBooksDownloadCenter : NSObject
+
+#if FEATURE_AUDIOBOOKS
+@property (nonatomic) NYPLAudiobookDownloader *audiobookDownloader;
+#endif
 
 + (id)new NS_UNAVAILABLE;
 - (id)init NS_UNAVAILABLE;
@@ -53,7 +58,7 @@
 - (NSURL *)fileURLForBookIndentifier:(NSString *)identifier;
 
 #if FEATURE_AUDIOBOOKS
-- (id)audiobookManagerForBookID:(NSString *)bookID;
+- (void)broadcastUpdate:(NSString *)bookID;
 
 - (void)downloadProgressDidUpdateTo:(double)progress forBookIdentifier:(NSString *)bookID;
 #endif

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -46,7 +46,7 @@
 @property (nonatomic) NSURLSession *session;
 @property (nonatomic) NSMutableDictionary *taskIdentifierToBook;
 @property (nonatomic) NYPLReauthenticator *reauthenticator;
-@property (nonatomic) DefaultAudiobookManager *audiobookManager;
+@property (nonatomic) NYPLAudiobookDownloader *audiobookDownloader;
 
 /// Maps a task identifier to a non-negative redirect attempt count. This
 /// tracks the number of redirect attempts for a particular download task.
@@ -86,6 +86,11 @@
   
 #if defined(FEATURE_DRM_CONNECTOR)
   [NYPLADEPT sharedInstance].delegate = self;
+#endif
+  
+#if FEATURE_AUDIOBOOKS
+  self.audiobookDownloader = [[NYPLAudiobookDownloader alloc] init];
+  self.audiobookDownloader.delegate = (id)self;
 #endif
   
   NSURLSessionConfiguration *const configuration =
@@ -396,10 +401,10 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
   
 #if FEATURE_AUDIOBOOKS
   if (book.defaultBookContentType == NYPLBookContentTypeAudiobook) {
-    [AudiobookManifestHelper parseAudiobookManifestWithBook:book
-                                                 completion:^(NSDictionary<NSString *,id> * _Nullable json,
-                                                              id<DRMDecryptor> _Nullable decryptor,
-                                                              enum AudiobookManifestError error) {
+    [AudiobookManifestAdapter transformAudiobookManifestWithBook:book
+                                                      completion:^(NSDictionary<NSString *,id> * _Nullable json,
+                                                                   id<DRMDecryptor> _Nullable decryptor,
+                                                                   enum AudiobookManifestError error) {
       if (error == AudiobookManifestErrorNone) {
         // Create audiobook
         id<Audiobook> const audiobook = [AudiobookFactory audiobook:json decryptor:decryptor];
@@ -410,15 +415,20 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
           [self broadcastUpdate:book.identifier];
           return;
         }
-        AudiobookMetadata *const metadata = [[AudiobookMetadata alloc] initWithTitle:book.title
-                                                                             authors:@[book.authors]];
+        AudiobookMetadata *metadata = [[AudiobookMetadata alloc] initWithTitle:book.title
+                                                                       authors:@[book.authors]];
         
         DefaultAudiobookManager *manager = [[DefaultAudiobookManager alloc] initWithMetadata:metadata
                                                                                    audiobook:audiobook];
-        // TODO: Create download object and make it a property of MyBooksDownloadCenter
-        self.audiobookManager = manager;
-        [self.audiobookManager.networkService fetch];
-        NYPLLOG(@"Fetching audiobook");
+        
+        [[NYPLBookRegistry sharedRegistry]
+         setState:NYPLBookStateDownloading
+         forIdentifier:book.identifier];
+        
+        [self downloadProgressDidUpdateTo:0 forBookIdentifier:book.identifier];
+        
+        [self.audiobookDownloader downloadAudiobookForBookID:book.identifier
+                                            audiobookManager:manager];
       } else {
         NYPLLOG(@"Audiobook corrupted/unsupported");
         // TODO: Handle Error
@@ -427,9 +437,9 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
     }];
     return;
   }
-#endif
-
+#else
   [self broadcastUpdate:book.identifier];
+#endif
 }
 
 // this doesn't log to crashlytics because it assumes that the caller
@@ -1656,5 +1666,14 @@ didFinishDownload:(BOOL)didFinishDownload
 }
 #endif
 
+#if FEATURE_AUDIOBOOKS
+- (void)downloadProgressDidUpdateTo:(double)progress forBookIdentifier:(NSString *)bookID {
+  NYPLLOG_F(@"Download progress updated to %f for %@", progress, bookID);
+  self.bookIdentifierToDownloadInfo[bookID] = [[self downloadInfoForBookIdentifier:bookID]
+                                               withDownloadProgress:progress];
+
+  [self broadcastUpdate:bookID];
+}
+#endif
 
 @end

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -46,7 +46,9 @@
 @property (nonatomic) NSURLSession *session;
 @property (nonatomic) NSMutableDictionary *taskIdentifierToBook;
 @property (nonatomic) NYPLReauthenticator *reauthenticator;
+#if FEATURE_AUDIOBOOKS
 @property (nonatomic) NYPLAudiobookDownloader *audiobookDownloader;
+#endif
 
 /// Maps a task identifier to a non-negative redirect attempt count. This
 /// tracks the number of redirect attempts for a particular download task.
@@ -401,40 +403,7 @@ didFinishDownloadingToURL:(NSURL *const)tmpSavedFileURL
   
 #if FEATURE_AUDIOBOOKS
   if (book.defaultBookContentType == NYPLBookContentTypeAudiobook) {
-    [AudiobookManifestAdapter transformAudiobookManifestWithBook:book
-                                                      completion:^(NSDictionary<NSString *,id> * _Nullable json,
-                                                                   id<DRMDecryptor> _Nullable decryptor,
-                                                                   enum AudiobookManifestError error) {
-      if (error == AudiobookManifestErrorNone) {
-        // Create audiobook
-        id<Audiobook> const audiobook = [AudiobookFactory audiobook:json decryptor:decryptor];
-        
-        if (!audiobook) {
-          NYPLLOG(@"Audiobook initiate failed");
-          // TODO: Handle Error
-          [self broadcastUpdate:book.identifier];
-          return;
-        }
-        AudiobookMetadata *metadata = [[AudiobookMetadata alloc] initWithTitle:book.title
-                                                                       authors:@[book.authors]];
-        
-        DefaultAudiobookManager *manager = [[DefaultAudiobookManager alloc] initWithMetadata:metadata
-                                                                                   audiobook:audiobook];
-        
-        [[NYPLBookRegistry sharedRegistry]
-         setState:NYPLBookStateDownloading
-         forIdentifier:book.identifier];
-        
-        [self downloadProgressDidUpdateTo:0 forBookIdentifier:book.identifier];
-        
-        [self.audiobookDownloader downloadAudiobookForBookID:book.identifier
-                                            audiobookManager:manager];
-      } else {
-        NYPLLOG(@"Audiobook corrupted/unsupported");
-        // TODO: Handle Error
-        [self broadcastUpdate:book.identifier];
-      }
-    }];
+    [self downloadAudiobookForBook:book];
     return;
   }
 #else
@@ -1318,6 +1287,9 @@ didCompleteWithError:(NSError *)error
     [[NYPLBookRegistry sharedRegistry]
      setState:NYPLBookStateDownloadNeeded forIdentifier:identifier];
   }
+#if FEATURE_AUDIOBOOKS
+  [self.audiobookDownloader cancelDownloadFor:identifier];
+#endif
 }
 
 - (void)deleteAudiobooksForAccount:(NSString * const)account
@@ -1667,6 +1639,44 @@ didFinishDownload:(BOOL)didFinishDownload
 #endif
 
 #if FEATURE_AUDIOBOOKS
+/// Create an audiobook object and add to download queue
+- (void)downloadAudiobookForBook:(NYPLBook *)book {
+  [AudiobookManifestAdapter transformAudiobookManifestWithBook:book
+                                                    completion:^(NSDictionary<NSString *,id> * _Nullable json,
+                                                                 id<DRMDecryptor> _Nullable decryptor,
+                                                                 enum AudiobookManifestError error) {
+    if (error == AudiobookManifestErrorNone) {
+      // Create audiobook
+      id<Audiobook> const audiobook = [AudiobookFactory audiobook:json decryptor:decryptor];
+      
+      if (!audiobook) {
+        NYPLLOG(@"Audiobook initiate failed");
+        // TODO: Handle Error
+        [self broadcastUpdate:book.identifier];
+        return;
+      }
+      AudiobookMetadata *metadata = [[AudiobookMetadata alloc] initWithTitle:book.title
+                                                                     authors:@[book.authors]];
+      
+      DefaultAudiobookManager *manager = [[DefaultAudiobookManager alloc] initWithMetadata:metadata
+                                                                                 audiobook:audiobook];
+      
+      [[NYPLBookRegistry sharedRegistry]
+       setState:NYPLBookStateDownloading
+       forIdentifier:book.identifier];
+      
+      [self downloadProgressDidUpdateTo:manager.networkService.downloadProgress forBookIdentifier:book.identifier];
+      
+      [self.audiobookDownloader downloadAudiobookForBookID:book.identifier
+                                          audiobookManager:manager];
+    } else {
+      NYPLLOG(@"Audiobook corrupted/unsupported");
+      // TODO: Handle Error
+      [self broadcastUpdate:book.identifier];
+    }
+  }];
+}
+
 - (id)audiobookManagerForBookID:(NSString *)bookID {
   return [_audiobookDownloader audiobookManagerFor:bookID];
 }

--- a/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
+++ b/Simplified/MyBooks/NYPLMyBooksDownloadCenter.m
@@ -1667,6 +1667,10 @@ didFinishDownload:(BOOL)didFinishDownload
 #endif
 
 #if FEATURE_AUDIOBOOKS
+- (id)audiobookManagerForBookID:(NSString *)bookID {
+  return [_audiobookDownloader audiobookManagerFor:bookID];
+}
+
 - (void)downloadProgressDidUpdateTo:(double)progress forBookIdentifier:(NSString *)bookID {
   NYPLLOG_F(@"Download progress updated to %f for %@", progress, bookID);
   self.bookIdentifierToDownloadInfo[bookID] = [[self downloadInfoForBookIdentifier:bookID]


### PR DESCRIPTION
**What's this do?**
Refactor code to create audiobook object for background download process
Implement downloader to download audiobooks in queue
Implement download status protocol to interfere with MyBooksDownloadCenter

**Why are we doing this? (w/ JIRA link if applicable)**
[iOS-390](https://jira.nypl.org/browse/IOS-390)
[iOS-391](https://jira.nypl.org/browse/IOS-391)

**How should this be tested? / Do these changes have associated tests?**
Will be tested once the UI ticket is done

**Dependencies for merging? Releasing to production?**
NYPLAudiobookToolkit and NYPLAEToolkit have been updated

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
Not until UI is ready

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 