### PR TITLE
PJR-70 Dependency-inject NYPLAnnotations calls

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -3046,8 +3046,6 @@
 		7361615525F75E3900395337 /* BusinessLogic */ = {
 			isa = PBXGroup;
 			children = (
-				73DB56CB25F7F684003788EE /* NYPLLastReadPositionPoster.swift */,
-				73DB56C125F769FF003788EE /* NYPLLastReadPositionSynchronizer.swift */,
 				734917D9242EB79700059AA5 /* NYPLR1R2UserSettings.swift */,
 				1188F3DF1A1ECC4B006B2F36 /* NYPLReaderSettings.h */,
 				1188F3E01A1ECC4B006B2F36 /* NYPLReaderSettings.m */,
@@ -3145,11 +3143,22 @@
 				73DE8984260BF61B003D9135 /* Bookmarks */,
 				7361615525F75E3900395337 /* BusinessLogic */,
 				73DB2D0924132C8B008346ED /* Internal */,
+				73AA8A92291C70E2000F3F9A /* Networking */,
 				7361615425F706D600395337 /* ReaderStackConfiguration */,
 				7361615325F705A500395337 /* ReaderPresentation */,
 				73F7136D2417260700C63B81 /* UI */,
 			);
 			path = Reader2;
+			sourceTree = "<group>";
+		};
+		73AA8A92291C70E2000F3F9A /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				2DF321821DC3B83500E1858F /* NYPLAnnotations.swift */,
+				73DB56CB25F7F684003788EE /* NYPLLastReadPositionPoster.swift */,
+				73DB56C125F769FF003788EE /* NYPLLastReadPositionSynchronizer.swift */,
+			);
+			path = Networking;
 			sourceTree = "<group>";
 		};
 		73B5DFD72605296300225C12 /* Book */ = {
@@ -3530,7 +3539,6 @@
 		73DE8984260BF61B003D9135 /* Bookmarks */ = {
 			isa = PBXGroup;
 			children = (
-				2DF321821DC3B83500E1858F /* NYPLAnnotations.swift */,
 				1798538A255A4092009F94D9 /* NYPLBookLocation+Locator.swift */,
 				730EF265260967FF008E1DC3 /* NYPLReadiumBookmarkFactory.swift */,
 				73DEB5462486FDFC00B5FF0A /* NYPLBookmarkR2Location.swift */,

--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -937,6 +937,10 @@
 		73A794C72549098700C59CC1 /* NYPLOPDSAcquisitionPathEntryMinimal.xml in Resources */ = {isa = PBXBuildFile; fileRef = 73A794C62549095700C59CC1 /* NYPLOPDSAcquisitionPathEntryMinimal.xml */; };
 		73A794CA25492C9800C59CC1 /* NYPLFake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A794C925492C9800C59CC1 /* NYPLFake.swift */; };
 		73A794CB25492C9800C59CC1 /* NYPLFake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A794C925492C9800C59CC1 /* NYPLFake.swift */; };
+		73AA8A8E291C2DFA000F3F9A /* NYPLRootTabBarController+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AA8A89291C2CDD000F3F9A /* NYPLRootTabBarController+Common.swift */; };
+		73AA8A8F291C2DFA000F3F9A /* NYPLRootTabBarController+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AA8A89291C2CDD000F3F9A /* NYPLRootTabBarController+Common.swift */; };
+		73AA8A90291C2DFB000F3F9A /* NYPLRootTabBarController+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AA8A89291C2CDD000F3F9A /* NYPLRootTabBarController+Common.swift */; };
+		73AA8A91291C2DFB000F3F9A /* NYPLRootTabBarController+Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AA8A89291C2CDD000F3F9A /* NYPLRootTabBarController+Common.swift */; };
 		73AB364927F3D7AA0067BAAC /* NYPLOAuthTokenRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AB364827F3D7AA0067BAAC /* NYPLOAuthTokenRefresher.swift */; };
 		73AB364A27F3D7AA0067BAAC /* NYPLOAuthTokenRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AB364827F3D7AA0067BAAC /* NYPLOAuthTokenRefresher.swift */; };
 		73AB364B27F3D7AA0067BAAC /* NYPLOAuthTokenRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AB364827F3D7AA0067BAAC /* NYPLOAuthTokenRefresher.swift */; };
