### PR TITLE
IOS-382 Remove some implicit dependencies in NYPLAnnotations

### DIFF
--- a/Simplified/Book/UI/NYPLBookCellDelegate.m
+++ b/Simplified/Book/UI/NYPLBookCellDelegate.m
@@ -127,6 +127,7 @@
 
   Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
   [NYPLAnnotations requestServerSyncStatusForAccount:[NYPLUserAccount sharedAccount]
+                                            settings:[NYPLSettings sharedSettings]
                              syncSupportedCompletion:^(BOOL enableSync, NSError *error) {
     if (error == nil) {
       currentAccount.details.syncPermissionGranted = enableSync;

--- a/Simplified/Book/UI/NYPLBookCellDelegate.m
+++ b/Simplified/Book/UI/NYPLBookCellDelegate.m
@@ -128,6 +128,7 @@
   Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
   [NYPLAnnotations requestServerSyncStatusForAccount:[NYPLUserAccount sharedAccount]
                                             settings:[NYPLSettings sharedSettings]
+                               syncPermissionGranted:currentAccount.details.syncPermissionGranted
                              syncSupportedCompletion:^(BOOL enableSync, NSError *error) {
     if (error == nil) {
       currentAccount.details.syncPermissionGranted = enableSync;

--- a/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
@@ -10,6 +10,7 @@ protocol NYPLAnnotationSyncing: AnyObject {
   
   static func requestServerSyncStatus(forAccount userAccount: NYPLUserAccount,
                                       settings: NYPLAnnotationSettings,
+                                      syncPermissionGranted: Bool,
                                       syncSupportedCompletion: @escaping (_ enableSync: Bool,
                                                                           _ error: Error?) -> ())
   
@@ -76,6 +77,7 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
   @objc
   class func requestServerSyncStatus(forAccount userAccount: NYPLUserAccount,
                                      settings: NYPLAnnotationSettings,
+                                     syncPermissionGranted: Bool,
                                      syncSupportedCompletion: @escaping (_ enableSync: Bool,
                                                                          _ error: Error?) -> ()) {
     guard syncIsPossible(userAccount) else {
@@ -83,8 +85,7 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
       return
     }
 
-    if settings.userHasSeenFirstTimeSyncMessage == true &&
-        AccountsManager.shared.currentAccount?.details?.syncPermissionGranted == false {
+    if settings.userHasSeenFirstTimeSyncMessage && !syncPermissionGranted {
       syncSupportedCompletion(false, nil)
       return
     }

--- a/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
+++ b/Simplified/Reader2/Bookmarks/NYPLAnnotations.swift
@@ -9,6 +9,7 @@ protocol NYPLAnnotationSyncing: AnyObject {
   // Server status
   
   static func requestServerSyncStatus(forAccount userAccount: NYPLUserAccount,
+                                      settings: NYPLAnnotationSettings,
                                       syncSupportedCompletion: @escaping (_ enableSync: Bool,
                                                                           _ error: Error?) -> ())
   
@@ -50,6 +51,11 @@ protocol NYPLAnnotationSyncing: AnyObject {
   static func syncIsPossibleAndPermitted() -> Bool
 }
 
+@objc
+protocol NYPLAnnotationSettings: AnyObject {
+  var userHasSeenFirstTimeSyncMessage: Bool {get set}
+}
+
 final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
   // MARK: - Sync Settings
 
@@ -69,6 +75,7 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
   ///   process, unless sync is not supported by the current library.
   @objc
   class func requestServerSyncStatus(forAccount userAccount: NYPLUserAccount,
+                                     settings: NYPLAnnotationSettings,
                                      syncSupportedCompletion: @escaping (_ enableSync: Bool,
                                                                          _ error: Error?) -> ()) {
     guard syncIsPossible(userAccount) else {
@@ -76,7 +83,6 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
       return
     }
 
-    let settings = NYPLSettings.shared
     if settings.userHasSeenFirstTimeSyncMessage == true &&
         AccountsManager.shared.currentAccount?.details?.syncPermissionGranted == false {
       syncSupportedCompletion(false, nil)

--- a/Simplified/Settings/NYPLSettings.swift
+++ b/Simplified/Settings/NYPLSettings.swift
@@ -12,7 +12,7 @@ import Foundation
   var accountMainFeedURL: URL? { get set }
 }
 
-@objcMembers class NYPLSettings: NSObject, NYPLFeedURLProvider, NYPLAgeCheckChoiceStorage {
+@objcMembers class NYPLSettings: NSObject, NYPLFeedURLProvider, NYPLAgeCheckChoiceStorage, NYPLAnnotationSettings {
   static let shared = NYPLSettings()
 
   @objc class func sharedSettings() -> NYPLSettings {

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
@@ -66,7 +66,7 @@ extension NYPLSignInBusinessLogic {
       preWork()
     }
 
-    NYPLAnnotations.requestServerSyncStatus(forAccount: userAccount) { enableSync, error in
+    NYPLAnnotations.requestServerSyncStatus(forAccount: userAccount, settings: NYPLSettings.shared) { enableSync, error in
       NYPLMainThreadRun.sync {
         postWork(enableSync, error)
       }

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
@@ -66,12 +66,16 @@ extension NYPLSignInBusinessLogic {
       preWork()
     }
 
-    NYPLAnnotations.requestServerSyncStatus(forAccount: userAccount, settings: NYPLSettings.shared) { enableSync, error in
-      NYPLMainThreadRun.sync {
-        postWork(enableSync, error)
-      }
+    NYPLAnnotations.requestServerSyncStatus(
+      forAccount: userAccount,
+      settings: NYPLSettings.shared,
+      syncPermissionGranted: libraryDetails.syncPermissionGranted) { enableSync, error in
+        
+        NYPLMainThreadRun.sync {
+          postWork(enableSync, error)
+        }
 
-      self.permissionsCheckLock.unlock()
-    }
+        self.permissionsCheckLock.unlock()
+      }
   }
 }

--- a/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
+++ b/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
@@ -22,6 +22,7 @@ class NYPLAnnotationsMock: NYPLAnnotationSyncing {
   // Server status
   
   static func requestServerSyncStatus(forAccount userAccount: NYPLUserAccount,
+                                      settings: NYPLAnnotationSettings,
                                       syncSupportedCompletion: @escaping (Bool, Error?) -> ()) {
     syncSupportedCompletion(true, nil)
   }

--- a/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
+++ b/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
@@ -23,6 +23,7 @@ class NYPLAnnotationsMock: NYPLAnnotationSyncing {
   
   static func requestServerSyncStatus(forAccount userAccount: NYPLUserAccount,
                                       settings: NYPLAnnotationSettings,
+                                      syncPermissionGranted: Bool,
                                       syncSupportedCompletion: @escaping (Bool, Error?) -> ()) {
     syncSupportedCompletion(true, nil)
   }


### PR DESCRIPTION
**What's this do?**
- Removes the NYPLSettings implicit dependencies from NYPLAnnotations.
- Removes the AccountsManager implicit dependencies from a couple methods in NYPLAnnotations.

**Why are we doing this? (w/ JIRA link if applicable)**
[IOS-382](https://jira.nypl.org/browse/IOS-382)

**How should this be tested? / Do these changes have associated tests?**
regression will cover this.

**Dependencies for merging? Releasing to production?**
no breaking changes

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ettore 