### PR TITLE
iOS-425 Integrate audiobook bookmark business logic into audiobook manager

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -196,6 +196,9 @@
 		17BE24ED25FB09F000AE707F /* NYPLCurrentLibraryAccountProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BE24EC25FB09F000AE707F /* NYPLCurrentLibraryAccountProviderMock.swift */; };
 		17BE24EF25FB114900AE707F /* simplye_authentication_document.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BE24EE25FB114900AE707F /* simplye_authentication_document.json */; };
 		17C4F75328E62D050007BE9B /* NYPLAudiobookBookmarksBusinessLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C4F75228E62D050007BE9B /* NYPLAudiobookBookmarksBusinessLogicTests.swift */; };
+		17D8633C29031A750096F11A /* NYPLBookCellDelegate+AudiobookBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D8633B29031A750096F11A /* NYPLBookCellDelegate+AudiobookBookmark.swift */; };
+		17D8633D29031A760096F11A /* NYPLBookCellDelegate+AudiobookBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D8633B29031A750096F11A /* NYPLBookCellDelegate+AudiobookBookmark.swift */; };
+		17D8633E29031A760096F11A /* NYPLBookCellDelegate+AudiobookBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D8633B29031A750096F11A /* NYPLBookCellDelegate+AudiobookBookmark.swift */; };
 		17DFC5ED251E7FBC003A19CC /* AudioEngine.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; };
 		17DFC5F6251E84CF003A19CC /* AudioEngine.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 176F8A802519684D00CE5BFB /* AudioEngine.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		17E81F08261522B3001003C2 /* NYPLRoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E81F07261522B3001003C2 /* NYPLRoundedButton.swift */; };
@@ -1884,6 +1887,7 @@
 		17BE24EE25FB114900AE707F /* simplye_authentication_document.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = simplye_authentication_document.json; sourceTree = "<group>"; };
 		17C4F75228E62D050007BE9B /* NYPLAudiobookBookmarksBusinessLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLAudiobookBookmarksBusinessLogicTests.swift; sourceTree = "<group>"; };
 		17CE5304243C020800315E63 /* NYPLUserAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLUserAccount.swift; sourceTree = "<group>"; };
+		17D8633B29031A750096F11A /* NYPLBookCellDelegate+AudiobookBookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLBookCellDelegate+AudiobookBookmark.swift"; sourceTree = "<group>"; };
 		17E81F07261522B3001003C2 /* NYPLRoundedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLRoundedButton.swift; sourceTree = "<group>"; };
 		17E81F31261FF758001003C2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		17E81F332620DAE0001003C2 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = it; path = it.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -3214,6 +3218,7 @@
 				085D31D61BE29E38007F7672 /* NYPLProblemReportViewController.m */,
 				085D31D81BE29ED4007F7672 /* NYPLProblemReportViewController.xib */,
 				17123D4227CEFB5700088193 /* NYPLBookCellDelegate+AudiobookProgressSaving.swift */,
+				17D8633B29031A750096F11A /* NYPLBookCellDelegate+AudiobookBookmark.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -4463,6 +4468,7 @@
 				73A172FD27ADA6FA005E7BCF /* NYPLAxisContentProtection.swift in Sources */,
 				7386C1F824525AFF004C78BD /* NYPLReaderTOCBusinessLogic.swift in Sources */,
 				172F410B26F3BAF70017476A /* NYPLConfiguration+Color.swift in Sources */,
+				17D8633D29031A760096F11A /* NYPLBookCellDelegate+AudiobookBookmark.swift in Sources */,
 				739E6059244A0D8600D00301 /* NYPLAlertUtils.swift in Sources */,
 				739E605A244A0D8600D00301 /* OPDS2Publication.swift in Sources */,
 				739E605B244A0D8600D00301 /* String+MD5.swift in Sources */,
@@ -4833,6 +4839,7 @@
 				73ED943A271F95F3001E5B73 /* NYPLBookCellDelegate+Audiobooks.m in Sources */,
 				73EB0ACD25821DF4006BC997 /* NYPLMyBooksDownloadInfo.m in Sources */,
 				73EB0ACE25821DF4006BC997 /* NYPLBookLocation.m in Sources */,
