### PR TITLE
iOS-426 Implement unit tests for audiobook bookmark and updated related classes

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		179A0BCA28D15F4100FAB9AB /* NYPLBookmarkFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179A0BC628D15F4100FAB9AB /* NYPLBookmarkFactory.swift */; };
 		17A5AB4F25D201BD005DFF05 /* LCPPassphraseAuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A5AB4E25D201BD005DFF05 /* LCPPassphraseAuthenticationService.swift */; };
 		17A5AB5025D201BD005DFF05 /* LCPPassphraseAuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A5AB4E25D201BD005DFF05 /* LCPPassphraseAuthenticationService.swift */; };
+		17A9E7C928E6599900362040 /* NYPLBookRegistryMock+Audiobooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A9E7C828E6599900362040 /* NYPLBookRegistryMock+Audiobooks.swift */; };
 		17ADCF4F254BB84800D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17ADCF4E254BB84800D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift */; };
 		17ADCF54254BBA4E00D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17ADCF4E254BB84800D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift */; };
 		17BE24C125F2ED5400AE707F /* NYPLAgeCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BC315C1E009F3E0021B65E /* NYPLAgeCheck.swift */; };
@@ -194,6 +195,7 @@
 		17BE24E725FABCDE00AE707F /* NYPLUserAccountProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BE24E625FABCDE00AE707F /* NYPLUserAccountProviderMock.swift */; };
 		17BE24ED25FB09F000AE707F /* NYPLCurrentLibraryAccountProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BE24EC25FB09F000AE707F /* NYPLCurrentLibraryAccountProviderMock.swift */; };
 		17BE24EF25FB114900AE707F /* simplye_authentication_document.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BE24EE25FB114900AE707F /* simplye_authentication_document.json */; };
+		17C4F75328E62D050007BE9B /* NYPLAudiobookBookmarksBusinessLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C4F75228E62D050007BE9B /* NYPLAudiobookBookmarksBusinessLogicTests.swift */; };
 		17DFC5ED251E7FBC003A19CC /* AudioEngine.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; };
 		17DFC5F6251E84CF003A19CC /* AudioEngine.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		17E81F08261522B3001003C2 /* NYPLRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E81F07261522B3001003C2 /* NYPLRoundedButton.swift */; };
@@ -1873,12 +1875,14 @@
 		179A0BBD28CC0BA200FAB9AB /* NYPLAudiobookRegistryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAudiobookRegistryProvider.swift; sourceTree = "<group>"; };
 		179A0BC628D15F4100FAB9AB /* NYPLBookmarkFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBookmarkFactory.swift; sourceTree = "<group>"; };
 		17A5AB4E25D201BD005DFF05 /* LCPPassphraseAuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPPassphraseAuthenticationService.swift; sourceTree = "<group>"; };
+		17A9E7C828E6599900362040 /* NYPLBookRegistryMock+Audiobooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLBookRegistryMock+Audiobooks.swift"; sourceTree = "<group>"; };
 		17ADCF4E254BB84800D0A5FE /* NYPLReaderBookmarksBusinessLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLReaderBookmarksBusinessLogicTests.swift; sourceTree = "<group>"; };
 		17BE24D625F85D2300AE707F /* NYPLAgeCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAgeCheckTests.swift; sourceTree = "<group>"; };
 		17BE24DF25FABA0900AE707F /* NYPLAgeCheckChoiceStorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAgeCheckChoiceStorageMock.swift; sourceTree = "<group>"; };
 		17BE24E625FABCDE00AE707F /* NYPLUserAccountProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserAccountProviderMock.swift; sourceTree = "<group>"; };
 		17BE24EC25FB09F000AE707F /* NYPLCurrentLibraryAccountProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLCurrentLibraryAccountProviderMock.swift; sourceTree = "<group>"; };
 		17BE24EE25FB114900AE707F /* simplye_authentication_document.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = simplye_authentication_document.json; sourceTree = "<group>"; };
+		17C4F75228E62D050007BE9B /* NYPLAudiobookBookmarksBusinessLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAudiobookBookmarksBusinessLogicTests.swift; sourceTree = "<group>"; };
 		17CE5304243C020800315E63 /* NYPLUserAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserAccount.swift; sourceTree = "<group>"; };
 		17E81F07261522B3001003C2 /* NYPLRoundedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLRoundedButton.swift; sourceTree = "<group>"; };
 		17E81F31261FF758001003C2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -2991,6 +2995,7 @@
 				17BE24EC25FB09F000AE707F /* NYPLCurrentLibraryAccountProviderMock.swift */,
 				178AD3E7276053BE003A6C12 /* NYPLAnnotationsMock.swift */,
 				17843D2227853914000D488E /* NYPLOPDSFeedFetcherMock.swift */,
