### PR TITLE
OE-514 Clever authentication refactor

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -342,7 +342,7 @@
 		731465202786106900027CFA /* PureLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7314651F2786106900027CFA /* PureLayout */; };
 		7314D1402551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7314D13F2551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift */; };
 		7314D1422551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7314D13F2551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift */; };
-		73186815285B9074001B9D86 /* NYPLSignInCleverHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73186811285B9074001B9D86 /* NYPLSignInCleverHelper.swift */; };
+		73186815285B9074001B9D86 /* OELoginCleverHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73186811285B9074001B9D86 /* OELoginCleverHelper.swift */; };
 		731A5B1224621F2B00B5E663 /* NYPLSignInBusinessLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731A5B1124621F2B00B5E663 /* NYPLSignInBusinessLogic.swift */; };
 		731B2B25244A2B6E00A7A649 /* R2Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 739E6157244A0F6D00D00301 /* R2Shared.framework */; };
 		731B2B27244A2B7100A7A649 /* R2Streamer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 731B2B12244A1D6500A7A649 /* R2Streamer.framework */; };
@@ -1942,7 +1942,7 @@
 		7314651C27860FCA00027CFA /* NYPLAEToolkit */ = {isa = PBXFileReference; lastKnownFileType = folder; path = NYPLAEToolkit; sourceTree = "<group>"; };
 		7314D13F2551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+SignOut.swift"; sourceTree = "<group>"; };
 		73165C67268662FA0021A6AD /* checkout-r2-branch.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "checkout-r2-branch.sh"; sourceTree = "<group>"; };
-		73186811285B9074001B9D86 /* NYPLSignInCleverHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSignInCleverHelper.swift; sourceTree = "<group>"; };
+		73186811285B9074001B9D86 /* OELoginCleverHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OELoginCleverHelper.swift; sourceTree = "<group>"; };
 		731A5B1124621F2B00B5E663 /* NYPLSignInBusinessLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSignInBusinessLogic.swift; sourceTree = "<group>"; };
 		731B2B12244A1D6500A7A649 /* R2Streamer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2Streamer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		731B2B18244A1D8600A7A649 /* R2Navigator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2Navigator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2845,10 +2845,10 @@
 				7314D13F2551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift */,
 				73A794A525477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift */,
 				739062D125358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift */,
-				73186811285B9074001B9D86 /* NYPLSignInCleverHelper.swift */,
 				73B501C024F48D4B00FBAD7D /* NYPLUserAccountFrontEndValidation.swift */,
 				73F4B8AF28496A0B0032F9FC /* OELoginChoice.xib */,
 				73085E182502DE87008F6244 /* OELoginChoiceViewController.swift */,
+				73186811285B9074001B9D86 /* OELoginCleverHelper.swift */,
 				73043AE12851552C0060FAAA /* OELoginFirstBookVC.xib */,
 				73043AE02851552C0060FAAA /* OELoginFirstBookVC.swift */,
 				73B70A33284FCD8100BDF490 /* OELoginNavHeader.xib */,
@@ -4846,7 +4846,7 @@
 				597E272B268B537E00A3CD23 /* NYPLAxisBookReadingAdapter.swift in Sources */,
 				7384C759252D20AA0012C2DD /* NYPLBook+DistributorChecks.swift in Sources */,
 				7350A79B27178D400042FF3A /* NYPLMyBooksNotifier.swift in Sources */,
-				73186815285B9074001B9D86 /* NYPLSignInCleverHelper.swift in Sources */,
+				73186815285B9074001B9D86 /* OELoginCleverHelper.swift in Sources */,
 				73FCA2BF25005BA4001B0C5D /* NYPLBookCellCollectionViewController.m in Sources */,
 				597E272D268B537E00A3CD23 /* NYPLAxisBookContentDecryptionAdapter.swift in Sources */,
 				597E2727268B537E00A3CD23 /* NYPLAxisDRMAuthorizer.swift in Sources */,

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -342,6 +342,7 @@
 		731465202786106900027CFA /* PureLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 7314651F2786106900027CFA /* PureLayout */; };
 		7314D1402551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7314D13F2551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift */; };
 		7314D1422551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7314D13F2551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift */; };
+		73186815285B9074001B9D86 /* NYPLSignInCleverHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73186811285B9074001B9D86 /* NYPLSignInCleverHelper.swift */; };
 		731A5B1224621F2B00B5E663 /* NYPLSignInBusinessLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731A5B1124621F2B00B5E663 /* NYPLSignInBusinessLogic.swift */; };
 		731B2B25244A2B6E00A7A649 /* R2Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 739E6157244A0F6D00D00301 /* R2Shared.framework */; };
 		731B2B27244A2B7100A7A649 /* R2Streamer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 731B2B12244A1D6500A7A649 /* R2Streamer.framework */; };
@@ -1941,6 +1942,7 @@
 		7314651C27860FCA00027CFA /* NYPLAEToolkit */ = {isa = PBXFileReference; lastKnownFileType = folder; path = NYPLAEToolkit; sourceTree = "<group>"; };
 		7314D13F2551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLSignInBusinessLogic+SignOut.swift"; sourceTree = "<group>"; };
 		73165C67268662FA0021A6AD /* checkout-r2-branch.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "checkout-r2-branch.sh"; sourceTree = "<group>"; };
+		73186811285B9074001B9D86 /* NYPLSignInCleverHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSignInCleverHelper.swift; sourceTree = "<group>"; };
 		731A5B1124621F2B00B5E663 /* NYPLSignInBusinessLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLSignInBusinessLogic.swift; sourceTree = "<group>"; };
 		731B2B12244A1D6500A7A649 /* R2Streamer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2Streamer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		731B2B18244A1D8600A7A649 /* R2Navigator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2Navigator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2843,11 +2845,12 @@
 				7314D13F2551E73C00723E26 /* NYPLSignInBusinessLogic+SignOut.swift */,
 				73A794A525477D8F00C59CC1 /* NYPLSignInBusinessLogic+UI.swift */,
 				739062D125358CF900D0743D /* NYPLSignInBusinessLogicUIDelegate.swift */,
+				73186811285B9074001B9D86 /* NYPLSignInCleverHelper.swift */,
 				73B501C024F48D4B00FBAD7D /* NYPLUserAccountFrontEndValidation.swift */,
