### PR TITLE
IOS-179 Surface book-downloading API errors

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -189,7 +189,6 @@
 		17BE24EF25FB114900AE707F /* simplye_authentication_document.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BE24EE25FB114900AE707F /* simplye_authentication_document.json */; };
 		17DFC5ED251E7FBC003A19CC /* AudioEngine.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; };
 		17DFC5F6251E84CF003A19CC /* AudioEngine.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		17E4030028B6069D00F6F5DE /* OverdriveProcessor in Frameworks */ = {isa = PBXBuildFile; productRef = 17E402FF28B6069D00F6F5DE /* OverdriveProcessor */; };
 		17E81F08261522B3001003C2 /* NYPLRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E81F07261522B3001003C2 /* NYPLRoundedButton.swift */; };
 		17E81F09261522B3001003C2 /* NYPLRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E81F07261522B3001003C2 /* NYPLRoundedButton.swift */; };
 		17E81F0B261522B3001003C2 /* NYPLRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E81F07261522B3001003C2 /* NYPLRoundedButton.swift */; };
@@ -961,6 +960,7 @@
 		73B5DFDD26052A1800225C12 /* NYPLBookButtonsState.m in Sources */ = {isa = PBXBuildFile; fileRef = 73B5DFDA26052A1800225C12 /* NYPLBookButtonsState.m */; };
 		73B5DFDF26052A1800225C12 /* NYPLBookButtonsState.m in Sources */ = {isa = PBXBuildFile; fileRef = 73B5DFDA26052A1800225C12 /* NYPLBookButtonsState.m */; };
 		73B5DFE026052A1800225C12 /* NYPLBookButtonsState.m in Sources */ = {isa = PBXBuildFile; fileRef = 73B5DFDA26052A1800225C12 /* NYPLBookButtonsState.m */; };
+		73B6E276278665AC0043FA30 /* OverdriveProcessor in Frameworks */ = {isa = PBXBuildFile; productRef = 73B6E275278665AC0043FA30 /* OverdriveProcessor */; };
 		73B6E278278665E10043FA30 /* OverdriveProcessor in Frameworks */ = {isa = PBXBuildFile; productRef = 73B6E277278665E10043FA30 /* OverdriveProcessor */; };
 		73B70A34284FCD8100BDF490 /* OELoginNavHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 73B70A33284FCD8100BDF490 /* OELoginNavHeader.xib */; };
 		73B80BAB25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B80BAA25509B43000BCAC1 /* NYPLSignInBusinessLogic+CardCreation.swift */; };
@@ -2510,6 +2510,8 @@
 				73829F4127861584008B2A80 /* NYPLAEToolkit in Frameworks */,
 				73A1731227ADA7D3005E7BCF /* NYPLAxis in Frameworks */,
 				7392E4602788E752006F010E /* NYPLAudiobookToolkit in Frameworks */,
+				73B6E276278665AC0043FA30 /* OverdriveProcessor in Frameworks */,
+				731465202786106900027CFA /* PureLayout in Frameworks */,
 				7392E4622788E75B006F010E /* NYPLCardCreator in Frameworks */,
 				73579046276BE7F2009F1ADF /* NYPLUtilities in Frameworks */,
 				732F046D2633783B0018A82E /* PDFRendererProvider.xcframework in Frameworks */,
@@ -3902,10 +3904,10 @@
 				73579045276BE7F2009F1ADF /* NYPLUtilities */,
 				7314651F2786106900027CFA /* PureLayout */,
 				73829F4027861584008B2A80 /* NYPLAEToolkit */,
+				73B6E275278665AC0043FA30 /* OverdriveProcessor */,
 				7392E45F2788E752006F010E /* NYPLAudiobookToolkit */,
 				7392E4612788E75B006F010E /* NYPLCardCreator */,
 				73A1731127ADA7D3005E7BCF /* NYPLAxis */,
-				17E402FF28B6069D00F6F5DE /* OverdriveProcessor */,
 			);
 			productName = Simplified;
 			productReference = A823D80D192BABA400B55DE2 /* SimplyE.app */;
@@ -6271,10 +6273,6 @@
 			package = 73579044276BE7F2009F1ADF /* XCRemoteSwiftPackageReference "iOS-Utilities" */;
 			productName = NYPLUtilities;
 		};
-		17E402FF28B6069D00F6F5DE /* OverdriveProcessor */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = OverdriveProcessor;
-		};
 		7314651F2786106900027CFA /* PureLayout */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 7314651E2786106900027CFA /* XCRemoteSwiftPackageReference "PureLayout" */;
@@ -6343,6 +6341,10 @@
 		73A1731327ADA80F005E7BCF /* NYPLAxis */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = NYPLAxis;
+		};
+		73B6E275278665AC0043FA30 /* OverdriveProcessor */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = OverdriveProcessor;
 		};
 		73B6E277278665E10043FA30 /* OverdriveProcessor */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -2506,7 +2506,6 @@
 				03B092301E78871A00AD338D /* MediaPlayer.framework in Frameworks */,
 				732F044E263376BB0018A82E /* Minizip.xcframework in Frameworks */,
 				7347B4DD265EFD1300E4E386 /* nanopb.xcframework in Frameworks */,