+				17A9E7C828E6599900362040 /* NYPLBookRegistryMock+Audiobooks.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -3737,6 +3742,7 @@
 				17BE24D625F85D2300AE707F /* NYPLAgeCheckTests.swift */,
 				5941F685268D1B2000F69F0B /* NYPLAxisTests */,
 				73BC2869269F995E0037930A /* NYPLReaderSettingsTests.swift */,
+				17C4F75228E62D050007BE9B /* NYPLAudiobookBookmarksBusinessLogicTests.swift */,
 			);
 			path = SimplifiedTests;
 			sourceTree = "<group>";
@@ -4353,6 +4359,7 @@
 				177C25F628B702EF00A786F1 /* NYPLBookmarkSpec+AudiobookTests.swift in Sources */,
 				7375AE5A25382AC900C85211 /* NYPLUserAccountMock.swift in Sources */,
 				73C3CF5A25CB8D6100CA8166 /* NYPLNetworkExecutorMock.swift in Sources */,
+				17C4F75328E62D050007BE9B /* NYPLAudiobookBookmarksBusinessLogicTests.swift in Sources */,
 				735771AE2537687D00067CEA /* NYPLURLSettingsProviderMock.swift in Sources */,
 				735771B12537691800067CEA /* NYPLDRMAuthorizingMock.swift in Sources */,
 				730EF263260955EF008E1DC3 /* NYPLBookmarkSpecTests.swift in Sources */,
@@ -4375,6 +4382,7 @@
 				735771AB2537650E00067CEA /* NYPLLibraryAccountsProviderMock.swift in Sources */,
 				1763C0D624F460FE00A4D0E2 /* NYPLAnnouncementManagerTests.swift in Sources */,
 				2D8790A520129AF200E2763F /* NYPLOPDSAcquisitionPathTests.swift in Sources */,
+				17A9E7C928E6599900362040 /* NYPLBookRegistryMock+Audiobooks.swift in Sources */,
 				735350B724918432006021BD /* URLRequest+NYPLTests.swift in Sources */,
 				73A794CA25492C9800C59CC1 /* NYPLFake.swift in Sources */,
 				7384C804242BCE5900D5F960 /* Date+NYPLAdditionsTests.swift in Sources */,

--- a/Simplified/Book/Models/NYPLBookRegistryRecord.h
+++ b/Simplified/Book/Models/NYPLBookRegistryRecord.h
@@ -13,7 +13,11 @@ typedef NS_ENUM(NSInteger, NYPLBookState);
 @property (nonatomic, readonly) NYPLBookState state;
 @property (nonatomic, readonly) NSString *fulfillmentId; // nilable
 @property (nonatomic, readonly) NSArray<NYPLReadiumBookmark *> *readiumBookmarks; // nilable
+#if FEATURE_AUDIOBOOKS
 @property (nonatomic, readonly) NSArray<NYPLAudiobookBookmark *> *audiobookBookmarks; // nilable
+#else
+@property (nonatomic, readonly) NSArray *audiobookBookmarks; // nilable
+#endif
 @property (nonatomic, readonly) NSArray<NYPLBookLocation *> *genericBookmarks; // nilable
 
 + (id)new NS_UNAVAILABLE;
@@ -25,7 +29,11 @@ typedef NS_ENUM(NSInteger, NYPLBookState);
                        state:(NYPLBookState)state
                fulfillmentId:(NSString *)fulfillmentId
             readiumBookmarks:(NSArray<NYPLReadiumBookmark *> *)readiumBookmarks
+#if FEATURE_AUDIOBOOKS
           audiobookBookmarks:(NSArray<NYPLAudiobookBookmark *> *)audiobookBookmarks