-				73043AE12851552C0060FAAA /* OELoginFirstBookVC.xib */,
-				73043AE02851552C0060FAAA /* OELoginFirstBookVC.swift */,
 				73F4B8AF28496A0B0032F9FC /* OELoginChoice.xib */,
 				73085E182502DE87008F6244 /* OELoginChoiceViewController.swift */,
+				73043AE12851552C0060FAAA /* OELoginFirstBookVC.xib */,
+				73043AE02851552C0060FAAA /* OELoginFirstBookVC.swift */,
 				73B70A33284FCD8100BDF490 /* OELoginNavHeader.xib */,
 				73CB8CC8285012D700603BA1 /* OELoginNavHeader.swift */,
 				734B789025659611006FB8AD /* URLResponse+NYPLAuthentication.swift */,
@@ -4843,6 +4846,7 @@
 				597E272B268B537E00A3CD23 /* NYPLAxisBookReadingAdapter.swift in Sources */,
 				7384C759252D20AA0012C2DD /* NYPLBook+DistributorChecks.swift in Sources */,
 				7350A79B27178D400042FF3A /* NYPLMyBooksNotifier.swift in Sources */,
+				73186815285B9074001B9D86 /* NYPLSignInCleverHelper.swift in Sources */,
 				73FCA2BF25005BA4001B0C5D /* NYPLBookCellCollectionViewController.m in Sources */,
 				597E272D268B537E00A3CD23 /* NYPLAxisBookContentDecryptionAdapter.swift in Sources */,
 				597E2727268B537E00A3CD23 /* NYPLAxisDRMAuthorizer.swift in Sources */,

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -985,7 +985,7 @@
 		73DE897E260BEA13003D9135 /* NYPLRequestExecuting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE8979260BEA13003D9135 /* NYPLRequestExecuting.swift */; };
 		73DEB54E2486FDFC00B5FF0A /* NYPLBookmarkR2Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DEB5462486FDFC00B5FF0A /* NYPLBookmarkR2Location.swift */; };
 		73DEB54F2486FDFC00B5FF0A /* NYPLBookmarkR2Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DEB5462486FDFC00B5FF0A /* NYPLBookmarkR2Location.swift */; };
-		73E64E6A252BB82600276953 /* NYPLWelcomeEULAViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E64E65252BB82600276953 /* NYPLWelcomeEULAViewController.swift */; };
+		73E64E6A252BB82600276953 /* OEEULAViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E64E65252BB82600276953 /* OEEULAViewController.swift */; };
 		73E64E6C252BB89A00276953 /* eula.html in Resources */ = {isa = PBXBuildFile; fileRef = 73E64E6B252BB89A00276953 /* eula.html */; };
 		73EB0A6525821DF4006BC997 /* NYPLLibraryDescriptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0826CD2E24AA2801000F4030 /* NYPLLibraryDescriptionCell.swift */; };
 		73EB0A6725821DF4006BC997 /* NYPLCirculationAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66AE32F1DC0FCFC00124AE2 /* NYPLCirculationAnalytics.swift */; };