-				17E4030028B6069D00F6F5DE /* OverdriveProcessor in Frameworks */,
 				73829F4127861584008B2A80 /* NYPLAEToolkit in Frameworks */,
 				73A1731227ADA7D3005E7BCF /* NYPLAxis in Frameworks */,
 				7392E4602788E752006F010E /* NYPLAudiobookToolkit in Frameworks */,
@@ -5664,7 +5663,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -5715,7 +5714,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -5765,7 +5764,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -5813,7 +5812,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -5859,7 +5858,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Simplified/AppInfrastructure/Simplified-Prefix.pch";
@@ -5875,7 +5874,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.1;
+				MARKETING_VERSION = 2.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.OpenEbooks;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PROVISIONING_PROFILE = "2e185b6c-271e-4b02-a05e-860b8c3831f6";
@@ -5907,7 +5906,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Simplified/AppInfrastructure/Simplified-Prefix.pch";
@@ -5923,7 +5922,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.1;
+				MARKETING_VERSION = 2.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.OpenEbooks;
 				PRODUCT_MODULE_NAME = SimplyE;
 				PROVISIONING_PROFILE = "b3d9154d-70e1-48d6-a0c5-869431277a5c";
@@ -6083,7 +6082,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -6134,7 +6133,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/Simplified/AxisService/Download/NYPLAxisBookDownloadMediator.swift
+++ b/Simplified/AxisService/Download/NYPLAxisBookDownloadMediator.swift
@@ -25,8 +25,8 @@ class NYPLAxisBookDownloadMediator: NYPLAxisBookDownloadListening {
     delegate?.downloadProgressDidUpdate(to: progress, forBook: book)
   }
   