+#else
+          audiobookBookmarks:(NSArray *)audiobookBookmarks
+#endif
             genericBookmarks:(NSArray<NYPLBookLocation *> *)genericBookmarks;
 
 // designated initializer
@@ -43,7 +51,11 @@ typedef NS_ENUM(NSInteger, NYPLBookState);
 
 - (instancetype)recordWithReadiumBookmarks:(NSArray<NYPLReadiumBookmark *> *)bookmarks;
 
+#if FEATURE_AUDIOBOOKS
 - (instancetype)recordWithAudiobookBookmarks:(NSArray<NYPLAudiobookBookmark *> *)bookmarks;
+#else
+- (instancetype)recordWithAudiobookBookmarks:(NSArray *)bookmarks;
+#endif
 
 - (instancetype)recordWithGenericBookmarks:(NSArray<NYPLBookLocation *> *)bookmarks;
 

--- a/Simplified/Book/Models/NYPLBookRegistryRecord.m
+++ b/Simplified/Book/Models/NYPLBookRegistryRecord.m
@@ -35,7 +35,11 @@ static NSString *const GenericBookmarksKey = @"genericBookmarks";
                        state:(NYPLBookState)state
                fulfillmentId:(NSString *)fulfillmentId
             readiumBookmarks:(NSArray<NYPLReadiumBookmark *> *)readiumBookmarks
+#if FEATURE_AUDIOBOOKS
           audiobookBookmarks:(NSArray<NYPLAudiobookBookmark *> *)audiobookBookmarks
+#else
+          audiobookBookmarks:(NSArray *)audiobookBookmarks
+#endif
             genericBookmarks:(NSArray<NYPLBookLocation *> *)genericBookmarks
 {
   self = [super init];
@@ -238,7 +242,11 @@ static NSString *const GenericBookmarksKey = @"genericBookmarks";
                            genericBookmarks:self.genericBookmarks];
 }
 
+#if FEATURE_AUDIOBOOKS
 - (instancetype)recordWithAudiobookBookmarks:(NSArray<NYPLAudiobookBookmark *> *)bookmarks