+				17D8633E29031A760096F11A /* NYPLBookCellDelegate+AudiobookBookmark.swift in Sources */,
 				73EB0ACF25821DF4006BC997 /* NYPLFacetView.m in Sources */,
 				1785228E27F52B59004445ED /* AudiobookManifestAdapter.swift in Sources */,
 				2126FE3C25C059810095C45C /* ReaderError.swift in Sources */,
@@ -5229,6 +5236,7 @@
 				5D1B142A22CC179F0006C964 /* NYPLAlertUtils.swift in Sources */,
 				7386C1F724525AFF004C78BD /* NYPLReaderTOCBusinessLogic.swift in Sources */,
 				172F410A26F3BAF70017476A /* NYPLConfiguration+Color.swift in Sources */,
+				17D8633C29031A750096F11A /* NYPLBookCellDelegate+AudiobookBookmark.swift in Sources */,
 				B51C1E0222861BBF003B49A5 /* OPDS2Publication.swift in Sources */,
 				5DD567AF22B95A30001F0C83 /* String+MD5.swift in Sources */,
 				E671FF7D1E3A7068002AB13F /* NYPLNetworkQueue.swift in Sources */,
@@ -5679,7 +5687,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -5730,7 +5738,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -5780,7 +5788,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -5828,7 +5836,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -6098,7 +6106,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -6149,7 +6157,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Simplified/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 7262U6ST2R;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/Simplified/Audiobooks/Bookmark/NYPLAudiobookBookmarksBusinessLogic.swift
+++ b/Simplified/Audiobooks/Bookmark/NYPLAudiobookBookmarksBusinessLogic.swift
@@ -25,7 +25,7 @@ class NYPLAudiobookBookmarksBusinessLogic: NYPLAudiobookBookmarking {
   /// of the same chapter into the dictionary. This improve the performance by
   /// avoiding comparison between the current location and
   /// all the existing bookmarks of this audiobook.
-  var bookmarksDictionary: [String: [NYPLAudiobookBookmark]]
+  private var bookmarksDictionary: [String: [NYPLAudiobookBookmark]]
   
   let book: NYPLBook
   private let drmDeviceID: String?
@@ -329,8 +329,8 @@ class NYPLAudiobookBookmarksBusinessLogic: NYPLAudiobookBookmarking {
   
   private func addBookmarkToDictionary(_ bookmark: NYPLAudiobookBookmark) {
     let key = key(for: bookmark)
-    if let existingBookmarks = bookmarksDictionary[key] {
-      let newBookmarks = existingBookmarks + [bookmark]
+    if let existingChapterBookmarks = bookmarksDictionary[key] {
+      let newBookmarks = existingChapterBookmarks + [bookmark]
       bookmarksDictionary[key] = newBookmarks.sorted { $0 < $1 }
     } else {
       bookmarksDictionary[key] = [bookmark]

--- a/Simplified/Book/Models/NYPLBookRegistry.h
+++ b/Simplified/Book/Models/NYPLBookRegistry.h
@@ -29,7 +29,15 @@ typedef NS_ENUM(NSInteger, NYPLBookState);
 
 @end
 
+#if FEATURE_AUDIOBOOKS
+// Hiding warnings for protocol defined in Swift is not accessible in ObjC
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
+@interface NYPLBookRegistry : NSObject <NYPLBookRegistryProvider, NYPLAudiobookRegistryProvider>
+#pragma clang diagnostic pop
+#else
 @interface NYPLBookRegistry : NSObject <NYPLBookRegistryProvider>
+#endif
 
 // Returns all registered books.
 @property (atomic, readonly, nonnull) NSArray *allBooks;
@@ -216,6 +224,18 @@ genericBookmarks:(nullable NSArray<NYPLBookLocation *> *)genericBookmarks;
 // Delete a generic bookmark (book location) for a book given its identifier
 - (void)deleteGenericBookmark:(nonnull NYPLBookLocation *)bookmark
                 forIdentifier:(nonnull NSString *)identifier;
+
+#if FEATURE_AUDIOBOOKS
+- (NSArray<NYPLAudiobookBookmark *> * _Nonnull)audiobookBookmarksForIdentifier:(NSString * _Nonnull)identifier;
+
+- (void)addAudiobookBookmark:(nonnull NYPLAudiobookBookmark *)bookmark
+               forIdentifier:(nonnull NSString *)identifier;
+
+- (void)deleteAudiobookBookmark:(NYPLAudiobookBookmark * _Nonnull)audiobookBookmark forIdentifier:(NSString * _Nonnull)identifier;
+
+
+- (void)replaceAudiobookBookmark:(NYPLAudiobookBookmark * _Nonnull)oldAudiobookBookmark withNewAudiobookBookmark:(NYPLAudiobookBookmark * _Nonnull)newAudiobookBookmark forIdentifier:(NSString * _Nonnull)identifier;
+#endif
 
 // Given an identifier, this method removes a book from the registry. Attempting to remove a book
 // that is not present will result in an error being logged.

--- a/Simplified/Book/Models/NYPLBookRegistry.m
+++ b/Simplified/Book/Models/NYPLBookRegistry.m
@@ -10,11 +10,8 @@
 
 #if FEATURE_AUDIOBOOKS
 @import NYPLAudiobookToolkit;
-
-@interface NYPLBookRegistry () <NYPLAudiobookRegistryProvider>
-#else
-@interface NYPLBookRegistry ()
 #endif
+@interface NYPLBookRegistry ()
 
 @property (nonatomic) NYPLBookCoverRegistry *coverRegistry;
 @property (nonatomic) NSMutableDictionary *identifiersToRecords;

--- a/Simplified/Book/UI/NYPLBookCellDelegate+AudiobookBookmark.swift
+++ b/Simplified/Book/UI/NYPLBookCellDelegate+AudiobookBookmark.swift
@@ -14,11 +14,13 @@ import UIKit
 /// The NYPLAudiobookBookmarksBusinessLogic is not accessible from ObjC,
 /// so we do this in a Swift extension file.
 @objc extension NYPLBookCellDelegate {
-  @objc(setBookmarkBusinessLogicForBook:AudiobookManager:)
-  func setBookmarkBusinessLogic(for book: NYPLBook, _ audiobookManager: DefaultAudiobookManager) {
+  @objc(setBookmarkBusinessLogicForBook:AudiobookManager:AudiobookRegistryProvider:)
+  func setBookmarkBusinessLogic(for book: NYPLBook,
+                                audiobookManager: DefaultAudiobookManager,
+                                audiobookRegistryProvider: NYPLAudiobookRegistryProvider) {
     let bizLogic = NYPLAudiobookBookmarksBusinessLogic(book: book,
                                                        drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
-                                                       bookRegistryProvider: NYPLBookRegistry.shared(),
+                                                       bookRegistryProvider: audiobookRegistryProvider,
                                                        currentLibraryAccountProvider: AccountsManager.shared,
                                                        annotationsSynchronizer: NYPLAnnotations.self)
     audiobookManager.bookmarkBusinessLogic = bizLogic

--- a/Simplified/Book/UI/NYPLBookCellDelegate+AudiobookBookmark.swift
+++ b/Simplified/Book/UI/NYPLBookCellDelegate+AudiobookBookmark.swift
@@ -1,0 +1,27 @@
+//
+//  NYPLBookCellDelegate+AudiobookBookmark.swift
+//  Simplified
+//
+//  Created by Ernest Fan on 2022-10-21.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+
+#if FEATURE_AUDIOBOOKS
+import Foundation
+import NYPLAudiobookToolkit
+import UIKit
+
+/// The NYPLAudiobookBookmarksBusinessLogic is not accessible from ObjC,
+/// so we do this in a Swift extension file.
+@objc extension NYPLBookCellDelegate {
+  @objc(setBookmarkBusinessLogicForBook:AudiobookManager:)
+  func setBookmarkBusinessLogic(for book: NYPLBook, _ audiobookManager: DefaultAudiobookManager) {
+    let bizLogic = NYPLAudiobookBookmarksBusinessLogic(book: book,
+                                                       drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
+                                                       bookRegistryProvider: NYPLBookRegistry.shared(),
+                                                       currentLibraryAccountProvider: AccountsManager.shared,
+                                                       annotationsSynchronizer: NYPLAnnotations.self)
+    audiobookManager.bookmarkBusinessLogic = bizLogic
+  }
+}
+#endif

--- a/Simplified/Book/UI/NYPLBookCellDelegate+Audiobooks.m
+++ b/Simplified/Book/UI/NYPLBookCellDelegate+Audiobooks.m
@@ -58,6 +58,7 @@
 }
 
 - (void)presentAudiobook:(NYPLBook *)book withAudiobookManager:(DefaultAudiobookManager *)audiobookManager {
+  [self setBookmarkBusinessLogicForBook:book AudiobookManager:audiobookManager];
   [NYPLMainThreadRun asyncIfNeeded:^{
     AudiobookPlayerViewController *audiobookVC = [self createPlayerVCForAudiobook:audiobookManager.audiobook
                                                                          withBook:book

--- a/Simplified/Book/UI/NYPLBookCellDelegate+Audiobooks.m
+++ b/Simplified/Book/UI/NYPLBookCellDelegate+Audiobooks.m
@@ -58,7 +58,7 @@
 }
 
 - (void)presentAudiobook:(NYPLBook *)book withAudiobookManager:(DefaultAudiobookManager *)audiobookManager {
-  [self setBookmarkBusinessLogicForBook:book AudiobookManager:audiobookManager];
+  [self setBookmarkBusinessLogicForBook:book AudiobookManager:audiobookManager AudiobookRegistryProvider:[NYPLBookRegistry sharedRegistry]];
   [NYPLMainThreadRun asyncIfNeeded:^{
     AudiobookPlayerViewController *audiobookVC = [self createPlayerVCForAudiobook:audiobookManager.audiobook
                                                                          withBook:book

--- a/Simplified/en.lproj/Localizable.strings
+++ b/Simplified/en.lproj/Localizable.strings
@@ -181,6 +181,8 @@
 "ReaderTOCViewControllerTitle" = "Table of Contents";
 "%@ through chapter" = "%@ through chapter";
 "There are no bookmarks for this book." = "There are no bookmarks for this book.";
+"Error Syncing Bookmarks" = "Error Syncing Bookmarks";
+"There was an error syncing bookmarks to the server. Ensure your device is connected to the internet or try again later." = "There was an error syncing bookmarks to the server. Ensure your device is connected to the internet or try again later.";
 
 // MARK: - Reader error messages (R2)
 "Content Protection Error" = "Content Protection Error";

--- a/Simplified/it.lproj/Localizable.strings
+++ b/Simplified/it.lproj/Localizable.strings
@@ -177,6 +177,8 @@
 "ReaderTOCViewControllerTitle" = "Sommario";
 "%@ through chapter" = "%@ del capitolo";
 "There are no bookmarks for this book." = "Non ci sono segnalibri per questo libro.";
+"Error Syncing Bookmarks" = "Errore nella sincronizzazione dei segnalibri";
+"There was an error syncing bookmarks to the server. Ensure your device is connected to the internet or try again later." = "Si è verificato un errore nella sincronizzazione dei segnalibri. Assicurati che il tuo dispositivo sia collegato a internet e riprova.";
 
 // MARK: - Reader error messages (R2)
 "Content Protection Error" = "Errore nella protezione del contenuto";

--- a/SimplifiedTests/NYPLAudiobookBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLAudiobookBookmarksBusinessLogicTests.swift
@@ -294,26 +294,26 @@ class NYPLAudiobookBookmarksBusinessLogicTests: XCTestCase {
     XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 1)
     
     guard let secondChapterLocation = ChapterLocation(number: 1, part: 2, duration: 50.0, startOffset: 0, playheadOffset: 15.0, title: "Title", audiobookID: bookIdentifier),
-          let secondDuplicatedChapterLocation = ChapterLocation(number: 1, part: 2, duration: 50.0, startOffset: 0, playheadOffset: 18.0, title: "Title", audiobookID: bookIdentifier) else {
+          let secondDuplicatedChapterLocation = ChapterLocation(number: 1, part: 2, duration: 50.0, startOffset: 0, playheadOffset: 18.1, title: "Title", audiobookID: bookIdentifier) else {
       XCTFail("Failed to create chapter location")
       return
     }
     bookmarkBusinessLogic.addAudiobookBookmark(secondChapterLocation)
     XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 2)
     
-    // Adding bookmark with matching chapter location and 3s difference (considered as different bookmark)
+    // Adding bookmark with matching chapter location and >3s difference (considered as different bookmark)
     bookmarkBusinessLogic.addAudiobookBookmark(secondDuplicatedChapterLocation)
     XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 3)
     
     guard let thirdChapterLocation = ChapterLocation(number: 1, part: 3, duration: 70.0, startOffset: 0, playheadOffset: 35.0, title: "Title", audiobookID: bookIdentifier),
-          let thirdDuplicatedChapterLocation = ChapterLocation(number: 1, part: 3, duration: 70.0, startOffset: 0, playheadOffset: 32.0, title: "Title", audiobookID: bookIdentifier) else {
+          let thirdDuplicatedChapterLocation = ChapterLocation(number: 1, part: 3, duration: 70.0, startOffset: 0, playheadOffset: 31.9, title: "Title", audiobookID: bookIdentifier) else {
       XCTFail("Failed to create chapter location")
       return
     }
     bookmarkBusinessLogic.addAudiobookBookmark(thirdChapterLocation)
     XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 4)
     
-    // Adding bookmark with matching chapter location and 3s difference in backward direction (considered as different bookmark)
+    // Adding bookmark with matching chapter location and >3s difference in backward direction (considered as different bookmark)
     bookmarkBusinessLogic.addAudiobookBookmark(thirdDuplicatedChapterLocation)
     XCTAssertEqual(bookmarkBusinessLogic.bookmarksCount, 5)
   }

--- a/SimplifiedTests/NYPLAudiobookBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLAudiobookBookmarksBusinessLogicTests.swift
@@ -377,7 +377,7 @@ class NYPLAudiobookBookmarksBusinessLogicTests: XCTestCase {
     XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 2)
     
     // Deleting bookmark at index
-    XCTAssertEqual(bookmarkBusinessLogic.deleteAudiobookBookmark(at: 1), true)
+    XCTAssertTrue(bookmarkBusinessLogic.deleteAudiobookBookmark(at: 1))
     
     // BookRegistry should have one bookmark after deletion
     // Server should not contain the deleted bookmark
@@ -414,13 +414,13 @@ class NYPLAudiobookBookmarksBusinessLogicTests: XCTestCase {
     XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 2)
     
     // Deleting bookmark at invalid index
-    XCTAssertEqual(bookmarkBusinessLogic.deleteAudiobookBookmark(at: -1), false)
+    XCTAssertFalse(bookmarkBusinessLogic.deleteAudiobookBookmark(at: -1))
     
     // Bookmarks in BookRegistry should remain unchanged
     XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 2)
     
     // Deleting bookmark at invalid index
-    XCTAssertEqual(bookmarkBusinessLogic.deleteAudiobookBookmark(at: 3), false)
+    XCTAssertFalse(bookmarkBusinessLogic.deleteAudiobookBookmark(at: 3))
     
     // Bookmarks in BookRegistry should remain unchanged
     XCTAssertEqual(self.bookRegistryMock.audiobookBookmarks(for: self.bookIdentifier).count, 2)
@@ -436,7 +436,7 @@ class NYPLAudiobookBookmarksBusinessLogicTests: XCTestCase {
     bookmarkBusinessLogic.addAudiobookBookmark(chapterLocation)
     XCTAssertNotNil(bookmarkBusinessLogic.bookmarkExisting(at:chapterLocation))
     
-    XCTAssertEqual(bookmarkBusinessLogic.deleteAudiobookBookmark(at: 0), true)
+    XCTAssertTrue(bookmarkBusinessLogic.deleteAudiobookBookmark(at: 0))
     XCTAssertNil(bookmarkBusinessLogic.bookmarkExisting(at:chapterLocation))
   }
   
@@ -459,27 +459,27 @@ class NYPLAudiobookBookmarksBusinessLogicTests: XCTestCase {
       return
     }
     
-    XCTAssertEqual(bookmarkBusinessLogic.bookmarkIsFirstInChapter(firstBookmark), true)
-    XCTAssertEqual(bookmarkBusinessLogic.bookmarkIsFirstInChapter(secondBookmark), false)
-    XCTAssertEqual(bookmarkBusinessLogic.bookmarkIsFirstInChapter(thirdBookmark), false)
+    XCTAssertTrue(bookmarkBusinessLogic.bookmarkIsFirstInChapter(firstBookmark))
+    XCTAssertFalse(bookmarkBusinessLogic.bookmarkIsFirstInChapter(secondBookmark))
+    XCTAssertFalse(bookmarkBusinessLogic.bookmarkIsFirstInChapter(thirdBookmark))
     
     // Delete first bookmark, secondBookmark should now be the first bookmark in the chapter
     XCTAssertNotNil(bookmarkBusinessLogic.deleteAudiobookBookmark(firstBookmark))
-    XCTAssertEqual(bookmarkBusinessLogic.bookmarkIsFirstInChapter(firstBookmark), false)
-    XCTAssertEqual(bookmarkBusinessLogic.bookmarkIsFirstInChapter(secondBookmark), true)
-    XCTAssertEqual(bookmarkBusinessLogic.bookmarkIsFirstInChapter(thirdBookmark), false)
+    XCTAssertFalse(bookmarkBusinessLogic.bookmarkIsFirstInChapter(firstBookmark))
+    XCTAssertTrue(bookmarkBusinessLogic.bookmarkIsFirstInChapter(secondBookmark))
+    XCTAssertFalse(bookmarkBusinessLogic.bookmarkIsFirstInChapter(thirdBookmark))
     
     // Delete second bookmark, thirdBookmark should now be the first bookmark in the chapter
     XCTAssertNotNil(bookmarkBusinessLogic.deleteAudiobookBookmark(secondBookmark))
-    XCTAssertEqual(bookmarkBusinessLogic.bookmarkIsFirstInChapter(firstBookmark), false)
-    XCTAssertEqual(bookmarkBusinessLogic.bookmarkIsFirstInChapter(secondBookmark), false)
-    XCTAssertEqual(bookmarkBusinessLogic.bookmarkIsFirstInChapter(thirdBookmark), true)
+    XCTAssertFalse(bookmarkBusinessLogic.bookmarkIsFirstInChapter(firstBookmark))
+    XCTAssertFalse(bookmarkBusinessLogic.bookmarkIsFirstInChapter(secondBookmark))
+    XCTAssertTrue(bookmarkBusinessLogic.bookmarkIsFirstInChapter(thirdBookmark))
     
     // Delete third bookmark, there should now be no bookmarks in the chapter
     XCTAssertNotNil(bookmarkBusinessLogic.deleteAudiobookBookmark(thirdBookmark))
-    XCTAssertEqual(bookmarkBusinessLogic.bookmarkIsFirstInChapter(firstBookmark), false)
-    XCTAssertEqual(bookmarkBusinessLogic.bookmarkIsFirstInChapter(secondBookmark), false)
-    XCTAssertEqual(bookmarkBusinessLogic.bookmarkIsFirstInChapter(thirdBookmark), false)
+    XCTAssertFalse(bookmarkBusinessLogic.bookmarkIsFirstInChapter(firstBookmark))
+    XCTAssertFalse(bookmarkBusinessLogic.bookmarkIsFirstInChapter(secondBookmark))
+    XCTAssertFalse(bookmarkBusinessLogic.bookmarkIsFirstInChapter(thirdBookmark))
 
   }
   


### PR DESCRIPTION
**What's this do?**
Integrate bookmark business logic into audiobook manager
Update NYPLAudiobookToolkit commit ref
Update localized strings
Update related unit tests

**Why are we doing this? (w/ JIRA link if applicable)**
[iOS-424](https://jira.nypl.org/browse/IOS-424)
[iOS-425](https://jira.nypl.org/browse/IOS-425)

**How should this be tested? / Do these changes have associated tests?**
See ticket

**Dependencies for merging? Releasing to production?**
Updated NYPLAudiobookToolkit

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
Yes

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 