-  func downloadDidFail() {
-    delegate?.failDownloadWithAlert(forBook: book)
+  func downloadDidFail(with error: Error) {
+    delegate?.failDownloadWithAlert(forBook: book, error: error)
   }
   
   func didFinishDownloadingBook(to sourceLocation: URL) {

--- a/Simplified/AxisService/NYPLAxisServiceAdapter.swift
+++ b/Simplified/AxisService/NYPLAxisServiceAdapter.swift
@@ -11,7 +11,7 @@ import NYPLAxis
 
 @objc protocol NYPLBookDownloadBroadcasting {
   func downloadProgressDidUpdate(to progress: Double, forBook book: NYPLBook)
-  func failDownloadWithAlert(forBook book: NYPLBook)
+  func failDownloadWithAlert(forBook book: NYPLBook, error: Error?)
   func replaceBook(_ book: NYPLBook,
                    withFileAtURL sourceLocation: URL,
                    forDownloadTask downloadtask: URLSessionDownloadTask) -> Bool

--- a/Simplified/ErrorHandling/NYPLUserFriendlyError.swift
+++ b/Simplified/ErrorHandling/NYPLUserFriendlyError.swift
@@ -39,6 +39,7 @@ extension NYPLUserFriendlyError {
 extension NSError: NYPLUserFriendlyError {
   private static let problemDocumentKey = "problemDocument"
   public static let httpResponseKey = "response"
+  public static let httpResponseContentKey = "responseContent"
 
   @objc var problemDocument: NYPLProblemDocument? {
     return userInfo[NSError.problemDocumentKey] as? NYPLProblemDocument
@@ -79,5 +80,12 @@ extension NSError: NYPLUserFriendlyError {
     var userInfo = userInfo ?? [String: Any]()
     userInfo[NSError.problemDocumentKey] = problemDoc
     return NSError(domain: domain, code: code, userInfo: userInfo)
+  }
+
+  static func makeGenericServerErrorMessage(forHTTPStatus code: Int) -> String {
+    return NSLocalizedString("Server response failure", comment: "")
+    + " (" + String(code) + "). "
+    + NSLocalizedString("Please check your connection or try again later.",
+                        comment: "Generic recovery message")
   }
 }

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -190,7 +190,11 @@ extension NYPLNetworkResponder: URLSessionDataDelegate {
     // no problem document nor error, but response could still be a failure
     if let httpResponse = task.response as? HTTPURLResponse {
       guard httpResponse.isSuccess() else {
-        logMetadata[NSLocalizedDescriptionKey] = NSLocalizedString("Server response failure: please check your connection or try again later.", comment: "A generic error message for a HTTP response failure")
+        if let responseContent = String(data: responseData, encoding: .utf8) {
+          logMetadata[NSError.httpResponseContentKey] = responseContent
+        }
+        logMetadata[NSLocalizedDescriptionKey] = NSError.makeGenericServerErrorMessage(
+          forHTTPStatus: httpResponse.statusCode)
         NYPLErrorLogger.logNetworkError(code: NYPLErrorCode.responseFail,
                                         summary: "Network request failed: server error response",
                                         request: task.originalRequest,

--- a/Simplified/Network/NYPLOAuthTokenRefresher.swift
+++ b/Simplified/Network/NYPLOAuthTokenRefresher.swift
@@ -169,7 +169,9 @@ class NYPLOAuthTokenRefresher {
                                 response: URLResponse?,
                                 metadata: [String: Any]) -> NSError {
     var logMetadata = metadata
-    logMetadata[NSLocalizedDescriptionKey] = NSLocalizedString("Server response failure: please check your connection or try again later.", comment: "A generic error message for a HTTP response failure")
+    let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+    logMetadata[NSLocalizedDescriptionKey] = NSError.makeGenericServerErrorMessage(
+      forHTTPStatus: statusCode)
     NYPLErrorLogger.logNetworkError(code: NYPLErrorCode.responseFail,
                                     summary: "OAuth Client Credentials token refresh failure: no data",
                                     request: request,

--- a/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
@@ -829,7 +829,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
   [self.businessLogic startRegularCardCreationWithCompletion:^(UINavigationController * _Nullable navVC, NSError * _Nullable error) {
     [cell setUserInteractionEnabled:YES];
     if (error) {
-      UIAlertController *alert = [NYPLAlertUtils alertWithTitle:NSLocalizedString(@"Error", "Alert title") error:error];
+      UIAlertController *alert = [NYPLAlertUtils alertWithTitle:NSLocalizedString(@"Error", "Alert title") message: nil error:error];
       [NYPLAlertUtils presentFromViewControllerOrNilWithAlertController:alert
                                                          viewController:nil
                                                                animated:YES
@@ -868,6 +868,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
     if (error) {
       UIAlertController *alert = [NYPLAlertUtils
                                   alertWithTitle:NSLocalizedString(@"Error", "Alert title")
+                                  message: nil
                                   error:error];
       [NYPLAlertUtils presentFromViewControllerOrNilWithAlertController:alert
                                                          viewController:nil
@@ -1685,6 +1686,7 @@ didEncounterValidationError:(NSError *)error
                                    message:serverMessage];
   } else {
     alert = [NYPLAlertUtils alertWithTitle:title
+                                   message:nil
                                      error:error];
   }
 

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.m
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.m
@@ -530,7 +530,7 @@ didSelectRowAtIndexPath:(NSIndexPath *const)indexPath
   [self.businessLogic startRegularCardCreationWithCompletion:^(UINavigationController * _Nullable navVC, NSError * _Nullable error) {
     [cell setUserInteractionEnabled:YES];
     if (error) {
-      UIAlertController *alert = [NYPLAlertUtils alertWithTitle:NSLocalizedString(@"Error", "Alert title") error:error];
+      UIAlertController *alert = [NYPLAlertUtils alertWithTitle:NSLocalizedString(@"Error", "Alert title") message:nil error:error];
       [NYPLAlertUtils presentFromViewControllerOrNilWithAlertController:alert
                                                          viewController:nil
                                                                animated:YES
@@ -976,6 +976,7 @@ didEncounterValidationError:(NSError *)error
                                    message:serverMessage];
   } else {
     alert = [NYPLAlertUtils alertWithTitle:title
+                                   message:nil
                                      error:error];
   }
 

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -90,7 +90,8 @@
 "An unrecoverable error occurred. Please force-quit the app and try again." = "An unrecoverable error occurred. Please force-quit the app and try again.";
 
 // MARK: - Generic networking
-"Server response failure: please check your connection or try again later." = "Server response failure: please check your connection or try again later.";
+"Server response failure" = "Server response failure";
+"Please check your connection or try again later." = "Please check your connection or try again later.";
 "HTTP status" = "HTTP status";
 
 // MARK: - NYPLAppDelegate

--- a/Simplified/it.lproj/Localizable.strings
+++ b/Simplified/it.lproj/Localizable.strings
@@ -86,7 +86,8 @@
 "An unrecoverable error occurred. Please force-quit the app and try again." = "Si è verificato un errore critico. È consigliato chiudere l'applicazione e riprovare.";
 
 // MARK: - Generic networking
-"Server response failure: please check your connection or try again later." = "Comunicazione col server fallita: controlla la tua connessione a internet o riprova più tardi.";
+"Server response failure" = "Comunicazione col server fallita";
+"Please check your connection or try again later." = "Controlla la tua connessione a internet o riprova più tardi.";
 "HTTP status" = "Codice errore HTTP";
 
 // MARK: - NYPLAppDelegate


### PR DESCRIPTION
**What's this do?**
- expand NYPLAlertUtils to be able to combine app-generated error messages with server (or network interaction) -generated errors
- surface errors in some My Books interactions (especially Axis downloads)

**Why are we doing this? (w/ JIRA link if applicable)**
[IOS-179](https://jira.nypl.org/browse/IOS-179)

**How should this be tested? / Do these changes have associated tests?**
I will add some info in the ticket, although this might be hard to replicate

**Dependencies for merging? Releasing to production?**
https://github.com/NYPL-Simplified/Axis-iOS/pull/20 needs to be merged beforehand

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
yes

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
I did have an active Axis loan that I am unable to fulfill, so I was able to test this.