+#else
+- (instancetype)recordWithAudiobookBookmarks:(NSArray *)bookmarks
+#endif
 {
   return [[[self class] alloc] initWithBook:self.book
                                    location:self.location

--- a/SimplifiedTests/Mocks/NYPLBookRegistryMock+Audiobooks.swift
+++ b/SimplifiedTests/Mocks/NYPLBookRegistryMock+Audiobooks.swift
@@ -1,0 +1,51 @@
+//
+//  NYPLBookRegistryMock+Audiobooks.swift
+//  SimplyETests
+//
+//  Created by Ernest Fan on 2022-09-29.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+
+import Foundation
+import NYPLAudiobookToolkit
+@testable import SimplyE
+
+extension NYPLBookRegistryMock: NYPLAudiobookRegistryProvider {
+  func audiobookBookmarks(for identifier: String) -> [NYPLAudiobookBookmark] {
+    guard let record = identifiersToRecords[identifier] else { return [NYPLAudiobookBookmark]() }
+    if let bookmarks = record.audiobookBookmarks as? [NYPLAudiobookBookmark] {
+      return bookmarks.sorted { $0.lessThan($1) }
+    } else {
+      return [NYPLAudiobookBookmark]()
+    }
+  }
+  
+  func addAudiobookBookmark(_ audiobookBookmark: NYPLAudiobookBookmark, for identifier: String) {
+    guard let record = identifiersToRecords[identifier] else { return }
+    var bookmarks = [NYPLAudiobookBookmark]()
+    if let recordBookmarks = record.audiobookBookmarks as? [NYPLAudiobookBookmark] {
+      bookmarks.append(contentsOf: recordBookmarks)
+    }
+    bookmarks.append(audiobookBookmark)
+    identifiersToRecords[identifier] = record.withAudiobookBookmarks(bookmarks)
+  }
+  
+  func deleteAudiobookBookmark(_ audiobookBookmark: NYPLAudiobookBookmark, for identifier: String) {
+    guard let record = identifiersToRecords[identifier] else { return }
+    if let bookmarks = record.audiobookBookmarks as? [NYPLAudiobookBookmark] {
+      let newBookmarks = bookmarks.filter { $0 != audiobookBookmark }
+      identifiersToRecords[identifier] = record.withAudiobookBookmarks(newBookmarks)
+    }
+  }
+  
+  func replaceAudiobookBookmark(_ oldAudiobookBookmark: NYPLAudiobookBookmark,
+                                with newAudiobookBookmark: NYPLAudiobookBookmark,
+                                for identifier: String) {
+    guard let record = identifiersToRecords[identifier] else { return }
+    if let bookmarks = record.audiobookBookmarks as? [NYPLAudiobookBookmark] {
+      var newBookmarks = bookmarks.filter { $0 != oldAudiobookBookmark }
+      newBookmarks.append(newAudiobookBookmark)
+      identifiersToRecords[identifier] = record.withAudiobookBookmarks(newBookmarks)
+    }
+  }
+}

--- a/SimplifiedTests/NYPLAudiobookBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLAudiobookBookmarksBusinessLogicTests.swift
@@ -1,0 +1,450 @@
+//
+//  NYPLAudiobookBookmarksBusinessLogicTests.swift
+//  SimplyETests
+//
+//  Created by Ernest Fan on 2022-09-29.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+
+import XCTest
+import NYPLAudiobookToolkit
+@testable import SimplyE
+
+class NYPLAudiobookBookmarksBusinessLogicTests: XCTestCase {
+  var bookmarkBusinessLogic: NYPLAudiobookBookmarksBusinessLogic!
+  var bookRegistryMock: NYPLBookRegistryMock!
+  var libraryAccountMock: NYPLLibraryAccountMock!
+  var annotationsMock: NYPLAnnotationsMock.Type!
+  var bookmarkCounter: Int = 0
+  let bookIdentifier = "fakeAudiobook"
+  let deviceID = "fakeDeviceID"
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    
+    let emptyUrl = URL.init(fileURLWithPath: "")
+    let fakeAcquisition = NYPLOPDSAcquisition.init(
+      relation: .generic,
+      type: "application/audiobook+zip",
+      hrefURL: emptyUrl,
+      indirectAcquisitions: [NYPLOPDSIndirectAcquisition](),
+      availability: NYPLOPDSAcquisitionAvailabilityUnlimited.init()
+    )
+    let fakeBook = NYPLBook.init(
+      acquisitions: [fakeAcquisition],
+      bookAuthors: [NYPLBookAuthor](),
+      categoryStrings: [String](),
+      distributor: "",
+      identifier: bookIdentifier,
+      imageURL: emptyUrl,
+      imageThumbnailURL: emptyUrl,
+      published: Date.init(),
+      publisher: "",
+      subtitle: "",
+      summary: "",
+      title: "",
+      updated: Date.init(),
+      annotationsURL: emptyUrl,
+      analyticsURL: emptyUrl,
+      alternateURL: emptyUrl,
+      relatedWorksURL: emptyUrl,
+      seriesURL: emptyUrl,
+      revokeURL: emptyUrl,
+      report: emptyUrl
+    )
+    
+    bookRegistryMock = NYPLBookRegistryMock()
+    bookRegistryMock.addBook(book: fakeBook, state: .DownloadSuccessful)
+    libraryAccountMock = NYPLLibraryAccountMock()
+    libraryAccountMock.currentAccount?.details?.syncPermissionGranted = true
+    annotationsMock = NYPLAnnotationsMock.self
+    bookmarkBusinessLogic = NYPLAudiobookBookmarksBusinessLogic(book: fakeBook,
+                                                                drmDeviceID: deviceID,
+                                                                bookRegistryProvider: bookRegistryMock,
+                                                                currentLibraryAccountProvider: libraryAccountMock,
+                                                                annotationsSynchronizer: annotationsMock)
+    bookmarkCounter = 0
+  }
+
+  override func tearDownWithError() throws {
+    try super.tearDownWithError()
+    bookmarkBusinessLogic = nil
+    libraryAccountMock = nil
+    bookRegistryMock.identifiersToRecords.removeAll()
+    bookRegistryMock = nil
+    bookmarkCounter = 0
+    annotationsMock.serverBookmarks.removeAll()
+    annotationsMock.readingPositions.removeAll()
+    annotationsMock = nil
+  }
+
+  // MARK: - Test updateLocalBookmarks
+
+  func testUpdateLocalBookmarksWithNoLocalBookmarks() throws {
+    var serverBookmarks = [NYPLAudiobookBookmark]()
+      
+    // Make sure BookRegistry contains no bookmark
+    XCTAssertEqual(bookRegistryMock.audiobookBookmarks(for: bookIdentifier).count, 0)
+    
+    guard let firstBookmark = newBookmark(title: "Title",
+                                          chapter: 1,
+                                          part: 1,
+                                          duration: 10.0,
+                                          time: 1.0,
+                                          audiobookId: bookIdentifier,
+                                          device: deviceID) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+    serverBookmarks.append(firstBookmark)
+
+    bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
+                                               localBookmarks: bookRegistryMock.audiobookBookmarks(for: bookIdentifier),
+                                               bookmarksFailedToUpload: [NYPLAudiobookBookmark]()) {
+      XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 1)
+    }
+  }
+
+  func testUpdateLocalBookmarksWithDuplicatedLocalBookmarks() throws {
+    var serverBookmarks = [NYPLAudiobookBookmark]()
+
+    // Make sure BookRegistry contains no bookmark
+    XCTAssertEqual(bookRegistryMock.audiobookBookmarks(for: bookIdentifier).count, 0)
+    
+    guard let firstBookmark = newBookmark(title: "Title",
+                                          chapter: 1,
+                                          part: 1,
+                                          duration: 10.0,
+                                          time: 1.0,
+                                          audiobookId: bookIdentifier,
+                                          device: deviceID),
+      let secondBookmark = newBookmark(title: "Title",
+                                       chapter: 1,
+                                       part: 1,
+                                       duration: 10.0,
+                                       time: 4.0,
+                                       audiobookId: bookIdentifier,
+                                       device: deviceID) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+      
+    serverBookmarks.append(firstBookmark)
+    serverBookmarks.append(secondBookmark)
+    bookRegistryMock.addAudiobookBookmark(firstBookmark, for: bookIdentifier)
+    XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 1)
+
+    // There are one duplicated bookmark and one non-synced (server) bookmark
+    bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
+                                               localBookmarks: bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier),
+                                               bookmarksFailedToUpload: [NYPLAudiobookBookmark]()) {
+      XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 2)
+    }
+  }
+
+  func testUpdateLocalBookmarksWithExtraLocalBookmarks() throws {
+    var serverBookmarks = [NYPLAudiobookBookmark]()
+
+    // Make sure BookRegistry contains no bookmark
+    XCTAssertEqual(bookRegistryMock.audiobookBookmarks(for: bookIdentifier).count, 0)
+    
+    guard let firstBookmark = newBookmark(title: "Title",
+                                          chapter: 1,
+                                          part: 1,
+                                          duration: 10.0,
+                                          time: 1.0,
+                                          audiobookId: bookIdentifier,
+                                          device: deviceID),
+      let secondBookmark = newBookmark(title: "Title",
+                                       chapter: 1,
+                                       part: 1,
+                                       duration: 10.0,
+                                       time: 4.0,
+                                       audiobookId: bookIdentifier,
+                                       device: deviceID) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+      
+    serverBookmarks.append(firstBookmark)
+    bookRegistryMock.addAudiobookBookmark(firstBookmark, for: bookIdentifier)
+    bookRegistryMock.addAudiobookBookmark(secondBookmark, for: bookIdentifier)
+    XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 2)
+
+    // There are one duplicated bookmark and one extra (local) bookmark,
+    // which means it has been delete from another device and should be removed locally
+    bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
+                                               localBookmarks: bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier),
+                                               bookmarksFailedToUpload: [NYPLAudiobookBookmark]()) {
+      XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 1)
+      
+      XCTAssertEqual (self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).first, firstBookmark)
+    }
+  }
+
+  func testUpdateLocalBookmarksWithFailedUploadBookmarks() throws {
+    var serverBookmarks = [NYPLAudiobookBookmark]()
+
+    // Make sure BookRegistry contains no bookmark
+    XCTAssertEqual(bookRegistryMock.audiobookBookmarks(for: bookIdentifier).count, 0)
+    
+    guard let firstBookmark = newBookmark(title: "Title",
+                                          chapter: 1,
+                                          part: 1,
+                                          duration: 10.0,
+                                          time: 1.0,
+                                          audiobookId: bookIdentifier,
+                                          device: deviceID),
+      let secondBookmark = newBookmark(title: "Title",
+                                       chapter: 1,
+                                       part: 1,
+                                       duration: 10.0,
+                                       time: 3.0,
+                                       audiobookId: bookIdentifier,
+                                       device: deviceID) else {
+      XCTFail("Failed to create new bookmark")
+      return
+    }
+      
+    serverBookmarks.append(firstBookmark)
+    bookRegistryMock.addAudiobookBookmark(firstBookmark, for: bookIdentifier)
+    XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 1)
+      
+    // There are one duplicated bookmark and one failed-to-upload bookmark
+    bookmarkBusinessLogic.updateLocalBookmarks(serverBookmarks: serverBookmarks,
+                                               localBookmarks: bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier),
+                                               bookmarksFailedToUpload: [secondBookmark]) {
+      XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 2)
+    }
+  }
+
+  // MARK: - Test addBookmark/postBookmark
+
+  func testAddBookmarkWithSucceededUpload() throws {
+    // Make sure server contains no bookmark
+    annotationsMock.getServerBookmarks(of: NYPLAudiobookBookmark.self,
+                                       forBook: bookIdentifier,
+                                       publication: nil,
+                                       atURL: nil) { bookmarks in
+      XCTAssertEqual(bookmarks, nil)
+    }
+    
+    
+    guard let chapterLocation = ChapterLocation(number: 1, part: 1, duration: 10.0, startOffset: 0, playheadOffset: 1.0, title: "Title", audiobookID: bookIdentifier) else {
+      XCTFail("Failed to create chapter location")
+      return
+    }
+    bookmarkBusinessLogic.addAudiobookBookmark(chapterLocation)
+    
+    // There should be one bookmark uploaded
+    XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 1)
+    annotationsMock.getServerBookmarks(of: NYPLAudiobookBookmark.self,
+                                       forBook: bookIdentifier,
+                                       publication: nil,
+                                       atURL: nil) { bookmarks in
+      guard let bookmarks = bookmarks else {
+        XCTFail("Failed to get bookmark from server")
+        return
+      }
+      XCTAssertEqual(bookmarks.count, 1)
+    }
+  }
+
+  func testAddBookmarkWithFailedUpload() throws {
+    // Make sure server contains no bookmark
+    annotationsMock.getServerBookmarks(of: NYPLAudiobookBookmark.self,
+                                       forBook: bookIdentifier,
+                                       publication: nil,
+                                       atURL: nil) { bookmarks in
+      XCTAssertEqual(bookmarks, nil)
+    }
+    
+    annotationsMock.failRequest = true
+    guard let chapterLocation = ChapterLocation(number: 1, part: 1, duration: 10.0, startOffset: 0, playheadOffset: 1.0, title: "Title", audiobookID: bookIdentifier) else {
+      XCTFail("Failed to create chapter location")
+      return
+    }
+    
+    // BookRegistry should have one bookmark even upload failed
+    // While server should not have any bookmarks
+    bookmarkBusinessLogic.addAudiobookBookmark(chapterLocation)
+    XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 1)
+    
+    annotationsMock.failRequest = false
+    annotationsMock.getServerBookmarks(of: NYPLAudiobookBookmark.self,
+                                       forBook: bookIdentifier,
+                                       publication: nil,
+                                       atURL: nil) { bookmarks in
+      XCTAssertEqual(bookmarks, nil)
+    }
+  }
+  
+  func testAddBookmarkWithNotDuplicatedBookmarks() throws {
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 0)
+    
+    guard let firstChapterLocation = ChapterLocation(number: 1, part: 1, duration: 10.0, startOffset: 0, playheadOffset: 1.0, title: "Title", audiobookID: bookIdentifier) else {
+      XCTFail("Failed to create chapter location")
+      return
+    }
+    bookmarkBusinessLogic.addAudiobookBookmark(firstChapterLocation)
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 1)
+    
+    // Adding bookmark with exact same chapter location
+    bookmarkBusinessLogic.addAudiobookBookmark(firstChapterLocation)
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 1)
+    
+    guard let secondChapterLocation = ChapterLocation(number: 1, part: 2, duration: 50.0, startOffset: 0, playheadOffset: 15.0, title: "Title", audiobookID: bookIdentifier),
+          let secondDuplicatedChapterLocation = ChapterLocation(number: 1, part: 2, duration: 50.0, startOffset: 0, playheadOffset: 18.0, title: "Title", audiobookID: bookIdentifier) else {
+      XCTFail("Failed to create chapter location")
+      return
+    }
+    bookmarkBusinessLogic.addAudiobookBookmark(secondChapterLocation)
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 2)
+    
+    // Adding bookmark with matching chapter location and 3s difference (considered as different bookmark)
+    bookmarkBusinessLogic.addAudiobookBookmark(secondDuplicatedChapterLocation)
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 3)
+    
+    guard let thirdChapterLocation = ChapterLocation(number: 1, part: 3, duration: 70.0, startOffset: 0, playheadOffset: 35.0, title: "Title", audiobookID: bookIdentifier),
+          let thirdDuplicatedChapterLocation = ChapterLocation(number: 1, part: 3, duration: 70.0, startOffset: 0, playheadOffset: 32.0, title: "Title", audiobookID: bookIdentifier) else {
+      XCTFail("Failed to create chapter location")
+      return
+    }
+    bookmarkBusinessLogic.addAudiobookBookmark(thirdChapterLocation)
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 4)
+    
+    // Adding bookmark with matching chapter location and 3s difference in backward direction (considered as different bookmark)
+    bookmarkBusinessLogic.addAudiobookBookmark(thirdDuplicatedChapterLocation)
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 5)
+  }
+  
+  func testAddBookmarkWithDuplicatedBookmarks() throws {
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 0)
+    
+    guard let firstChapterLocation = ChapterLocation(number: 1, part: 1, duration: 10.0, startOffset: 0, playheadOffset: 1.0, title: "Title", audiobookID: bookIdentifier) else {
+      XCTFail("Failed to create chapter location")
+      return
+    }
+    bookmarkBusinessLogic.addAudiobookBookmark(firstChapterLocation)
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 1)
+    
+    // Adding bookmark with same chapter location
+    bookmarkBusinessLogic.addAudiobookBookmark(firstChapterLocation)
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 1)
+    
+    guard let secondChapterLocation = ChapterLocation(number: 1, part: 2, duration: 50.0, startOffset: 0, playheadOffset: 15.0, title: "Title", audiobookID: bookIdentifier),
+          let secondDuplicatedChapterLocation = ChapterLocation(number: 1, part: 2, duration: 50.0, startOffset: 0, playheadOffset: 17.9, title: "Title", audiobookID: bookIdentifier) else {
+      XCTFail("Failed to create chapter location")
+      return
+    }
+    bookmarkBusinessLogic.addAudiobookBookmark(secondChapterLocation)
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 2)
+    
+    // Adding bookmark with matching chapter location and offset difference smaller than 3s (considered as same bookmark)
+    bookmarkBusinessLogic.addAudiobookBookmark(secondDuplicatedChapterLocation)
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 2)
+    
+    guard let thirdChapterLocation = ChapterLocation(number: 1, part: 3, duration: 70.0, startOffset: 0, playheadOffset: 35.0, title: "Title", audiobookID: bookIdentifier),
+          let thirdDuplicatedChapterLocation = ChapterLocation(number: 1, part: 3, duration: 70.0, startOffset: 0, playheadOffset: 32.1, title: "Title", audiobookID: bookIdentifier) else {
+      XCTFail("Failed to create chapter location")
+      return
+    }
+    bookmarkBusinessLogic.addAudiobookBookmark(thirdChapterLocation)
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 3)
+    
+    // Adding bookmark with matching chapter location and offset difference smaller than 3s in backward direction (considered as same bookmark)
+    bookmarkBusinessLogic.addAudiobookBookmark(thirdDuplicatedChapterLocation)
+    XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 3)
+  }
+
+  // MARK: - Test deleteBookmark/didDeleteBookmark
+  
+  func testDeleteBookmarkWithValidIndex() throws {
+    
+    guard let firstChapterLocation = ChapterLocation(number: 1, part: 1, duration: 10.0, startOffset: 0, playheadOffset: 1.0, title: "Title", audiobookID: bookIdentifier) else {
+      XCTFail("Failed to create chapter location")
+      return
+    }
+    bookmarkBusinessLogic.addAudiobookBookmark(firstChapterLocation)
+    
+    guard let secondChapterLocation = ChapterLocation(number: 1, part: 2, duration: 50.0, startOffset: 0, playheadOffset: 15.0, title: "Title", audiobookID: bookIdentifier) else {
+      XCTFail("Failed to create chapter location")
+      return
+    }
+    bookmarkBusinessLogic.addAudiobookBookmark(secondChapterLocation)
+    
+    // Make sure we have the right amount of bookmarks in BookRegistry
+    XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 2)
+    
+    // Deleting bookmark at index
+    bookmarkBusinessLogic.deleteAudiobookBookmark(at: 1)
+    
+    // BookRegistry should have one bookmark after deletion
+    // Server should not contain the deleted bookmark
+    XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 1)
+    annotationsMock.getServerBookmarks(of: NYPLAudiobookBookmark.self,
+                                       forBook: bookIdentifier,
+                                       publication: nil,
+                                       atURL: nil) { bookmarks in
+      guard let bookmarks = bookmarks else {
+        XCTFail("Failed to get bookmark from server")
+        return
+      }
+      for bookmark in bookmarks {
+        if bookmark.locationMatches(secondChapterLocation) {
+          XCTFail("Failed to delete bookmark")
+        }
+      }
+    }
+  }
+  
+  func testDeleteBookmarkWithInvalidIndex() throws {
+    guard let firstChapterLocation = ChapterLocation(number: 1, part: 1, duration: 10.0, startOffset: 0, playheadOffset: 1.0, title: "Title", audiobookID: bookIdentifier) else {
+      XCTFail("Failed to create chapter location")
+      return
+    }
+    bookmarkBusinessLogic.addAudiobookBookmark(firstChapterLocation)
+    
+    guard let secondChapterLocation = ChapterLocation(number: 1, part: 2, duration: 50.0, startOffset: 0, playheadOffset: 15.0, title: "Title", audiobookID: bookIdentifier) else {
+      XCTFail("Failed to create chapter location")
+      return
+    }
+    bookmarkBusinessLogic.addAudiobookBookmark(secondChapterLocation)
+    // Make sure we have the right amount of bookmarks in BookRegistry
+    XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 2)
+    
+    // Deleting bookmark at invalid index
+    bookmarkBusinessLogic.deleteAudiobookBookmark(at: -1)
+    
+    // Bookmarks in BookRegistry should remain unchanged
+    XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 2)
+    
+    // Deleting bookmark at invalid index
+    bookmarkBusinessLogic.deleteAudiobookBookmark(at: 3)
+    
+    // Bookmarks in BookRegistry should remain unchanged
+    XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 2)
+  }
+  
+  // MARK: Helper
+
+  private func newBookmark(title: String? = nil,
+                           chapter: UInt,
+                           part: UInt,
+                           duration: TimeInterval,
+                           time: TimeInterval,
+                           audiobookId: String,
+                           device: String? = nil) -> NYPLAudiobookBookmark? {
+    // Annotation id needs to be unique
+    bookmarkCounter += 1
+    return NYPLAudiobookBookmark(title: title,
+                                 chapter: chapter,
+                                 part: part,
+                                 duration: duration,
+                                 time: time,
+                                 audiobookId: audiobookId,
+                                 annotationId: "fakeAnnotationID\(bookmarkCounter)",
+                                 device: device,
+                                 creationTime: Date())
+  }
+}


### PR DESCRIPTION
**What's this do?**
Implement unit tests for audiobook bookmark business logic
Update NYPLBookRegistryMock and NYPLBookRegistryRecord

**Why are we doing this? (w/ JIRA link if applicable)**
[iOS-426](https://jira.nypl.org/browse/IOS-426)

**How should this be tested? / Do these changes have associated tests?**
Unit tests should be ran by CI

**Dependencies for merging? Releasing to production?**
Will update the NYPLAudiobookToolkit commit ref once the other PR is merged

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 