@@ -2102,7 +2102,7 @@
 		73DE53302525A386003E2C56 /* NYPLLibraryAccountURLsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLLibraryAccountURLsProvider.swift; sourceTree = "<group>"; };
 		73DE8979260BEA13003D9135 /* NYPLRequestExecuting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLRequestExecuting.swift; sourceTree = "<group>"; };
 		73DEB5462486FDFC00B5FF0A /* NYPLBookmarkR2Location.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLBookmarkR2Location.swift; sourceTree = "<group>"; };
-		73E64E65252BB82600276953 /* NYPLWelcomeEULAViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLWelcomeEULAViewController.swift; sourceTree = "<group>"; };
+		73E64E65252BB82600276953 /* OEEULAViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OEEULAViewController.swift; sourceTree = "<group>"; };
 		73E64E6B252BB89A00276953 /* eula.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = eula.html; sourceTree = "<group>"; };
 		73EB0B7525821DF4006BC997 /* SimplyE-noDRM.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SimplyE-noDRM.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		73EB0B7F2582CCE9006BC997 /* build-dependencies.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "build-dependencies.sh"; sourceTree = "<group>"; };
@@ -2973,7 +2973,7 @@
 		738CB2092509AD3B00891F31 /* WelcomeScreen */ = {
 			isa = PBXGroup;
 			children = (
-				73E64E65252BB82600276953 /* NYPLWelcomeEULAViewController.swift */,
+				73E64E65252BB82600276953 /* OEEULAViewController.swift */,
 				E6202A031DD52B8600C99553 /* NYPLWelcomeScreenViewController.swift */,
 			);
 			path = WelcomeScreen;
@@ -5027,7 +5027,7 @@
 				73FCA34125005BA4001B0C5D /* NYPLOPDSEntryGroupAttributes.m in Sources */,
 				73FCA34225005BA4001B0C5D /* NYPLMyBooksDownloadCenter.m in Sources */,
 				73FCA34325005BA4001B0C5D /* NYPLProblemDocumentCacheManager.swift in Sources */,
-				73E64E6A252BB82600276953 /* NYPLWelcomeEULAViewController.swift in Sources */,
+				73E64E6A252BB82600276953 /* OEEULAViewController.swift in Sources */,
 				7353940C250854A90043C800 /* NYPLSettingsSplitViewController+OE.swift in Sources */,
 				73FCA34425005BA4001B0C5D /* NYPLBookButtonsView.m in Sources */,
 				73FCA34525005BA4001B0C5D /* NYPLMyBooksSimplifiedBearerToken.m in Sources */,

--- a/Simplified/Accounts/User/NYPLUserAccount.swift
+++ b/Simplified/Accounts/User/NYPLUserAccount.swift
@@ -20,6 +20,8 @@ private enum StorageKey: String {
   case authDefinition = "NYPLAccountAuthDefinitionKey"
   case cookies = "NYPLAccountAuthCookiesKey"
 
+  /// Generates the Keychain key for the enum case by appending the given
+  /// library UUID to the enum raw value.
   func keyForLibrary(uuid libraryUUID: String?) -> String {
     guard
       // historically user data for NYPL has not used keys that contain the
@@ -51,6 +53,11 @@ private enum StorageKey: String {
 ///
 /// This class works as a singleton even if the initializer is not private
 /// for unit tests reasons.
+///
+/// The way this class achieves saving credentials for multiple accounts is
+/// by storing credentials on the keychain using storage keys that contain the
+/// the library UUID appended after the actual key name.
+/// - seealso: StorageKey.keyForLibrary(uuid:)
 @objcMembers class NYPLUserAccount : NSObject, NYPLUserAccountProvider, NYPLOAuthTokenProvider {
   static private let shared = NYPLUserAccount()
 
@@ -127,6 +134,11 @@ private enum StorageKey: String {
     }
   }
 
+  /// The queue where updates to the `credentials` property happen.
+  var credentialsUpdateQueue: DispatchQueue {
+    return _credentials.updateQueue
+  }
+  
   var credentials: NYPLCredentials? {
     get {
       var credentials = _credentials.read()
@@ -460,6 +472,7 @@ private enum StorageKey: String {
   
   @objc(setPatron:)
   func setPatron(_ patron: [String : Any]) {
+    Log.debug(#file, "About to write value for patron property")
     _patron.write(patron)
     notifyAccountDidChange()
   }
@@ -474,6 +487,8 @@ private enum StorageKey: String {
   /// - Parameter token: The new OAuth token.
   @objc(setAuthToken:)
   func setAuthToken(_ token: String) {
+    Log.debug(#function, "authType=\(String(describing: authDefinition?.authType)) authToken=\(token)")
+
     // this check is required because in the client credentials flow we need
     // to save both the username/password and authtoken. However, during
     // sign-in, when we save the OAuth token this triggers an accountDidChange
@@ -482,6 +497,7 @@ private enum StorageKey: String {
     // to save username and password. For this reason we require to save
     // the refresh username and password *before* saving the authToken.
     if !hasOAuthClientCredentials() || authTokenRefreshUsername != nil {
+      Log.debug(#function, "About to write credentials for authToken...")
       credentials = .token(authToken: token)
     }
   }
@@ -539,6 +555,7 @@ private enum StorageKey: String {
 
       keychainTransaction.perform {
         _authDefinition.write(nil)
+        Log.debug(#function, "authDefinition after removing value: \(String(describing: _authDefinition.read()?.authType))")
         _credentials.write(nil)
         _cookies.write(nil)
         _authorizationIdentifier.write(nil)

--- a/Simplified/Accounts/User/NYPLUserAccount.swift
+++ b/Simplified/Accounts/User/NYPLUserAccount.swift
@@ -96,17 +96,11 @@ private enum StorageKey: String {
 
   var authDefinition: AccountDetails.Authentication? {
     get {
-      guard let read = _authDefinition.read() else {
-        if let libraryUUID = self.libraryUUID {
-          return AccountsManager.shared.account(libraryUUID)?.details?.auths.first
-        }
-            
-        return AccountsManager.shared.currentAccount?.details?.auths.first
-      }
-      return read
+      return _authDefinition.read()
     }
     set {
       guard let newValue = newValue else { return }
+      Log.debug(#function, "About to write value \(newValue.authType) for authDefinition")
       _authDefinition.write(newValue)
 
       DispatchQueue.main.async {

--- a/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
@@ -8,7 +8,11 @@
 
 import Foundation
 
-extension NYPLAppDelegate {
+@objc protocol OEAppUIStructureConfigurating {
+  @objc func setUpRootVC()
+}
+
+extension NYPLAppDelegate: OEAppUIStructureConfigurating {
   @objc func setUpRootVC() {
     if NYPLSettings.shared.userHasAcceptedEULA {
       if NYPLSettings.shared.userHasSeenWelcomeScreen,
@@ -39,9 +43,12 @@ extension NYPLAppDelegate {
   }
 
   private func createLoginNavController() -> UINavigationController {
-    return UINavigationController(rootViewController: OELoginChoiceViewController())
+    let vc = OELoginChoiceViewController(postLoginConfigurator: self)
+    return UINavigationController(rootViewController: vc)
   }
+}
 
+extension NYPLAppDelegate {
   /// Handle all custom URL schemes specific to Open eBooks here.
   /// - Parameter url: The URL to process.
   /// - Returns: `true` if the app should handle the URL because it matches a

--- a/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate+OE.swift
@@ -26,7 +26,7 @@ extension NYPLAppDelegate: OEAppUIStructureConfigurating {
         NYPLSettings.shared.userHasSeenWelcomeScreen = true
       }
     } else {
-      let eulaVC = NYPLWelcomeEULAViewController() {
+      let eulaVC = OEEULAViewController() {
         UIView.transition(
           with: self.window,
           duration: 0.5,

--- a/Simplified/AppInfrastructure/NYPLAppDelegate.m
+++ b/Simplified/AppInfrastructure/NYPLAppDelegate.m
@@ -9,12 +9,6 @@
 #import "NYPLReaderSettings.h"
 #import "NYPLRootTabBarController.h"
 
-
-#if defined(FEATURE_DRM_CONNECTOR)
-#import <ADEPT/ADEPT.h>
-#import "NYPLAccountSignInViewController.h"
-#endif
-
 // TODO: Remove these imports and move handling the "open a book url" code to a more appropriate handler
 #import "NYPLXML.h"
 #import "NYPLOPDSEntry.h"

--- a/Simplified/Book/Models/NYPLBookRegistry.m
+++ b/Simplified/Book/Models/NYPLBookRegistry.m
@@ -308,7 +308,8 @@ static NSString *const RecordsKey = @"records";
     self.syncShouldCommit = YES;
     [self broadcastChange];
   } //@synchronized
-  
+
+  NYPLLOG(@"[syncWithCompletionHandler] Begin BookRegistry syncing...");
   [NYPLOPDSFeedFetcher fetchOPDSFeedWithUrl:[[[AccountsManager sharedInstance] currentAccount] loansUrl]
                             networkExecutor:[NYPLNetworkExecutor shared]
                            shouldResetCache:shouldResetCache

--- a/Simplified/Catalog/NYPLCatalogNavigationController.m
+++ b/Simplified/Catalog/NYPLCatalogNavigationController.m
@@ -199,14 +199,18 @@
 
 - (void)syncBegan
 {
-  self.navigationItem.leftBarButtonItem.enabled = NO;
-  self.feedVC.navigationItem.leftBarButtonItem.enabled = NO;
+  [NYPLMainThreadRun asyncIfNeeded:^{
+    self.navigationItem.leftBarButtonItem.enabled = NO;
+    self.feedVC.navigationItem.leftBarButtonItem.enabled = NO;
+  }];
 }
 
 - (void)syncEnded
 {
-  self.navigationItem.leftBarButtonItem.enabled = YES;
-  self.feedVC.navigationItem.leftBarButtonItem.enabled = YES;
+  [NYPLMainThreadRun asyncIfNeeded:^{
+    self.navigationItem.leftBarButtonItem.enabled = YES;
+    self.feedVC.navigationItem.leftBarButtonItem.enabled = YES;
+  }];
 }
 
 #ifdef SIMPLYE

--- a/Simplified/Catalog/NYPLCatalogs+OE.swift
+++ b/Simplified/Catalog/NYPLCatalogs+OE.swift
@@ -10,9 +10,10 @@ import Foundation
 
 extension NYPLCatalogNavigationController {
   @objc func didSignOut() {
-    popToRootViewController(animated: true)
-
-    loadTopLevelCatalogViewController()
+    NYPLMainThreadRun.asyncIfNeeded { [self] in
+      popToRootViewController(animated: true)
+      loadTopLevelCatalogViewController()
+    }
   }
 }
 

--- a/Simplified/ErrorHandling/NYPLAlertUtils.swift
+++ b/Simplified/ErrorHandling/NYPLAlertUtils.swift
@@ -196,4 +196,12 @@ import UIKit
       Log.info(#file, msg)
     }
   }
+
+  static func presentUnrecoverableAlert(for error: String) {
+    Log.error(#file, error)
+    let alert = UIAlertController(title: NSLocalizedString("Error", comment: ""),
+                                  message: NSLocalizedString("An unrecoverable error occurred. Please force-quit the app and try again.", comment: "Generic error message for internal errors"),
+                                  preferredStyle: .alert)
+    NYPLPresentationUtils.safelyPresent(alert)
+  }
 }

--- a/Simplified/Holds/NYPLHoldsViewController.m
+++ b/Simplified/Holds/NYPLHoldsViewController.m
@@ -301,12 +301,16 @@ didSelectItemAtIndexPath:(NSIndexPath *const)indexPath
 
 - (void)syncBegan
 {
-  self.navigationItem.leftBarButtonItem.enabled = NO;
+  [NYPLMainThreadRun asyncIfNeeded:^{
+    self.navigationItem.leftBarButtonItem.enabled = NO;
+  }];
 }
 
 - (void)syncEnded
 {
-  self.navigationItem.leftBarButtonItem.enabled = YES;
+  [NYPLMainThreadRun asyncIfNeeded:^{
+    self.navigationItem.leftBarButtonItem.enabled = YES;
+  }];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)__unused size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)__unused coordinator

--- a/Simplified/MyBooks/NYPLMyBooksViewController.m
+++ b/Simplified/MyBooks/NYPLMyBooksViewController.m
@@ -399,12 +399,16 @@ OK:
 
 - (void)syncBegan
 {
-  self.navigationItem.leftBarButtonItem.enabled = NO;
+  [NYPLMainThreadRun asyncIfNeeded:^{
+    self.navigationItem.leftBarButtonItem.enabled = NO;
+  }];
 }
 
 - (void)syncEnded
 {
-  self.navigationItem.leftBarButtonItem.enabled = YES;
+  [NYPLMainThreadRun asyncIfNeeded:^{
+    self.navigationItem.leftBarButtonItem.enabled = YES;
+  }];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)__unused size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)__unused coordinator

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+OAuth.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+OAuth.swift
@@ -52,10 +52,10 @@ extension NYPLSignInBusinessLogic {
   }
 
   func oauthIntermediaryLogIn() {
-    //TODO: OE-514 cleanup
-//    guard let finalURL = oauthIntermediaryURL() else {
-//      return
-//    }
+    guard let finalURL = oauthIntermediaryURL() else {
+      return
+    }
+
     Log.debug(#function, "setting up observer for redirect URL")
     NotificationCenter.default
       .addObserver(self,
@@ -63,9 +63,9 @@ extension NYPLSignInBusinessLogic {
                    name: .NYPLAppDelegateDidReceiveCleverRedirectURL,
                    object: nil)
 
-//    NYPLMainThreadRun.asyncIfNeeded {
-//      UIApplication.shared.open(finalURL)
-//    }
+    NYPLMainThreadRun.asyncIfNeeded {
+      UIApplication.shared.open(finalURL)
+    }
   }
 
   //----------------------------------------------------------------------------

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+OAuth.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+OAuth.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension NYPLSignInBusinessLogic {
   //----------------------------------------------------------------------------
-  func oauthIntermediaryLogIn() {
+  func oauthIntermediaryURL() -> URL? {
     // for this kind of authentication, we want to redirect user to Safari to
     // conduct the process
     guard let oauthURL = selectedAuthentication?.oauthIntermediaryUrl else {
@@ -19,7 +19,7 @@ extension NYPLSignInBusinessLogic {
                                metadata: [
                                 "authMethod": selectedAuthentication?.methodDescription ?? "N/A",
                                 "context": uiDelegate?.context ?? "N/A"])
-      return
+      return nil
     }
 
     guard var urlComponents = URLComponents(url: oauthURL, resolvingAgainstBaseURL: true) else {
@@ -29,7 +29,7 @@ extension NYPLSignInBusinessLogic {
                                 "authMethod": selectedAuthentication?.methodDescription ?? "N/A",
                                 "OAUth Intermediary URL": oauthURL.absoluteString,
                                 "context": uiDelegate?.context ?? "N/A"])
-      return
+      return nil
     }
 
     let redirectParam = URLQueryItem(
@@ -45,18 +45,27 @@ extension NYPLSignInBusinessLogic {
                                 "OAUth Intermediary URL": oauthURL.absoluteString,
                                 "redirectParam": redirectParam,
                                 "context": uiDelegate?.context ?? "N/A"])
-      return
+      return nil
     }
 
+    return finalURL
+  }
+
+  func oauthIntermediaryLogIn() {
+    //TODO: OE-514 cleanup
+//    guard let finalURL = oauthIntermediaryURL() else {
+//      return
+//    }
+    Log.debug(#function, "setting up observer for redirect URL")
     NotificationCenter.default
       .addObserver(self,
                    selector: #selector(handleRedirectURL(_:)),
                    name: .NYPLAppDelegateDidReceiveCleverRedirectURL,
                    object: nil)
 
-    NYPLMainThreadRun.asyncIfNeeded {
-      UIApplication.shared.open(finalURL)
-    }
+//    NYPLMainThreadRun.asyncIfNeeded {
+//      UIApplication.shared.open(finalURL)
+//    }
   }
 
   //----------------------------------------------------------------------------
@@ -80,6 +89,7 @@ extension NYPLSignInBusinessLogic {
     NotificationCenter.default
       .removeObserver(self, name: .NYPLAppDelegateDidReceiveCleverRedirectURL, object: nil)
 
+    Log.debug(#function, "Received OAuth redirect with object \(String(describing: notification.object))")
     guard let url = notification.object as? URL else {
       NYPLErrorLogger.logError(withCode: .noURL,
                                summary: "Sign-in redirection error",

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
@@ -481,6 +481,7 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider, NYPLCurrentL
   }
 
   /// Updates the user account for the library we are signing in to.
+  ///
   /// - Parameters:
   ///   - drmSuccess: whether the DRM authorization was successful or not.
   ///   Ignored if the app is built without DRM support.
@@ -531,16 +532,6 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider, NYPLCurrentL
     }
 
     userAccount.authDefinition = selectedAuthentication
-
-    if libraryAccountID == libraryAccountsProvider.currentAccountId {
-      bookRegistry.syncResettingCache(false) { [weak bookRegistry] errorDict in
-        if errorDict == nil {
-          bookRegistry?.save()
-        }
-      }
-    }
-
-    NotificationCenter.default.post(name: .NYPLIsSigningIn, object: false)
   }
 
   private func setBarcode(_ barcode: String?, pin: String?) {

--- a/Simplified/SignInLogic/NYPLSignInCleverHelper.swift
+++ b/Simplified/SignInLogic/NYPLSignInCleverHelper.swift
@@ -1,0 +1,228 @@
+//
+//  NYPLCleverSignInHelper.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 6/16/22.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+
+import UIKit
+import SafariServices
+import AuthenticationServices
+
+class NYPLSignInCleverHelper: NSObject {
+
+  var signInBusinessLogic: NYPLSignInBusinessLogic!
+  weak var navigationController: UINavigationController?
+  var forceEditability: Bool = false
+  weak var postLoginConfigurator: OEAppUIStructureConfigurating?
+
+  init(navigationController: UINavigationController,
+       postLoginConfigurator: OEAppUIStructureConfigurating?) {
+    self.navigationController = navigationController
+    self.postLoginConfigurator = postLoginConfigurator
+
+    let drmAuthorizerAdobe: NYPLDRMAuthorizing?
+#if FEATURE_DRM_CONNECTOR
+    drmAuthorizerAdobe = NYPLADEPT.sharedInstance
+#else
+    drmAuthorizerAdobe = nil
+#endif
+
+    let drmAuthorizerAxis: NYPLDRMAuthorizing?
+#if AXIS
+    drmAuthorizerAxis = NYPLAxisDRMAuthorizer.sharedInstance
+#else
+    drmAuthorizerAxis = nil
+#endif
+
+    super.init()
+
+    let accountManager = AccountsManager.shared
+    self.signInBusinessLogic = NYPLSignInBusinessLogic(
+      libraryAccountID: accountManager.currentAccountId!, //TODO
+      libraryAccountsProvider: accountManager,
+      urlSettingsProvider: NYPLSettings.shared,
+      bookRegistry: NYPLBookRegistry.shared(),
+      bookDownloadsRemover: NYPLMyBooksDownloadCenter.shared(),
+      userAccountProvider: NYPLUserAccount.self,
+      uiDelegate: self,
+      drmAuthorizerAdobe: drmAuthorizerAdobe,
+      drmAuthorizerAxis: drmAuthorizerAxis)
+  }
+
+  func startCleverFlow() {
+    let cleverAuth = signInBusinessLogic.libraryAccount?.details?.auths.filter { auth in
+      auth.isOauthIntermediary
+    }.first
+
+    signInBusinessLogic.selectedIDP = nil
+    signInBusinessLogic.selectedAuthentication = cleverAuth
+    signInBusinessLogic.logIn()
+  }
+
+  private func openSafariVC(withCleverURL cleverURL: URL) {
+    Log.debug(#function, "about to push Safari VC")
+    let safariVC = SFSafariViewController(url: cleverURL)
+    if #available(iOS 11.0, *) {
+      safariVC.dismissButtonStyle = .cancel
+    }
+    safariVC.delegate = self
+    navigationController?.pushViewController(safariVC, animated: true)
+  }
+
+  private func openExternalBrowser(withCleverURL cleverURL: URL) {
+    NYPLMainThreadRun.asyncIfNeeded {
+      UIApplication.shared.open(cleverURL)
+    }
+  }
+
+  private func openAuthenticatedWebSession(withCleverURL cleverURL: URL) {
+    guard #available(iOS 12.0, *) else {
+      return
+    }
+
+    let webSession = ASWebAuthenticationSession(url: cleverURL,
+                                                callbackURLScheme: "https") { url, error in
+      let notif = Notification(name: .NYPLAppDelegateDidReceiveCleverRedirectURL,
+                               object: url)
+      self.signInBusinessLogic.handleRedirectURL(notif)
+    }
+    if #available(iOS 13.0, *) {
+      webSession.presentationContextProvider = self
+      webSession.prefersEphemeralWebBrowserSession = true
+    }
+
+    if !webSession.start() {
+      print("failed to start websession")
+    }
+  }
+}
+
+extension NYPLSignInCleverHelper: ASWebAuthenticationPresentationContextProviding {
+  @available(iOS 12.0, *)
+  func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+    if let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) {
+      return window
+    } else {
+      return ASPresentationAnchor()
+    }
+  }
+}
+
+extension NYPLSignInCleverHelper: NYPLSignInOutBusinessLogicUIDelegate {
+  func businessLogicWillSignOut(_ businessLogic: NYPLSignInBusinessLogic) {
+    // unused
+  }
+
+  func businessLogic(_ logic: NYPLSignInBusinessLogic, didEncounterSignOutError error: Error?, withHTTPStatusCode httpStatusCode: Int) {
+    // unused
+  }
+
+  func businessLogicDidFinishDeauthorizing(_ logic: NYPLSignInBusinessLogic) {
+    // unused
+  }
+
+  var context: String {
+    return "CleverHelper"
+  }
+
+  func businessLogicWillSignIn(_ signInBusinessLogic: NYPLSignInBusinessLogic) {
+    //TODO: OE-514 cleanup
+    guard let cleverURL = signInBusinessLogic.oauthIntermediaryURL() else {
+      return
+    }
+
+    // "https://circulation.openebooks.us/USOEI/oauth_authenticate?provider=Clever&redirect_uri=https://librarysimplified.org/callbacks/OpenEbooks"
+    if #available(iOS 12.0, *) {
+      openAuthenticatedWebSession(withCleverURL: cleverURL)
+    } else {
+      openSafariVC(withCleverURL: cleverURL)
+    }
+  }
+
+  func businessLogicDidCompleteSignIn(_ businessLogic: NYPLSignInBusinessLogic) {
+    DispatchQueue.main.async {
+      assert(businessLogic.userAccount.isSignedIn())
+      Log.debug(#function, "about to set up root VC; isSignedIn=\(businessLogic.userAccount.isSignedIn())")
+      self.postLoginConfigurator?.setUpRootVC()
+    }
+  }
+
+  func businessLogic(_ logic: NYPLSignInBusinessLogic,
+                     didEncounterValidationError error: Error?,
+                     userFriendlyErrorTitle title: String?,
+                     andMessage serverMessage: String?) {
+    let alert: UIAlertController!
+    if serverMessage != nil {
+      alert = NYPLAlertUtils.alert(title: title, message: serverMessage)
+    } else {
+      alert = NYPLAlertUtils.alert(title: title, error: error as? NSError)
+    }
+
+    self.present(alert, animated: true, completion: nil)
+  }
+
+  func dismiss(animated flag: Bool, completion: (() -> Void)?) {
+    navigationController?.dismiss(animated: flag, completion: completion)
+  }
+
+  func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
+    navigationController?.present(viewControllerToPresent, animated: flag, completion: completion)
+  }
+
+  // MARK: - NYPLBasicAuthCredentialsProvider
+
+  var username: String? {
+    return nil
+  }
+
+  var pin: String? {
+    return nil
+  }
+
+  var requiresUserAuthentication: Bool {
+    signInBusinessLogic.userAccount.requiresUserAuthentication
+  }
+
+  func hasCredentials() -> Bool {
+    signInBusinessLogic.userAccount.hasCredentials()
+  }
+
+  // MARK: - NYPLOAuthTokenProvider
+
+  var authToken: String? {
+    signInBusinessLogic.userAccount.authToken
+  }
+
+  func setAuthToken(_ token: String) {
+    signInBusinessLogic.userAccount.setAuthToken(token)
+  }
+
+  func hasOAuthClientCredentials() -> Bool {
+    return false
+  }
+
+  var oauthTokenRefreshURL: URL? {
+    signInBusinessLogic.userAccount.oauthTokenRefreshURL
+  }
+
+  // MARK: - NYPLUserAccountInputProvider
+
+  var usernameTextField: UITextField? {
+    return nil
+  }
+
+  var PINTextField: UITextField? {
+    return nil
+  }
+}
+
+// MARK: -
+
+//TODO: OE-514 cleanup
+extension NYPLSignInCleverHelper: SFSafariViewControllerDelegate {
+  func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+    navigationController?.popToRootViewController(animated: true)
+  }
+}

--- a/Simplified/SignInLogic/NYPLSignInCleverHelper.swift
+++ b/Simplified/SignInLogic/NYPLSignInCleverHelper.swift
@@ -7,8 +7,6 @@
 //
 
 import UIKit
-import SafariServices
-import AuthenticationServices
 
 class NYPLSignInCleverHelper: NSObject {
 
@@ -60,54 +58,6 @@ class NYPLSignInCleverHelper: NSObject {
     signInBusinessLogic.selectedAuthentication = cleverAuth
     signInBusinessLogic.logIn()
   }
-
-  private func openSafariVC(withCleverURL cleverURL: URL) {
-    Log.debug(#function, "about to push Safari VC")
-    let safariVC = SFSafariViewController(url: cleverURL)
-    if #available(iOS 11.0, *) {
-      safariVC.dismissButtonStyle = .cancel
-    }
-    safariVC.delegate = self
-    navigationController?.pushViewController(safariVC, animated: true)
-  }
-
-  private func openExternalBrowser(withCleverURL cleverURL: URL) {
-    NYPLMainThreadRun.asyncIfNeeded {
-      UIApplication.shared.open(cleverURL)
-    }
-  }
-
-  private func openAuthenticatedWebSession(withCleverURL cleverURL: URL) {
-    guard #available(iOS 12.0, *) else {
-      return
-    }
-
-    let webSession = ASWebAuthenticationSession(url: cleverURL,
-                                                callbackURLScheme: "https") { url, error in
-      let notif = Notification(name: .NYPLAppDelegateDidReceiveCleverRedirectURL,
-                               object: url)
-      self.signInBusinessLogic.handleRedirectURL(notif)
-    }
-    if #available(iOS 13.0, *) {
-      webSession.presentationContextProvider = self
-      webSession.prefersEphemeralWebBrowserSession = true
-    }
-
-    if !webSession.start() {
-      print("failed to start websession")
-    }
-  }
-}
-
-extension NYPLSignInCleverHelper: ASWebAuthenticationPresentationContextProviding {
-  @available(iOS 12.0, *)
-  func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-    if let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) {
-      return window
-    } else {
-      return ASPresentationAnchor()
-    }
-  }
 }
 
 extension NYPLSignInCleverHelper: NYPLSignInOutBusinessLogicUIDelegate {
@@ -128,17 +78,7 @@ extension NYPLSignInCleverHelper: NYPLSignInOutBusinessLogicUIDelegate {
   }
 
   func businessLogicWillSignIn(_ signInBusinessLogic: NYPLSignInBusinessLogic) {
-    //TODO: OE-514 cleanup
-    guard let cleverURL = signInBusinessLogic.oauthIntermediaryURL() else {
-      return
-    }
-
-    // "https://circulation.openebooks.us/USOEI/oauth_authenticate?provider=Clever&redirect_uri=https://librarysimplified.org/callbacks/OpenEbooks"
-    if #available(iOS 12.0, *) {
-      openAuthenticatedWebSession(withCleverURL: cleverURL)
-    } else {
-      openSafariVC(withCleverURL: cleverURL)
-    }
+    // unused
   }
 
   func businessLogicDidCompleteSignIn(_ businessLogic: NYPLSignInBusinessLogic) {
@@ -215,14 +155,5 @@ extension NYPLSignInCleverHelper: NYPLSignInOutBusinessLogicUIDelegate {
 
   var PINTextField: UITextField? {
     return nil
-  }
-}
-
-// MARK: -
-
-//TODO: OE-514 cleanup
-extension NYPLSignInCleverHelper: SFSafariViewControllerDelegate {
-  func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-    navigationController?.popToRootViewController(animated: true)
   }
 }

--- a/Simplified/SignInLogic/OELoginChoiceViewController.swift
+++ b/Simplified/SignInLogic/OELoginChoiceViewController.swift
@@ -82,7 +82,7 @@ class OELoginChoiceViewController : UIViewController {
   }
 
   @IBAction func showEULA() {
-    let eulaVC = NYPLWelcomeEULAViewController(displayOnly: true)
+    let eulaVC = OEEULAViewController(displayOnly: true)
     navigationController?.pushViewController(eulaVC, animated: true)
   }
 

--- a/Simplified/SignInLogic/OELoginChoiceViewController.swift
+++ b/Simplified/SignInLogic/OELoginChoiceViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import SafariServices
 
 class OELoginChoiceViewController : UIViewController {
   @IBOutlet var headerLabel: UILabel?

--- a/Simplified/SignInLogic/OELoginChoiceViewController.swift
+++ b/Simplified/SignInLogic/OELoginChoiceViewController.swift
@@ -17,7 +17,7 @@ class OELoginChoiceViewController : UIViewController {
   @IBOutlet var privacyButton: UIButton?
 
   weak var postLoginConfigurator: OEAppUIStructureConfigurating?
-  var cleverHelper: NYPLSignInCleverHelper?
+  var cleverHelper: OELoginCleverHelper?
   
   init(postLoginConfigurator: OEAppUIStructureConfigurating) {
     self.postLoginConfigurator = postLoginConfigurator
@@ -59,7 +59,7 @@ class OELoginChoiceViewController : UIViewController {
     firstBookLoginButton?.layer.borderWidth = 1
 
     if let navController = navigationController {
-      cleverHelper = NYPLSignInCleverHelper(navigationController: navController, postLoginConfigurator: postLoginConfigurator)
+      cleverHelper = OELoginCleverHelper(navigationController: navController, postLoginConfigurator: postLoginConfigurator)
     }
   }
   

--- a/Simplified/SignInLogic/OELoginChoiceViewController.swift
+++ b/Simplified/SignInLogic/OELoginChoiceViewController.swift
@@ -16,8 +16,10 @@ class OELoginChoiceViewController : UIViewController {
   @IBOutlet var termsButton: UIButton?
   @IBOutlet var privacyButton: UIButton?
 
+  weak var postLoginConfigurator: OEAppUIStructureConfigurating?
   
-  init() {
+  init(postLoginConfigurator: OEAppUIStructureConfigurating) {
+    self.postLoginConfigurator = postLoginConfigurator
     super.init(nibName: "OELoginChoice", bundle: nil)
   }
   
@@ -65,12 +67,12 @@ class OELoginChoiceViewController : UIViewController {
 
   @IBAction func didSelectFirstBook() {
     guard let libraryAccount = AccountsManager.shared.currentAccount else {
-      displayGenericAlert(for: "Unable to get library Account instance after selecting First Book as login choice")
+      NYPLAlertUtils.presentUnrecoverableAlert(for: "Unable to get library Account instance after selecting First Book as login choice")
       return
     }
 
     let firstBookVC = OELoginFirstBookVC(libraryAccount: libraryAccount,
-                                         loginSuccessCompletion: completeLogin)
+                                         postLoginConfigurator: postLoginConfigurator)
     navigationController?.pushViewController(firstBookVC, animated: true)
   }
 
@@ -92,24 +94,6 @@ class OELoginChoiceViewController : UIViewController {
   }
 
   // MARK: - Private
-
-  private func completeLogin() {
-    view.window?.rootViewController?.dismiss(animated: true, completion: nil)
-    dismiss(animated: true, completion: nil)
-
-    guard let appDelegate = UIApplication.shared.delegate else {
-      displayGenericAlert(for: "Could not load app delegate")
-      return
-    }
-
-    guard let appWindow = appDelegate.window else {
-      displayGenericAlert(for: "Could not load app window")
-      return
-    }
-
-    Log.info(#function, "Installing main root VC")
-    appWindow?.rootViewController = NYPLRootTabBarController.shared()
-  }
 
   private func didSelectAuthenticationMethod(_ loginChoice: LoginChoice) {
     let libAccount = AccountsManager.shared.currentAccount
@@ -136,13 +120,5 @@ class OELoginChoiceViewController : UIViewController {
     let signInVC = NYPLAccountSignInViewController(loginChoice: loginChoice)
     signInVC.presentIfNeeded(usingExistingCredentials: false,
                              completionHandler: self.completeLogin)
-  }
-
-  private func displayGenericAlert(for error: String) {
-    Log.error(#file, error)
-    let alert = UIAlertController(title: NSLocalizedString("Error", comment: ""),
-                                  message: NSLocalizedString("An unrecoverable error occurred. Please force-quit the app and try again.", comment: "Generic error message for internal errors"),
-                                  preferredStyle: .alert)
-    NYPLPresentationUtils.safelyPresent(alert)
   }
 }

--- a/Simplified/SignInLogic/OELoginCleverHelper.swift
+++ b/Simplified/SignInLogic/OELoginCleverHelper.swift
@@ -1,5 +1,5 @@
 //
-//  NYPLCleverSignInHelper.swift
+//  OELoginCleverHelper.swift
 //  Simplified
 //
 //  Created by Ettore Pasquini on 6/16/22.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class NYPLSignInCleverHelper: NSObject {
+class OELoginCleverHelper: NSObject {
 
   var signInBusinessLogic: NYPLSignInBusinessLogic!
   weak var navigationController: UINavigationController?
@@ -19,20 +19,6 @@ class NYPLSignInCleverHelper: NSObject {
        postLoginConfigurator: OEAppUIStructureConfigurating?) {
     self.navigationController = navigationController
     self.postLoginConfigurator = postLoginConfigurator
-
-    let drmAuthorizerAdobe: NYPLDRMAuthorizing?
-#if FEATURE_DRM_CONNECTOR
-    drmAuthorizerAdobe = NYPLADEPT.sharedInstance
-#else
-    drmAuthorizerAdobe = nil
-#endif
-
-    let drmAuthorizerAxis: NYPLDRMAuthorizing?
-#if AXIS
-    drmAuthorizerAxis = NYPLAxisDRMAuthorizer.sharedInstance
-#else
-    drmAuthorizerAxis = nil
-#endif
 
     super.init()
 
@@ -45,8 +31,8 @@ class NYPLSignInCleverHelper: NSObject {
       bookDownloadsRemover: NYPLMyBooksDownloadCenter.shared(),
       userAccountProvider: NYPLUserAccount.self,
       uiDelegate: self,
-      drmAuthorizerAdobe: drmAuthorizerAdobe,
-      drmAuthorizerAxis: drmAuthorizerAxis)
+      drmAuthorizerAdobe: nil,
+      drmAuthorizerAxis: NYPLAxisDRMAuthorizer.sharedInstance)
   }
 
   func startCleverFlow() {
@@ -60,7 +46,7 @@ class NYPLSignInCleverHelper: NSObject {
   }
 }
 
-extension NYPLSignInCleverHelper: NYPLSignInOutBusinessLogicUIDelegate {
+extension OELoginCleverHelper: NYPLSignInOutBusinessLogicUIDelegate {
   func businessLogicWillSignOut(_ businessLogic: NYPLSignInBusinessLogic) {
     // unused
   }

--- a/Simplified/SignInLogic/OELoginFirstBookVC.swift
+++ b/Simplified/SignInLogic/OELoginFirstBookVC.swift
@@ -27,6 +27,8 @@ class OELoginFirstBookVC: UIViewController {
   @IBOutlet var troublesButton: UIButton!
   @IBOutlet var faqButton: UIButton!
 
+  weak var postLoginConfigurator: OEAppUIStructureConfigurating?
+
   // MARK: - Validation logic
 
   private var businessLogic: NYPLSignInBusinessLogic!
@@ -40,12 +42,11 @@ class OELoginFirstBookVC: UIViewController {
   /// the @p NYPLSignInBusinessLogic.
   var forceEditability: Bool = false
 
-  private let loginSuccessCompletion: () -> Void
-
   // MARK: - Init / Deinit
 
-  init(libraryAccount: Account, loginSuccessCompletion: @escaping () -> Void) {
-    self.loginSuccessCompletion = loginSuccessCompletion
+  init(libraryAccount: Account,
+       postLoginConfigurator: OEAppUIStructureConfigurating?) {
+    self.postLoginConfigurator = postLoginConfigurator
 
     super.init(nibName: "OELoginFirstBookVC", bundle: nil)
 
@@ -259,9 +260,11 @@ extension OELoginFirstBookVC: NYPLSignInOutBusinessLogicUIDelegate {
   }
 
   func businessLogicDidCompleteSignIn(_ businessLogic: NYPLSignInBusinessLogic) {
-    signInButton.isUserInteractionEnabled = true
-    spinner.stopAnimating()
-    loginSuccessCompletion()
+    NYPLMainThreadRun.asyncIfNeeded { [self] in
+      signInButton.isUserInteractionEnabled = true
+      spinner.stopAnimating()
+      postLoginConfigurator?.setUpRootVC()
+    }
   }
 
   func businessLogic(_ logic: NYPLSignInBusinessLogic,

--- a/Simplified/WelcomeScreen/OEEULAViewController.swift
+++ b/Simplified/WelcomeScreen/OEEULAViewController.swift
@@ -1,6 +1,6 @@
 import WebKit
 
-class NYPLWelcomeEULAViewController : UIViewController {
+class OEEULAViewController: UIViewController {
   private static let offlineEULAPathComponent = "eula.html"
 
   private let onlineEULAURL = URL(string: "https://openebooks.net/app_user_agreement.html")!
@@ -95,13 +95,13 @@ class NYPLWelcomeEULAViewController : UIViewController {
     // prevent possible infinite loop
     attemptedLoadFromBundle = true
 
-    guard let filePath = Bundle.main.path(forResource: NYPLWelcomeEULAViewController.offlineEULAPathComponent, ofType: nil) else {
+    guard let filePath = Bundle.main.path(forResource: OEEULAViewController.offlineEULAPathComponent, ofType: nil) else {
 
       NYPLErrorLogger.logError(
         withCode: .noURL,
         summary: "Fallback EULA file not Present in Bundle",
         metadata: [
-          "hardcodedFileName": NYPLWelcomeEULAViewController.offlineEULAPathComponent
+          "hardcodedFileName": OEEULAViewController.offlineEULAPathComponent
         ]
       )
 
@@ -133,14 +133,14 @@ class NYPLWelcomeEULAViewController : UIViewController {
 
 // MARK:- WKNavigationDelegate
 
-extension NYPLWelcomeEULAViewController: WKNavigationDelegate {
+extension OEEULAViewController: WKNavigationDelegate {
   func webView(_ webView: WKWebView,
                decidePolicyFor navigationAction: WKNavigationAction,
                decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
     if navigationAction.request.url == onlineEULAURL {
       return decisionHandler(.allow)
 
-    } else if navigationAction.request.url?.lastPathComponent == NYPLWelcomeEULAViewController.offlineEULAPathComponent {
+    } else if navigationAction.request.url?.lastPathComponent == OEEULAViewController.offlineEULAPathComponent {
       return decisionHandler(.allow)
 
     } else if navigationAction.navigationType == .linkActivated,


### PR DESCRIPTION
**What's this do?**
Refactors Clever authentication logic for the new login harmonization flow. I left a checkin with the implementation of using SFSafariViewController and ASWebAuthenticationSession for the record, in case we want to get back to it.

This also fixes what I think were 3 related but separate bugs:
1. the getter for `NYPLUserAccount.authDefinition` could return a non null value even when we were signed out. For example, if the authentication document supported OAuthClientCredentials, the `hasOAuthClientCredentials()` function would return true in all cases, leading to think that we are signed in.
2. the signIn business logic updateUserAccount() method contained extra work that didn't belong there, and would result in confusing expectations
3. because saving on the keychain takes a while, we need to synchronize that process with the signing business logic. Otherwise we may end up in downstream logic (such as BookRegistry sync) that still thinks that we are not signed in.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-514

**How should this be tested? / Do these changes have associated tests?**
I'll update the ticket

**Dependencies for merging? Releasing to production?**
merging to feature branch

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
not yet

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
I tested this on OE and SE to avoid regressions. On SE I signed in on 1 library, then while still browsing that library catalog, I signed in on a new library. Then signed out from both.