### PR TITLE
PJR-69 Remove download logic dependency from book opening logic

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -2527,7 +2527,6 @@
 				73579046276BE7F2009F1ADF /* NYPLUtilities in Frameworks */,
 				732F046D2633783B0018A82E /* PDFRendererProvider.xcframework in Frameworks */,
 				7347B4E5265EFD3C00E4E386 /* PromisesObjC.xcframework in Frameworks */,
-				731465202786106900027CFA /* PureLayout in Frameworks */,
 				03B092241E78839D00AD338D /* QuartzCore.framework in Frameworks */,
 				732F0486263379680018A82E /* R2Navigator.xcframework in Frameworks */,
 				732F0490263379BA0018A82E /* R2Shared.xcframework in Frameworks */,

--- a/Simplified/Accounts/User/NYPLUserAccount.swift
+++ b/Simplified/Accounts/User/NYPLUserAccount.swift
@@ -41,7 +41,7 @@ private enum StorageKey: String {
   static func sharedAccount(libraryUUID: String?) -> NYPLUserAccount
 }
 
-@objc protocol NYPLOAuthTokenProvider {
+@objc protocol NYPLOAuthTokenSource {
   var authToken: String? { get }
   func setAuthToken(_ token: String)
   func hasOAuthClientCredentials() -> Bool
@@ -58,7 +58,7 @@ private enum StorageKey: String {
 /// by storing credentials on the keychain using storage keys that contain the
 /// the library UUID appended after the actual key name.
 /// - seealso: StorageKey.keyForLibrary(uuid:)
-@objcMembers class NYPLUserAccount : NSObject, NYPLUserAccountProvider, NYPLOAuthTokenProvider {
+@objcMembers class NYPLUserAccount : NSObject, NYPLUserAccountProvider, NYPLOAuthTokenSource {
   static private let shared = NYPLUserAccount()
 
   private let accountInfoLock = NSRecursiveLock()

--- a/Simplified/AxisService/Download/NYPLAxisNetworkExecutor.swift
+++ b/Simplified/AxisService/Download/NYPLAxisNetworkExecutor.swift
@@ -16,7 +16,7 @@ class NYPLAxisNetworkExecutor: NYPLAxisNetworkExecuting {
   
   init() {
     self.requestExecutor = NYPLNetworkExecutor(
-      credentialsProvider: NYPLUserAccount.sharedAccount(),
+      credentialsSource: NYPLUserAccount.sharedAccount(),
       cachingStrategy: .ephemeral)
   }
   

--- a/Simplified/AxisService/Read/NYPLAxisBookReadingAdapter.swift
+++ b/Simplified/AxisService/Read/NYPLAxisBookReadingAdapter.swift
@@ -36,9 +36,9 @@ struct NYPLAxisBookReadingAdapter {
   ///   - asset: R2 book asset on disk associated to a NYPLBook
   ///   - completion: Returns a R2 tuple containing the PublicationAsset and
   ///   its Content Protection, or an error.
-  func openAsset(_ asset: FileAsset,
-                 fetcher: Fetcher,
-                 completion: @escaping ProtectedAssetCompletion) {
+  func open(asset: FileAsset,
+            fetcher: Fetcher,
+            completion: @escaping ProtectedAssetCompletion) {
     
     let licenseService = NYPLAxisLicenseService(axisItemDownloader: downloader,
                                                 cypher: decryptor.cypher,
@@ -83,6 +83,4 @@ struct NYPLAxisBookReadingAdapter {
                                         onCreatePublication: nil)
     return protectedAsset
   }
-  
-  
 }

--- a/Simplified/AxisService/Read/NYPLAxisBookReadingAdapter.swift
+++ b/Simplified/AxisService/Read/NYPLAxisBookReadingAdapter.swift
@@ -13,20 +13,18 @@ import R2Streamer
 
 struct NYPLAxisBookReadingAdapter {
   
-  private let axisKeysProvider: NYPLAxisKeysProviding
   private let decryptor: NYPLAxisContentDecrypting
   private let downloader: NYPLAxisItemDownloading
   
-  init?(axisKeysProvider: NYPLAxisKeysProviding = NYPLAxisKeysProvider(),
-       decryptor: NYPLAxisContentDecrypting? = NYPLAxisContentDecryptor(),
-       downloader: NYPLAxisItemDownloading = NYPLAxisItemDownloader(downloader: NYPLAxisContentDownloader(), errorLogger: NYPLAxisErrorLogsAdapter())
+  init?(decryptor: NYPLAxisContentDecrypting? = NYPLAxisContentDecryptor(),
+        downloader: NYPLAxisItemDownloading = NYPLAxisItemDownloader(downloader: NYPLAxisContentDownloader(),
+                                                                     errorLogger: NYPLAxisErrorLogsAdapter())
   ) {
     
     guard let decryptor = decryptor else {
       return nil
     }
     
-    self.axisKeysProvider = axisKeysProvider
     self.decryptor = decryptor
     self.downloader = downloader
   }

--- a/Simplified/AxisService/Read/NYPLAxisBookReadingAdapter.swift
+++ b/Simplified/AxisService/Read/NYPLAxisBookReadingAdapter.swift
@@ -12,21 +12,14 @@ import R2Shared
 import R2Streamer
 
 struct NYPLAxisBookReadingAdapter {
-  
   private let decryptor: NYPLAxisContentDecrypting
-  private let downloader: NYPLAxisItemDownloading
-  
-  init?(decryptor: NYPLAxisContentDecrypting? = NYPLAxisContentDecryptor(),
-        downloader: NYPLAxisItemDownloading = NYPLAxisItemDownloader(downloader: NYPLAxisContentDownloader(),
-                                                                     errorLogger: NYPLAxisErrorLogsAdapter())
-  ) {
-    
+
+  init?(decryptor: NYPLAxisContentDecrypting? = NYPLAxisContentDecryptor()) {
     guard let decryptor = decryptor else {
       return nil
     }
     
     self.decryptor = decryptor
-    self.downloader = downloader
   }
   
   /// Given an asset on disk, obtains the R2 ProtectedAsset needed to open
@@ -40,14 +33,13 @@ struct NYPLAxisBookReadingAdapter {
             fetcher: Fetcher,
             completion: @escaping ProtectedAssetCompletion) {
     
-    let licenseService = NYPLAxisLicenseService(axisItemDownloader: downloader,
-                                                cypher: decryptor.cypher,
-                                                errorLogger: NYPLAxisErrorLogsAdapter(),
-                                                parentDirectory: asset.url)
+    let licenseService = NYPLAxisLicenseExtractService(
+      errorLogger: NYPLAxisErrorLogsAdapter(),
+      parentDirectory: asset.url)
     
     // we decrypt the encrypted key (used to unlock content) and use that
     // to get the ProtectedAsset
-    licenseService.extractAESKey { result in
+    licenseService.extractAESKeyFromDisk { result in
       switch result {
       case .success(let key):
         // If it succeeded and returned data is nil,

--- a/Simplified/Book/UI/NYPLBookDetailViewController.m
+++ b/Simplified/Book/UI/NYPLBookDetailViewController.m
@@ -41,7 +41,7 @@
   self.book = book;
     
   self.executor = [[NYPLNetworkExecutor alloc]
-                   initWithCredentialsProvider:NYPLUserAccount.sharedAccount
+                   initWithCredentialsSource:NYPLUserAccount.sharedAccount
                    cachingStrategy:NYPLCachingStrategyEphemeral
                    waitsForConnectivity:YES
                    delegateQueue:nil];

--- a/Simplified/Network/NYPLNetworkResponder.swift
+++ b/Simplified/Network/NYPLNetworkResponder.swift
@@ -37,7 +37,7 @@ class NYPLNetworkResponder: NSObject {
 
   /// The object providing the credentials to respond to an authentication
   /// challenge.
-  let credentialsProvider: NYPLBasicAuthCredentialsProvider & NYPLOAuthTokenProvider
+  let credentialsSource: NYPLBasicAuthCredentialsProvider & NYPLOAuthTokenSource
 
   var oauthTokenRefresher: NYPLOAuthTokenRefresher?
 
@@ -45,14 +45,14 @@ class NYPLNetworkResponder: NSObject {
   /// - Parameter shouldEnableFallbackCaching: If set to `true`, the executor
   /// will attempt to cache responses even when these lack a sufficient set of
   /// caching headers. The default is `false`.
-  /// - Parameter credentialsProvider: The object providing the credentials
+  /// - Parameter credentialsSource: The object providing the credentials
   /// to respond to an authentication challenge.
-  init(credentialsProvider: NYPLBasicAuthCredentialsProvider & NYPLOAuthTokenProvider,
+  init(credentialsSource: NYPLBasicAuthCredentialsProvider & NYPLOAuthTokenSource,
        useFallbackCaching: Bool = false) {
     self.taskInfo = [Int: NYPLNetworkTaskInfo]()
     self.taskInfoLock = NSRecursiveLock()
     self.useFallbackCaching = useFallbackCaching
-    self.credentialsProvider = credentialsProvider
+    self.credentialsSource = credentialsSource
     super.init()
   }
 
@@ -163,7 +163,7 @@ extension NYPLNetworkResponder: URLSessionDataDelegate {
       // if we detect an expired client credentials token,
       // nil it out so that next time it will trigger a token refresh
       let problemDoc = errorWithProblemDoc.problemDocument
-      if credentialsProvider.hasOAuthClientCredentials(),
+      if credentialsSource.hasOAuthClientCredentials(),
          response.indicatesAuthenticationNeedsRefresh(with: problemDoc) {
         oauthTokenRefresher?.currentToken = nil
       }
@@ -301,7 +301,7 @@ extension NYPLNetworkResponder: URLSessionTaskDelegate {
                   didReceive challenge: URLAuthenticationChallenge,
                   completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
   {
-    let authChallenger = NYPLBasicAuth(credentialsProvider: credentialsProvider)
+    let authChallenger = NYPLBasicAuth(credentialsProvider: credentialsSource)
     authChallenger.handleChallenge(challenge, completion: completionHandler)
   }
 }

--- a/Simplified/Network/NYPLOAuthTokenRefresher.swift
+++ b/Simplified/Network/NYPLOAuthTokenRefresher.swift
@@ -17,7 +17,7 @@ class NYPLOAuthTokenRefresher {
   private let urlSession: URLSession
   private let tokenRefreshURL: URL
   private let serialQueue: DispatchQueue
-  private let oauthTokenProvider: NYPLOAuthTokenProvider
+  private let oauthTokenSetter: NYPLOAuthTokenSource
 
   var currentToken: NYPLOAuthAccessToken? {
     didSet {
@@ -25,7 +25,7 @@ class NYPLOAuthTokenRefresher {
         return
       }
 
-      oauthTokenProvider.setAuthToken(token)
+      oauthTokenSetter.setAuthToken(token)
     }
   }
 
@@ -38,13 +38,13 @@ class NYPLOAuthTokenRefresher {
   /// Designated initializer
   /// - Parameters:
   ///   - refreshURL: The URL to be used to obtain a new token.
-  ///   - oauthTokenProvider: The object that will be storing the token.
+  ///   - oauthTokenSetter: The object that will be storing the token.
   ///   - urlSession: The URLSession that will execute the request. This
   ///   urlSession needs to be able to handle the authentication necessary
   ///   to obtain a new token.
-  init(refreshURL: URL, oauthTokenProvider: NYPLOAuthTokenProvider, urlSession: URLSession) {
+  init(refreshURL: URL, oauthTokenSetter: NYPLOAuthTokenSource, urlSession: URLSession) {
     tokenRefreshURL = refreshURL
-    self.oauthTokenProvider = oauthTokenProvider
+    self.oauthTokenSetter = oauthTokenSetter
     self.urlSession = urlSession
     serialQueue = DispatchQueue(label: "nypl_refresh_oauth_token_queue",
                                 qos: .userInitiated,

--- a/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionSynchronizer.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionSynchronizer.swift
@@ -27,7 +27,7 @@ class NYPLLastReadPositionSynchronizer {
   init(bookRegistry: NYPLBookRegistryProvider) {
     self.bookRegistry = bookRegistry
     failFastNetworkExecutor = NYPLNetworkExecutor(
-      credentialsProvider: NYPLUserAccount.sharedAccount(),
+      credentialsSource: NYPLUserAccount.sharedAccount(),
       cachingStrategy: .ephemeral,
       waitsForConnectivity: false)
   }

--- a/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisContentProtection.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisContentProtection.swift
@@ -16,15 +16,15 @@ struct NYPLAxisContentProtection: ContentProtection {
   
   func open(asset: PublicationAsset, fetcher: Fetcher, credentials: String?,
             allowUserInteraction: Bool, sender: Any?,
-            completion: @escaping (
-              CancellableResult<ProtectedAsset?, Publication.OpeningError>) -> Void) {
-    
+            completion: @escaping (CancellableResult<ProtectedAsset?,
+                                   Publication.OpeningError>) -> Void) {
+
     guard let asset = asset as? FileAsset else {
       completion(.failure(.notFound))
       return
     }
     
-    protectedAssetOpener.openAsset(asset, fetcher: fetcher) { result in
+    protectedAssetOpener.open(asset: asset, fetcher: fetcher) { result in
       switch result {
       case .success(let protectedAsset):
         completion(.success(protectedAsset))

--- a/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisProtectedAssetHandler.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/Axis/NYPLAxisProtectedAssetHandler.swift
@@ -13,9 +13,9 @@ import R2Streamer
 typealias ProtectedAssetCompletion = (Result<ProtectedAsset?, Publication.OpeningError>) -> Void
 
 protocol NYPLAxisProtectedAssetOpening {
-  func openAsset(_ asset: FileAsset,
-                 fetcher: Fetcher,
-                 completion: @escaping ProtectedAssetCompletion)
+  func open(asset: FileAsset,
+            fetcher: Fetcher,
+            completion: @escaping ProtectedAssetCompletion)
 }
 
 struct NYPLAxisProtectedAssetOpener: NYPLAxisProtectedAssetOpening {
@@ -32,11 +32,11 @@ struct NYPLAxisProtectedAssetOpener: NYPLAxisProtectedAssetOpening {
   /// Opens asset using the `bookReadingAdapter` instance property which first
   /// decrypts the encrypted key from disk, and uses the decrypted key to unlock
   ///  and provide data to the ereader.
-  func openAsset(_ asset: FileAsset,
-                 fetcher: Fetcher,
-                 completion: @escaping ProtectedAssetCompletion) {
+  func open(asset: FileAsset,
+            fetcher: Fetcher,
+            completion: @escaping ProtectedAssetCompletion) {
     
-    bookReadingAdapter.openAsset(asset, fetcher: fetcher, completion: completion)
+    bookReadingAdapter.open(asset: asset, fetcher: fetcher, completion: completion)
   }
   
 }

--- a/Simplified/Reader2/ReaderStackConfiguration/LibraryService.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/LibraryService.swift
@@ -85,9 +85,9 @@ final class LibraryService: Loggable {
   }
   
   /// Opens the Readium 2 Publication at the given `url`.
-  private func openPublication(at url: URL, allowUserInteraction: Bool, sender: UIViewController?) -> Deferred<Publication, Error> {
+  private func openPublication(at fileURL: URL, allowUserInteraction: Bool, sender: UIViewController?) -> Deferred<Publication, Error> {
     return deferred {
-      self.streamer.open(asset: FileAsset(url: url), allowUserInteraction: allowUserInteraction, sender: sender, completion: $0)
+      self.streamer.open(asset: FileAsset(url: fileURL), allowUserInteraction: allowUserInteraction, sender: sender, completion: $0)
     }
     .eraseToAnyError()
   }

--- a/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
+++ b/Simplified/Settings/NYPLSettingsAccountDetailViewController.m
@@ -124,7 +124,7 @@ static const CGFloat sConstantSpacing = 12.0;
   return self.selectedUserAccount.hasCredentials;
 }
 
-#pragma mark - NYPLOAuthTokenProvider
+#pragma mark - NYPLOAuthTokenSource
 
 - (NSString *)authToken
 {

--- a/Simplified/SignInLogic/NYPLAccountSignInViewController.m
+++ b/Simplified/SignInLogic/NYPLAccountSignInViewController.m
@@ -83,7 +83,7 @@ CGFloat const marginPadding = 2.0;
   return self.businessLogic.userAccount.hasCredentials;
 }
 
-#pragma mark - NYPLOAuthTokenProvider
+#pragma mark - NYPLOAuthTokenSource
 
 - (NSString *)authToken
 {

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
@@ -64,7 +64,7 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider, NYPLCurrentL
               bookRegistry: bookRegistry,
               bookDownloadsRemover: bookDownloadsRemover,
               userAccountProvider: userAccountProvider,
-              networkExecutor: NYPLNetworkExecutor(credentialsProvider: uiDelegate,
+              networkExecutor: NYPLNetworkExecutor(credentialsSource: uiDelegate,
                                                    cachingStrategy: .ephemeral,
                                                    delegateQueue: OperationQueue.main),
               uiDelegate: uiDelegate,

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogicUIDelegate.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogicUIDelegate.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// The functionalities on the UI that the sign-in business logic requires.
-@objc protocol NYPLSignInBusinessLogicUIDelegate: NYPLBasicAuthCredentialsProvider, NYPLOAuthTokenProvider, NYPLUserAccountInputProvider {
+@objc protocol NYPLSignInBusinessLogicUIDelegate: NYPLBasicAuthCredentialsProvider, NYPLOAuthTokenSource, NYPLUserAccountInputProvider {
   /// The context in which the UI delegate is operating in, such as in a modal
   /// sheet or a tab.
   /// - Note: This should not be derived from a computation involving views,

--- a/Simplified/SignInLogic/OELoginCleverHelper.swift
+++ b/Simplified/SignInLogic/OELoginCleverHelper.swift
@@ -129,7 +129,7 @@ extension OELoginCleverHelper: NYPLSignInOutBusinessLogicUIDelegate {
     signInBusinessLogic.userAccount.hasCredentials()
   }
 
-  // MARK: - NYPLOAuthTokenProvider
+  // MARK: - NYPLOAuthTokenSource
 
   var authToken: String? {
     signInBusinessLogic.userAccount.authToken

--- a/Simplified/SignInLogic/OELoginFirstBookVC.swift
+++ b/Simplified/SignInLogic/OELoginFirstBookVC.swift
@@ -377,7 +377,7 @@ extension OELoginFirstBookVC: NYPLSignInOutBusinessLogicUIDelegate {
     businessLogic.userAccount.hasCredentials()
   }
 
-  // MARK: - NYPLOAuthTokenProvider
+  // MARK: - NYPLOAuthTokenSource
 
   var authToken: String? {
     businessLogic.userAccount.authToken

--- a/SimplifiedTests/Mocks/NYPLSignInOutBusinessLogicUIDelegateMock.swift
+++ b/SimplifiedTests/Mocks/NYPLSignInOutBusinessLogicUIDelegateMock.swift
@@ -72,7 +72,7 @@ class NYPLSignInOutBusinessLogicUIDelegateMock: NSObject, NYPLSignInOutBusinessL
 
   var forceEditability: Bool = false
 
-  // MARK: - NYPLOAuthTokenProvider
+  // MARK: - NYPLOAuthTokenSource
 
   var authToken: String? {
     return "fake token"


### PR DESCRIPTION
**What's this do?**
Removes download logic dependency from class that opens an Axis book.

Other minor renames and cleanups.

**Why are we doing this? (w/ JIRA link if applicable)**
[PJR-69](https://jira.nypl.org/browse/PJR-69)

**How should this be tested? / Do these changes have associated tests?**
no breaking changes, will be covered by regression.

**Dependencies for merging? Releasing to production?**
This is dependent on https://github.com/NYPL-Simplified/Axis-iOS/pull/22 which should be merged first. I'll then need to update the commit ref for the Axis-iOS submodule.

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 