@@ -2153,6 +2157,7 @@
 		73A794BC2548E36100C59CC1 /* NYPLBookCreationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBookCreationTests.swift; sourceTree = "<group>"; };
 		73A794C62549095700C59CC1 /* NYPLOPDSAcquisitionPathEntryMinimal.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = NYPLOPDSAcquisitionPathEntryMinimal.xml; sourceTree = "<group>"; };
 		73A794C925492C9800C59CC1 /* NYPLFake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLFake.swift; sourceTree = "<group>"; };
+		73AA8A89291C2CDD000F3F9A /* NYPLRootTabBarController+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLRootTabBarController+Common.swift"; sourceTree = "<group>"; };
 		73AB364827F3D7AA0067BAAC /* NYPLOAuthTokenRefresher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLOAuthTokenRefresher.swift; sourceTree = "<group>"; };
 		73AB365127F5119C0067BAAC /* URLSession+SynchronousTasks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+SynchronousTasks.swift"; sourceTree = "<group>"; };
 		73B501C024F48D4B00FBAD7D /* NYPLUserAccountFrontEndValidation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLUserAccountFrontEndValidation.swift; sourceTree = "<group>"; };
@@ -2865,6 +2870,7 @@
 				738CB2052509A87700891F31 /* NYPLConfiguration+SE.swift */,
 				11548C091939136C009DBF2E /* NYPLRootTabBarController.h */,
 				11548C0A1939136C009DBF2E /* NYPLRootTabBarController.m */,
+				73AA8A89291C2CDD000F3F9A /* NYPLRootTabBarController+Common.swift */,
 				73225DEA250B471400EF1877 /* NYPLRootTabBarController+OE.swift */,
 				739ECB2D25108EE800691A70 /* NYPLRootTabBarController+SE.swift */,
 				730EDFFF251567820038DD9F /* NYPLLibraryNavigationController.h */,
@@ -4479,6 +4485,7 @@
 				5916E7D5262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift in Sources */,
 				73A172FC27ADA6FA005E7BCF /* NYPLAxisProtectedAssetHandler.swift in Sources */,
 				1747331D284AA4100090B1F3 /* NYPLSettingsDeleteServerDataViewController.swift in Sources */,
+				73AA8A8F291C2DFA000F3F9A /* NYPLRootTabBarController+Common.swift in Sources */,
 				73B5510D2511750A00D05B86 /* NYPLSamlIDPCell.swift in Sources */,
 				73A172FA27ADA6FA005E7BCF /* NYPLAxisErrorLogsAdapter.swift in Sources */,
 				739E605F244A0D8600D00301 /* NYPLXML.m in Sources */,
@@ -4929,6 +4936,7 @@
 				73EB0B1925821DF4006BC997 /* NYPLBookDetailsProblemDocumentViewController.swift in Sources */,
 				73EB0B1A25821DF4006BC997 /* NYPLCatalogGroupedFeed.m in Sources */,
 				73EB0B1B25821DF4006BC997 /* NYPLCatalogFacet.m in Sources */,
+				73AA8A90291C2DFB000F3F9A /* NYPLRootTabBarController+Common.swift in Sources */,
 				73EB0B1C25821DF4006BC997 /* NYPLBook+DistributorChecks.swift in Sources */,
 				73EB0B1D25821DF4006BC997 /* NYPLLoginCellTypes.swift in Sources */,
 				73EB0B1E25821DF4006BC997 /* NYPLAccountSignInViewController.m in Sources */,
