### PR TITLE
OE-604 Fix delete data wordings for OEB

### DIFF
--- a/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
@@ -1725,7 +1725,11 @@ didEncounterSignOutError:(NSError *)error
     
     // Present alert and update sync button
     self.syncSwitch.on = NO;
+#ifdef SIMPLYE
     NSString *alertTitle = NSLocalizedString(@"You have successfully deleted your SimplyE data", nil);
+#else
+    NSString *alertTitle = NSLocalizedString(@"You have successfully deleted your Open eBooks data", nil);
+#endif
     UIAlertController *alert = [NYPLAlertUtils alertWithTitle:alertTitle message:nil];
     [NYPLAlertUtils presentFromViewControllerOrNilWithAlertController:alert viewController:self animated:YES completion:nil];
   }];

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -264,6 +264,7 @@
 "Please wait..." = "Please wait...";
 "Delete all the bookmarks you have saved in the cloud." = "Delete all the bookmarks you have saved in the cloud.";
 "You have successfully deleted your SimplyE data" = "You have successfully deleted your SimplyE data";
+"You have successfully deleted your Open eBooks data" = "You have successfully deleted your Open eBooks data";
 "Unsubscribe from emails" = "Unsubscribe from emails";
 "E-Mail to cancel your library card" = "E-Mail to cancel your library card";
 "If the above link does not work, please email us at" = "If the above link does not work, please email us at";

--- a/Simplified/it.lproj/Localizable.strings
+++ b/Simplified/it.lproj/Localizable.strings
@@ -257,12 +257,13 @@
 "13 or Older" = "13 o di più";
 
 // Account / Data deletion
-"Delete my SimplyE Data" = "Rimuovi i miei dati di SimplyE";
-"Delete my Open eBooks Data" = "Rimuovi i miei dati di Open eBooks";
+"Delete my SimplyE Data" = "Rimuovi i miei dati";
+"Delete my Open eBooks Data" = "Rimuovi i miei dati";
 "Delete Reading Data" = "Rimozione dati";
 "Please wait..." = "Attendere, prego...";
 "Delete all the bookmarks you have saved in the cloud." = "Tutti i segnalibri salvati sul server saranno rimossi.";
-"You have successfully deleted your SimplyE data" = "I tuoi dati di SimplyE sono stati rimossi";
+"You have successfully deleted your SimplyE data" = "I dati del tuo utente SimplyE sono stati rimossi";
+"You have successfully deleted your Open eBooks data" = "I dati del tuo utente Open eBooks sono stati rimossi";
 "Unsubscribe from emails" = "Rimuovimi dalle email";
 "E-Mail to cancel your library card" = "Manda una mail per cancellare la tua tessera";
 "If the above link does not work, please email us at" = "Se il link soprastante non funziona, manda una mail a";


### PR DESCRIPTION
**What's this do?**
The alert after deleting server data now shows Open eBooks instead of SimplyE
Bump version to 2.5.1

**Why are we doing this? (w/ JIRA link if applicable)**
[OE-604](https://jira.nypl.org/browse/OE-604)

**How should this be tested? / Do these changes have associated tests?**
Log into Open eBooks
Go to 'Account' -> 'Delete Server Data'
After deleting server data, it should show an alert with Open eBooks name on it

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
Yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 