@@ -5145,6 +5153,7 @@
 				73FCA32D25005BA4001B0C5D /* NSURLRequest+NYPLURLRequestAdditions.m in Sources */,
 				73FCA32E25005BA4001B0C5D /* NYPLRootTabBarController.m in Sources */,
 				7380E713254B4091004613B1 /* LibraryService.swift in Sources */,
+				73AA8A91291C2DFB000F3F9A /* NYPLRootTabBarController+Common.swift in Sources */,
 				73FCA32F25005BA4001B0C5D /* ExtendedNavBarView.swift in Sources */,
 				219E4D9225C34A8600588588 /* DRMLibraryService.swift in Sources */,
 				73FCA33025005BA4001B0C5D /* OPDS2Link.swift in Sources */,
@@ -5247,6 +5256,7 @@
 				5916E7D4262791B20021CD67 /* NYPLSignInBusinessLogic+Adept.swift in Sources */,
 				73A172E627ADA6F9005E7BCF /* NYPLAxisProtectedAssetHandler.swift in Sources */,
 				1747331C284AA4100090B1F3 /* NYPLSettingsDeleteServerDataViewController.swift in Sources */,
+				73AA8A8E291C2DFA000F3F9A /* NYPLRootTabBarController+Common.swift in Sources */,
 				111559ED19B8FA590003BE94 /* NYPLXML.m in Sources */,
 				73A172E427ADA6F9005E7BCF /* NYPLAxisErrorLogsAdapter.swift in Sources */,
 				731A5B1224621F2B00B5E663 /* NYPLSignInBusinessLogic.swift in Sources */,

--- a/Simplified/AppInfrastructure/NYPLRootTabBarController+Common.swift
+++ b/Simplified/AppInfrastructure/NYPLRootTabBarController+Common.swift
@@ -11,8 +11,10 @@ import Foundation
 extension NYPLRootTabBarController {
   @objc func createR2Owner() -> NYPLR2Owner {
     let lastReadSyncer = NYPLLastReadPositionSynchronizer(
-      bookRegistry: NYPLBookRegistry.shared())
+      bookRegistry: NYPLBookRegistry.shared(),
+      synchronizer: NYPLAnnotations.self)
 
-    return NYPLR2Owner(lastReadPositionSynchronizer: lastReadSyncer)
+    return NYPLR2Owner(lastReadPositionSynchronizer: lastReadSyncer,
+                       annotationsSynchronizer: NYPLAnnotations.self)
   }
 }

--- a/Simplified/AppInfrastructure/NYPLRootTabBarController+Common.swift
+++ b/Simplified/AppInfrastructure/NYPLRootTabBarController+Common.swift
@@ -1,0 +1,18 @@
+//
+//  NYPLRootTabBarController+Common.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 11/9/22.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+
+import Foundation
+
+extension NYPLRootTabBarController {
+  @objc func createR2Owner() -> NYPLR2Owner {
+    let lastReadSyncer = NYPLLastReadPositionSynchronizer(
+      bookRegistry: NYPLBookRegistry.shared())
+
+    return NYPLR2Owner(lastReadPositionSynchronizer: lastReadSyncer)
+  }
+}

--- a/Simplified/AppInfrastructure/NYPLRootTabBarController+Common.swift
+++ b/Simplified/AppInfrastructure/NYPLRootTabBarController+Common.swift
@@ -9,12 +9,8 @@
 import Foundation
 
 extension NYPLRootTabBarController {
-  @objc func createR2Owner() -> NYPLR2Owner {
-    let lastReadSyncer = NYPLLastReadPositionSynchronizer(
-      bookRegistry: NYPLBookRegistry.shared(),
-      synchronizer: NYPLAnnotations.self)
-
-    return NYPLR2Owner(lastReadPositionSynchronizer: lastReadSyncer,
+  @objc func makeR2Owner() -> NYPLR2Owner {
+    return NYPLR2Owner(bookRegistry: NYPLBookRegistry.shared(),
                        annotationsSynchronizer: NYPLAnnotations.self)
   }
 }

--- a/Simplified/AppInfrastructure/NYPLRootTabBarController.m
+++ b/Simplified/AppInfrastructure/NYPLRootTabBarController.m
@@ -59,7 +59,7 @@
                                            selector:@selector(setTabViewControllers)
                                                name:NSNotification.NYPLCurrentAccountDidChange
                                              object:nil];
-  self.r2Owner = [self createR2Owner];
+  self.r2Owner = [self makeR2Owner];
   return self;
 }
 

--- a/Simplified/AppInfrastructure/NYPLRootTabBarController.m
+++ b/Simplified/AppInfrastructure/NYPLRootTabBarController.m
@@ -59,8 +59,7 @@
                                            selector:@selector(setTabViewControllers)
                                                name:NSNotification.NYPLCurrentAccountDidChange
                                              object:nil];
-
-  self.r2Owner = [[NYPLR2Owner alloc] init];
+  self.r2Owner = [self createR2Owner];
   return self;
 }
 

--- a/Simplified/Book/UI/NYPLBookCellDelegate.m
+++ b/Simplified/Book/UI/NYPLBookCellDelegate.m
@@ -126,10 +126,10 @@
                                          successCompletion:successCompletion];
 
   Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
-  [NYPLAnnotations requestServerSyncStatusForAccount:[NYPLUserAccount sharedAccount]
-                                            settings:[NYPLSettings sharedSettings]
-                               syncPermissionGranted:currentAccount.details.syncPermissionGranted
-                             syncSupportedCompletion:^(BOOL enableSync, NSError *error) {
+  [NYPLAnnotations
+   requestServerSyncStatusWithSettings:[NYPLSettings sharedSettings]
+   syncPermissionGranted:currentAccount.details.syncPermissionGranted
+   syncSupportedCompletion:^(BOOL enableSync, NSError *error) {
     if (error == nil) {
       currentAccount.details.syncPermissionGranted = enableSync;
     }

--- a/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionSynchronizer.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLLastReadPositionSynchronizer.swift
@@ -9,9 +9,16 @@
 import Foundation
 import R2Shared
 
+protocol NYPLLastReadPositionSynchronizing {
+  func sync(for publication: Publication,
+            book: NYPLBook,
+            drmDeviceID: String?,
+            completion: @escaping (Locator?) -> Void)
+}
+
 /// A front-end to the Annotations api to sync the reading progress for
 /// a given book with the progress on the server.
-class NYPLLastReadPositionSynchronizer {
+class NYPLLastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing {
   private let bookRegistry: NYPLBookRegistryProvider
 
   private enum NavigationChoice: Int {

--- a/Simplified/Reader2/Networking/NYPLAnnotations.swift
+++ b/Simplified/Reader2/Networking/NYPLAnnotations.swift
@@ -6,7 +6,7 @@ import NYPLAudiobookToolkit
 #endif
 
 protocol NYPLAnnotationSyncing: AnyObject {
-  // Server status
+  // Server sync status
   
   static func requestServerSyncStatus(forAccount userAccount: NYPLUserAccount,
                                       settings: NYPLAnnotationSettings,
@@ -15,7 +15,9 @@ protocol NYPLAnnotationSyncing: AnyObject {
                                                                           _ error: Error?) -> ())
   
   static func updateServerSyncSetting(toEnabled enabled: Bool, completion:@escaping (Bool)->())
-  
+
+  static func syncIsPossibleAndPermitted() -> Bool
+
   // Reading position
   
   static func syncReadingPosition(ofBook bookID: String?,
@@ -46,10 +48,6 @@ protocol NYPLAnnotationSyncing: AnyObject {
   static func postBookmark(_ bookmark: NYPLBookmark,
                            forBookID bookID: String,
                            completion: @escaping (_ serverID: String?) -> ())
-  
-  // Permission
-  
-  static func syncIsPossibleAndPermitted() -> Bool
 }
 
 @objc

--- a/Simplified/Reader2/Networking/NYPLAnnotations.swift
+++ b/Simplified/Reader2/Networking/NYPLAnnotations.swift
@@ -8,13 +8,13 @@ import NYPLAudiobookToolkit
 protocol NYPLAnnotationSyncing: AnyObject {
   // Server sync status
   
-  static func requestServerSyncStatus(forAccount userAccount: NYPLUserAccount,
-                                      settings: NYPLAnnotationSettings,
+  static func requestServerSyncStatus(settings: NYPLAnnotationSettings,
                                       syncPermissionGranted: Bool,
                                       syncSupportedCompletion: @escaping (_ enableSync: Bool,
                                                                           _ error: Error?) -> ())
   
-  static func updateServerSyncSetting(toEnabled enabled: Bool, completion:@escaping (Bool)->())
+  static func updateServerSyncSetting(toEnabled enabled: Bool,
+                                      completion:@escaping (Bool)->())
 
   static func syncIsPossibleAndPermitted() -> Bool
 
@@ -69,16 +69,17 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
   /// - Note: This flow will be run only for the user account on the currently
   /// selected library. Anything else will result in a no-op.
   /// - Parameters:
-  ///   - userAccount: The account to attempt to enable annotations-syncing on.
+  ///   - settings: The interface to the settings related to annotations.
+  ///   - syncPermissionGranted: Whether the permission to sync bookmarks was
+  ///   granted or not.
   ///   - syncSupportedCompletion: Handler always called at the end of the
   ///   process, unless sync is not supported by the current library.
   @objc
-  class func requestServerSyncStatus(forAccount userAccount: NYPLUserAccount,
-                                     settings: NYPLAnnotationSettings,
+  class func requestServerSyncStatus(settings: NYPLAnnotationSettings,
                                      syncPermissionGranted: Bool,
                                      syncSupportedCompletion: @escaping (_ enableSync: Bool,
                                                                          _ error: Error?) -> ()) {
-    guard syncIsPossible(userAccount) else {
+    guard syncIsPossible() else {
       Log.info(#function, "Account does not satisfy conditions for sync setting request.")
       return
     }
@@ -593,16 +594,17 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
     return annotationID
   }
 
-  /// Annotation-syncing is possible only if the given `account` is signed-in
+  /// Annotation-syncing is possible only if the current user account is signed-in
   /// and if the currently selected library supports it.
-  class func syncIsPossible(_ account: NYPLUserAccount) -> Bool {
+  private class func syncIsPossible() -> Bool {
     let library = AccountsManager.shared.currentAccount
-    return account.hasCredentials() && library?.details?.supportsSimplyESync == true
+    let userAccount = NYPLUserAccount.sharedAccount()
+    return userAccount.hasCredentials() && library?.details?.supportsSimplyESync == true
   }
 
   class func syncIsPossibleAndPermitted() -> Bool {
-    let acct = AccountsManager.shared.currentAccount
-    return syncIsPossible(NYPLUserAccount.sharedAccount()) && acct?.details?.syncPermissionGranted == true
+    let library = AccountsManager.shared.currentAccount
+    return syncIsPossible() && library?.details?.syncPermissionGranted == true
   }
 
   static var annotationsURL: URL? {

--- a/Simplified/Reader2/Networking/NYPLLastReadPositionPoster.swift
+++ b/Simplified/Reader2/Networking/NYPLLastReadPositionPoster.swift
@@ -60,7 +60,7 @@ class NYPLLastReadPositionPoster {
       return
     }
 
-    // save location locally, so that it can be later be saved on disk
+    // save location locally, so that it can be saved on disk later
     bookRegistryProvider.setLocation(location, forIdentifier: book.identifier)
 
     // attempt to store location on server

--- a/Simplified/Reader2/Networking/NYPLLastReadPositionSynchronizer.swift
+++ b/Simplified/Reader2/Networking/NYPLLastReadPositionSynchronizer.swift
@@ -26,13 +26,16 @@ class NYPLLastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing {
   }
 
   private let failFastNetworkExecutor: NYPLNetworkExecutor
+  let synchronizer: NYPLAnnotationSyncing.Type
 
   /// Designated initializer.
   ///
   /// - Parameters:
   ///   - bookRegistry: The registry that stores the reading progresses.
-  init(bookRegistry: NYPLBookRegistryProvider) {
+  init(bookRegistry: NYPLBookRegistryProvider,
+       synchronizer: NYPLAnnotationSyncing.Type) {
     self.bookRegistry = bookRegistry
+    self.synchronizer = synchronizer
     failFastNetworkExecutor = NYPLNetworkExecutor(
       credentialsSource: NYPLUserAccount.sharedAccount(),
       cachingStrategy: .ephemeral,
@@ -109,7 +112,7 @@ class NYPLLastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing {
 
     let localLocation = bookRegistry.location(forIdentifier: book.identifier)
 
-    NYPLAnnotations
+    synchronizer
       .syncReadingPosition(ofBook: book.identifier, publication: publication, toURL: book.annotationsURL, usingNetworkExecutor: failFastNetworkExecutor) { bookmark in
 
         guard let bookmark = bookmark else {

--- a/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
+++ b/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
@@ -54,17 +54,17 @@ final class ReaderModule: ReaderModuleAPI {
   
   weak var delegate: R2ModuleDelegate?
   private let resourcesServer: ResourcesServer
-  private let progressSynchronizer: NYPLLastReadPositionSynchronizer
+  private let progressSynchronizer: NYPLLastReadPositionSynchronizing
 
   /// Sub-modules to handle different publication formats (eg. EPUB, CBZ)
   var formatModules: [ReaderFormatModule] = []
 
   init(delegate: R2ModuleDelegate?,
        resourcesServer: ResourcesServer,
-       bookRegistry: NYPLBookRegistryProvider) {
+       lastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing) {
     self.delegate = delegate
     self.resourcesServer = resourcesServer
-    self.progressSynchronizer = NYPLLastReadPositionSynchronizer(bookRegistry: bookRegistry)
+    self.progressSynchronizer = lastReadPositionSynchronizer
 
     formatModules = [
       EPUBModule(delegate: self.delegate, resourcesServer: resourcesServer)

--- a/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
+++ b/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
@@ -61,11 +61,13 @@ final class ReaderModule: ReaderModuleAPI {
 
   init(delegate: R2ModuleDelegate?,
        resourcesServer: ResourcesServer,
-       lastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing,
+       bookRegistry: NYPLBookRegistryProvider,
        annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
     self.delegate = delegate
     self.resourcesServer = resourcesServer
-    self.progressSynchronizer = lastReadPositionSynchronizer
+    self.progressSynchronizer = NYPLLastReadPositionSynchronizer(
+      bookRegistry: bookRegistry,
+      synchronizer: annotationsSynchronizer)
 
     formatModules = [
       EPUBModule(delegate: self.delegate,

--- a/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
+++ b/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
@@ -61,13 +61,16 @@ final class ReaderModule: ReaderModuleAPI {
 
   init(delegate: R2ModuleDelegate?,
        resourcesServer: ResourcesServer,
-       lastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing) {
+       lastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing,
+       annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
     self.delegate = delegate
     self.resourcesServer = resourcesServer
     self.progressSynchronizer = lastReadPositionSynchronizer
 
     formatModules = [
-      EPUBModule(delegate: self.delegate, resourcesServer: resourcesServer)
+      EPUBModule(delegate: self.delegate,
+                 resourcesServer: resourcesServer,
+                 annotationsSynchronizer: annotationsSynchronizer)
     ]
   }
   

--- a/Simplified/Reader2/ReaderPresentation/ReadingFormats/EPUBModule.swift
+++ b/Simplified/Reader2/ReaderPresentation/ReadingFormats/EPUBModule.swift
@@ -19,10 +19,14 @@ final class EPUBModule: ReaderFormatModule {
   
   weak var delegate: R2ModuleDelegate?
   let resourcesServer: ResourcesServer
+  private let annotationsSynchronizer: NYPLAnnotationSyncing.Type
   
-  init(delegate: R2ModuleDelegate?, resourcesServer: ResourcesServer) {
+  init(delegate: R2ModuleDelegate?,
+       resourcesServer: ResourcesServer,
+       annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
     self.delegate = delegate
     self.resourcesServer = resourcesServer
+    self.annotationsSynchronizer = annotationsSynchronizer
   }
 
   func supports(_ publication: Publication) -> Bool {
@@ -40,7 +44,8 @@ final class EPUBModule: ReaderFormatModule {
     let epubVC = NYPLEPUBViewController(publication: publication,
                                         book: book,
                                         initialLocation: initialLocation,
-                                        resourcesServer: resourcesServer)
+                                        resourcesServer: resourcesServer,
+                                        annotationsSynchronizer: annotationsSynchronizer)
     epubVC.moduleDelegate = delegate
     return epubVC
   }

--- a/Simplified/Reader2/ReaderStackConfiguration/NYPLR2Owner.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/NYPLR2Owner.swift
@@ -23,7 +23,7 @@ import R2Streamer
   var libraryService: LibraryService! = nil
   var readerModule: ReaderModuleAPI! = nil
 
-  override init() {
+  init(lastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing) {
     super.init()
     guard let server = PublicationServer() else {
       /// FIXME: we should recover properly if the publication server can't
@@ -32,9 +32,11 @@ import R2Streamer
     }
 
     libraryService = LibraryService(publicationServer: server)
-    readerModule = ReaderModule(delegate: self,
-                                resourcesServer: server,
-                                bookRegistry: NYPLBookRegistry.shared())
+
+    readerModule = ReaderModule(
+      delegate: self,
+      resourcesServer: server,
+      lastReadPositionSynchronizer: lastReadPositionSynchronizer)
 
     // Set Readium 2's logging minimum level.
     R2EnableLog(withMinimumSeverityLevel: .debug)

--- a/Simplified/Reader2/ReaderStackConfiguration/NYPLR2Owner.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/NYPLR2Owner.swift
@@ -23,7 +23,7 @@ import R2Streamer
   var libraryService: LibraryService! = nil
   var readerModule: ReaderModuleAPI! = nil
 
-  init(lastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing,
+  init(bookRegistry: NYPLBookRegistryProvider,
        annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
     super.init()
     guard let server = PublicationServer() else {
@@ -37,7 +37,7 @@ import R2Streamer
     readerModule = ReaderModule(
       delegate: self,
       resourcesServer: server,
-      lastReadPositionSynchronizer: lastReadPositionSynchronizer,
+      bookRegistry: bookRegistry,
       annotationsSynchronizer: annotationsSynchronizer)
 
     // Set Readium 2's logging minimum level.

--- a/Simplified/Reader2/ReaderStackConfiguration/NYPLR2Owner.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/NYPLR2Owner.swift
@@ -23,7 +23,8 @@ import R2Streamer
   var libraryService: LibraryService! = nil
   var readerModule: ReaderModuleAPI! = nil
 
-  init(lastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing) {
+  init(lastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing,
+       annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
     super.init()
     guard let server = PublicationServer() else {
       /// FIXME: we should recover properly if the publication server can't
@@ -36,7 +37,8 @@ import R2Streamer
     readerModule = ReaderModule(
       delegate: self,
       resourcesServer: server,
-      lastReadPositionSynchronizer: lastReadPositionSynchronizer)
+      lastReadPositionSynchronizer: lastReadPositionSynchronizer,
+      annotationsSynchronizer: annotationsSynchronizer)
 
     // Set Readium 2's logging minimum level.
     R2EnableLog(withMinimumSeverityLevel: .debug)

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -47,7 +47,8 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
   ///   - drm: Information about the DRM associated with the publication.
   init(navigator: UIViewController & Navigator,
        publication: Publication,
-       book: NYPLBook) {
+       book: NYPLBook,
+       annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
 
     self.navigator = navigator
     self.publication = publication
@@ -55,7 +56,7 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
     lastReadPositionPoster = NYPLLastReadPositionPoster(
       book: book,
       bookRegistryProvider: NYPLBookRegistry.shared(),
-      annotationsSynchronizer: NYPLAnnotations.self
+      annotationsSynchronizer: annotationsSynchronizer
     )
 
     bookmarksBusinessLogic = NYPLReaderBookmarksBusinessLogic(
@@ -64,7 +65,7 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
       drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
       bookRegistryProvider: NYPLBookRegistry.shared(),
       currentLibraryAccountProvider: AccountsManager.shared,
-      annotationsSynchronizer: NYPLAnnotations.self)
+      bookmarksSynchronizer: annotationsSynchronizer)
 
     bookmarksBusinessLogic.syncBookmarks { (_, _) in }
 

--- a/Simplified/Reader2/UI/NYPLEPUBViewController.swift
+++ b/Simplified/Reader2/UI/NYPLEPUBViewController.swift
@@ -22,7 +22,8 @@ class NYPLEPUBViewController: NYPLBaseReaderViewController {
   init(publication: Publication,
        book: NYPLBook,
        initialLocation: Locator?,
-       resourcesServer: ResourcesServer) {
+       resourcesServer: ResourcesServer,
+       annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
 
     // - hyphens = true helps with layout on small screens especially when
     // publisher's defaults are off.
@@ -58,7 +59,10 @@ class NYPLEPUBViewController: NYPLBaseReaderViewController {
     // to re-set that to reflect our ad-hoc configuration.
     publication.userProperties = navigator.userSettings.userProperties
 
-    super.init(navigator: navigator, publication: publication, book: book)
+    super.init(navigator: navigator,
+               publication: publication,
+               book: book,
+               annotationsSynchronizer: annotationsSynchronizer)
 
     navigator.delegate = self
   }

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
@@ -67,7 +67,6 @@ extension NYPLSignInBusinessLogic {
     }
 
     NYPLAnnotations.requestServerSyncStatus(
-      forAccount: userAccount,
       settings: NYPLSettings.shared,
       syncPermissionGranted: libraryDetails.syncPermissionGranted) { enableSync, error in
         

--- a/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
+++ b/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
@@ -21,8 +21,7 @@ class NYPLAnnotationsMock: NYPLAnnotationSyncing {
   
   // Server status
   
-  static func requestServerSyncStatus(forAccount userAccount: NYPLUserAccount,
-                                      settings: NYPLAnnotationSettings,
+  static func requestServerSyncStatus(settings: NYPLAnnotationSettings,
                                       syncPermissionGranted: Bool,
                                       syncSupportedCompletion: @escaping (Bool, Error?) -> ()) {
     syncSupportedCompletion(true, nil)

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -65,7 +65,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       drmDeviceID: "fakeDeviceID",
       bookRegistryProvider: bookRegistryMock,
       currentLibraryAccountProvider: libraryAccountMock,
-      annotationsSynchronizer: annotationsMock)
+      bookmarksSynchronizer: annotationsMock)
     bookmarkCounter = 0
   }
 


### PR DESCRIPTION
**What's this do?**
Makes it so that the notion of NYPLAnnotations is not implicit inside the reader, but is injected at the entry point (NYPLR2Owner).

**Why are we doing this? (w/ JIRA link if applicable)**
PJR-70

**How should this be tested? / Do these changes have associated tests?**
No breaking changes. A regression will cover this

**Dependencies for merging? Releasing to production?**
n/a

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 