### PR TITLE
PJR-86 Remove AccountManager implicit dependency from reader

### DIFF
--- a/Simplified/Accounts/Library/Account.swift
+++ b/Simplified/Accounts/Library/Account.swift
@@ -27,9 +27,13 @@ class OPDS2SamlIDP: NSObject, Codable {
   func isSignedIn() -> Bool
 }
 
+@objc protocol NYPLReaderServerPermissions {
+  var syncPermissionGranted:Bool {get}
+}
+
 // MARK: AccountDetails
 // Extra data that gets loaded from an OPDS2AuthenticationDocument,
-@objcMembers final class AccountDetails: NSObject {
+@objcMembers final class AccountDetails: NSObject, NYPLReaderServerPermissions {
   enum AuthType: String, Codable {
     /// This is used with barcode/username credentials on SimplyE. It was also
     /// used for FirstBook authentication on Open eBooks versions before 2.4.0.

--- a/Simplified/Accounts/Library/AccountsManager.swift
+++ b/Simplified/Accounts/Library/AccountsManager.swift
@@ -348,3 +348,9 @@ let currentAccountIdentifierKey  = "NYPLCurrentAccountIdentifier"
     }
   }
 }
+
+extension AccountsManager: NYPLReaderServerPermissions {
+  var syncPermissionGranted: Bool {
+    return currentAccount?.details?.syncPermissionGranted ?? false
+  }
+}

--- a/Simplified/Audiobooks/Bookmark/NYPLAudiobookBookmarksBusinessLogic.swift
+++ b/Simplified/Audiobooks/Bookmark/NYPLAudiobookBookmarksBusinessLogic.swift
@@ -30,7 +30,7 @@ class NYPLAudiobookBookmarksBusinessLogic: NYPLAudiobookBookmarking {
   let book: NYPLBook
   private let drmDeviceID: String?
   private let bookRegistry: NYPLAudiobookRegistryProvider
-  private let serverPermissions: NYPLReaderServerPermissions
+  private let syncPermission: Bool
   private let annotationsSynchronizer: NYPLAnnotationSyncing.Type
   
   var bookmarksCount: Int {
@@ -50,12 +50,12 @@ class NYPLAudiobookBookmarksBusinessLogic: NYPLAudiobookBookmarking {
   init(book: NYPLBook,
        drmDeviceID: String?,
        bookRegistryProvider: NYPLAudiobookRegistryProvider,
-       serverPermissions: NYPLReaderServerPermissions,
+       syncPermission: Bool,
        annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
     self.book = book
     self.drmDeviceID = drmDeviceID
     self.bookRegistry = bookRegistryProvider
-    self.serverPermissions = serverPermissions
+    self.syncPermission = syncPermission
     self.annotationsSynchronizer = annotationsSynchronizer
     self.bookmarks = bookRegistry.audiobookBookmarks(for: book.identifier)
     self.bookmarksDictionary = [String: [NYPLAudiobookBookmark]]()
@@ -216,7 +216,7 @@ class NYPLAudiobookBookmarksBusinessLogic: NYPLAudiobookBookmarking {
   /// Store a bookmark to local storage and upload it to server if sync permission is granted
   /// - Parameter bookmark: The bookmark to be stored and uploaded.
   private func postBookmark(_ bookmark: NYPLAudiobookBookmark) {
-    guard serverPermissions.syncPermissionGranted else {
+    guard syncPermission else {
       self.bookRegistry.addAudiobookBookmark(bookmark, for: book.identifier)
         return
     }
@@ -241,7 +241,7 @@ class NYPLAudiobookBookmarksBusinessLogic: NYPLAudiobookBookmarking {
       return
     }
     
-    if serverPermissions.syncPermissionGranted && annotationId.count > 0 {
+    if syncPermission && annotationId.count > 0 {
       annotationsSynchronizer.deleteBookmark(annotationId: annotationId) { (success) in
         Log.info(#file, success ?
           "Bookmark successfully deleted" :

--- a/Simplified/Book/UI/NYPLBookCellDelegate+AudiobookBookmark.swift
+++ b/Simplified/Book/UI/NYPLBookCellDelegate+AudiobookBookmark.swift
@@ -22,7 +22,7 @@ import UIKit
       book: book,
       drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
       bookRegistryProvider: audiobookRegistryProvider,
-      serverPermissions: AccountsManager.shared,
+      syncPermission: AccountsManager.shared.syncPermissionGranted,
       annotationsSynchronizer: NYPLAnnotations.self)
     audiobookManager.bookmarkBusinessLogic = bizLogic
   }

--- a/Simplified/Book/UI/NYPLBookCellDelegate+AudiobookBookmark.swift
+++ b/Simplified/Book/UI/NYPLBookCellDelegate+AudiobookBookmark.swift
@@ -18,11 +18,12 @@ import UIKit
   func setBookmarkBusinessLogic(for book: NYPLBook,
                                 audiobookManager: DefaultAudiobookManager,
                                 audiobookRegistryProvider: NYPLAudiobookRegistryProvider) {
-    let bizLogic = NYPLAudiobookBookmarksBusinessLogic(book: book,
-                                                       drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
-                                                       bookRegistryProvider: audiobookRegistryProvider,
-                                                       currentLibraryAccountProvider: AccountsManager.shared,
-                                                       annotationsSynchronizer: NYPLAnnotations.self)
+    let bizLogic = NYPLAudiobookBookmarksBusinessLogic(
+      book: book,
+      drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
+      bookRegistryProvider: audiobookRegistryProvider,
+      serverPermissions: AccountsManager.shared,
+      annotationsSynchronizer: NYPLAnnotations.self)
     audiobookManager.bookmarkBusinessLogic = bizLogic
   }
 }

--- a/Simplified/Book/UI/NYPLBookCellDelegate.m
+++ b/Simplified/Book/UI/NYPLBookCellDelegate.m
@@ -121,11 +121,14 @@
 {
   NSURL *const url = [[NYPLMyBooksDownloadCenter sharedDownloadCenter]
                       fileURLForBookIndentifier:book.identifier];
+
+  AccountsManager *accountMgr = [AccountsManager sharedInstance];
   [[NYPLRootTabBarController sharedController] presentBook:book
                                                fromFileURL:url
+                                         serverPermissions:accountMgr
                                          successCompletion:successCompletion];
 
-  Account *currentAccount = [[AccountsManager sharedInstance] currentAccount];
+  Account *currentAccount = [accountMgr currentAccount];
   [NYPLAnnotations
    requestServerSyncStatusWithSettings:[NYPLSettings sharedSettings]
    syncPermissionGranted:currentAccount.details.syncPermissionGranted

--- a/Simplified/Book/UI/NYPLBookCellDelegate.m
+++ b/Simplified/Book/UI/NYPLBookCellDelegate.m
@@ -123,15 +123,17 @@
                       fileURLForBookIndentifier:book.identifier];
 
   AccountsManager *accountMgr = [AccountsManager sharedInstance];
+  Account *currentAccount = [accountMgr currentAccount];
+  BOOL syncPermission = currentAccount.details.syncPermissionGranted;
+
   [[NYPLRootTabBarController sharedController] presentBook:book
                                                fromFileURL:url
-                                         serverPermissions:accountMgr
+                                            syncPermission:syncPermission
                                          successCompletion:successCompletion];
 
-  Account *currentAccount = [accountMgr currentAccount];
   [NYPLAnnotations
    requestServerSyncStatusWithSettings:[NYPLSettings sharedSettings]
-   syncPermissionGranted:currentAccount.details.syncPermissionGranted
+   syncPermissionGranted:syncPermission
    syncSupportedCompletion:^(BOOL enableSync, NSError *error) {
     if (error == nil) {
       currentAccount.details.syncPermissionGranted = enableSync;

--- a/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
@@ -19,7 +19,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
   private let publication: Publication
   private let drmDeviceID: String?
   private let bookRegistry: NYPLBookRegistryProvider
-  private let serverPermissions: NYPLReaderServerPermissions
+  private let syncPermission: Bool
   private let bookmarksFactory: NYPLReadiumBookmarkFactory
   private let bookmarksSynchronizer: NYPLAnnotationSyncing.Type
 
@@ -27,14 +27,14 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
        r2Publication: Publication,
        drmDeviceID: String?,
        bookRegistryProvider: NYPLBookRegistryProvider,
-       serverPermissions: NYPLReaderServerPermissions,
+       syncPermission: Bool,
        bookmarksSynchronizer: NYPLAnnotationSyncing.Type) {
     self.book = book
     self.publication = r2Publication
     self.drmDeviceID = drmDeviceID
     self.bookRegistry = bookRegistryProvider
     bookmarks = bookRegistryProvider.readiumBookmarks(forIdentifier: book.identifier)
-    self.serverPermissions = serverPermissions
+    self.syncPermission = syncPermission
     self.bookmarksFactory = NYPLReadiumBookmarkFactory(publication: publication,
                                                        drmDeviceID: drmDeviceID)
     self.bookmarksSynchronizer = bookmarksSynchronizer
@@ -108,7 +108,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
   }
     
   private func postBookmark(_ bookmark: NYPLReadiumBookmark) {
-    guard serverPermissions.syncPermissionGranted else {
+    guard syncPermission else {
       self.bookRegistry.add(bookmark, forIdentifier: book.identifier)
       return
     }
@@ -154,7 +154,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
       return
     }
     
-    if serverPermissions.syncPermissionGranted && annotationId.count > 0 {
+    if syncPermission && annotationId.count > 0 {
       bookmarksSynchronizer.deleteBookmark(annotationId: annotationId) { (success) in
         Log.info(#file, success ?
           "Bookmark successfully deleted" :

--- a/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
@@ -19,7 +19,7 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
   private let publication: Publication
   private let drmDeviceID: String?
   private let bookRegistry: NYPLBookRegistryProvider
-  private let currentLibraryAccountProvider: NYPLCurrentLibraryAccountProvider
+  private let serverPermissions: NYPLReaderServerPermissions
   private let bookmarksFactory: NYPLReadiumBookmarkFactory
   private let bookmarksSynchronizer: NYPLAnnotationSyncing.Type
 
@@ -27,14 +27,14 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
        r2Publication: Publication,
        drmDeviceID: String?,
        bookRegistryProvider: NYPLBookRegistryProvider,
-       currentLibraryAccountProvider: NYPLCurrentLibraryAccountProvider,
+       serverPermissions: NYPLReaderServerPermissions,
        bookmarksSynchronizer: NYPLAnnotationSyncing.Type) {
     self.book = book
     self.publication = r2Publication
     self.drmDeviceID = drmDeviceID
     self.bookRegistry = bookRegistryProvider
     bookmarks = bookRegistryProvider.readiumBookmarks(forIdentifier: book.identifier)
-    self.currentLibraryAccountProvider = currentLibraryAccountProvider
+    self.serverPermissions = serverPermissions
     self.bookmarksFactory = NYPLReadiumBookmarkFactory(publication: publication,
                                                        drmDeviceID: drmDeviceID)
     self.bookmarksSynchronizer = bookmarksSynchronizer
@@ -108,12 +108,9 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
   }
     
   private func postBookmark(_ bookmark: NYPLReadiumBookmark) {
-    guard
-      let currentAccount = currentLibraryAccountProvider.currentAccount,
-      let accountDetails = currentAccount.details,
-      accountDetails.syncPermissionGranted else {
-        self.bookRegistry.add(bookmark, forIdentifier: book.identifier)
-        return
+    guard serverPermissions.syncPermissionGranted else {
+      self.bookRegistry.add(bookmark, forIdentifier: book.identifier)
+      return
     }
     
     bookmarksSynchronizer.postBookmark(bookmark, forBookID: book.identifier) { serverAnnotationID in
@@ -152,14 +149,12 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
   private func didDeleteBookmark(_ bookmark: NYPLReadiumBookmark) {
     bookRegistry.delete(bookmark, forIdentifier: book.identifier)
 
-    guard let libraryAccount = currentLibraryAccountProvider.currentAccount,
-        let libAccountDetails = libraryAccount.details,
-        let annotationId = bookmark.annotationId else {
+    guard let annotationId = bookmark.annotationId else {
       Log.info(#file, "Delete on Server skipped: Annotation ID did not exist for bookmark.")
       return
     }
     
-    if libAccountDetails.syncPermissionGranted && annotationId.count > 0 {
+    if serverPermissions.syncPermissionGranted && annotationId.count > 0 {
       bookmarksSynchronizer.deleteBookmark(annotationId: annotationId) { (success) in
         Log.info(#file, success ?
           "Bookmark successfully deleted" :

--- a/Simplified/Reader2/ReaderPresentation/NYPLRootTabBarController+R2.swift
+++ b/Simplified/Reader2/ReaderPresentation/NYPLRootTabBarController+R2.swift
@@ -11,7 +11,7 @@ import Foundation
 @objc extension NYPLRootTabBarController {
   func presentBook(_ book: NYPLBook,
                    fromFileURL fileURL: URL?,
-                   serverPermissions: NYPLReaderServerPermissions,
+                   syncPermission: Bool,
                    successCompletion: (() -> Void)?) {
     guard let libraryService = r2Owner?.libraryService, let readerModule = r2Owner?.readerModule else {
       return
@@ -27,7 +27,7 @@ import Foundation
       case .success(let publication):
         readerModule.presentPublication(publication,
                                         book: book,
-                                        serverPermissions: serverPermissions,
+                                        syncPermission: syncPermission,
                                         deviceID: drmDeviceID,
                                         in: navVC,
                                         successCompletion: successCompletion)

--- a/Simplified/Reader2/ReaderPresentation/NYPLRootTabBarController+R2.swift
+++ b/Simplified/Reader2/ReaderPresentation/NYPLRootTabBarController+R2.swift
@@ -9,7 +9,10 @@
 import Foundation
 
 @objc extension NYPLRootTabBarController {
-  func presentBook(_ book: NYPLBook, fromFileURL fileURL: URL?, successCompletion: (() -> Void)?) {
+  func presentBook(_ book: NYPLBook,
+                   fromFileURL fileURL: URL?,
+                   serverPermissions: NYPLReaderServerPermissions,
+                   successCompletion: (() -> Void)?) {
     guard let libraryService = r2Owner?.libraryService, let readerModule = r2Owner?.readerModule else {
       return
     }
@@ -24,6 +27,7 @@ import Foundation
       case .success(let publication):
         readerModule.presentPublication(publication,
                                         book: book,
+                                        serverPermissions: serverPermissions,
                                         deviceID: drmDeviceID,
                                         in: navVC,
                                         successCompletion: successCompletion)

--- a/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
+++ b/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
@@ -38,7 +38,7 @@ protocol ReaderModuleAPI {
   /// - Parameter navigationController: The navigation stack the book will be presented in.
   func presentPublication(_ publication: Publication,
                           book: NYPLBook,
-                          serverPermissions: NYPLReaderServerPermissions,
+                          syncPermission: Bool,
                           deviceID: String?,
                           in navigationController: UINavigationController,
                           successCompletion: (() -> Void)?)
@@ -79,7 +79,7 @@ final class ReaderModule: ReaderModuleAPI {
   
   func presentPublication(_ publication: Publication,
                           book: NYPLBook,
-                          serverPermissions: NYPLReaderServerPermissions,
+                          syncPermission: Bool,
                           deviceID: String?,
                           in navigationController: UINavigationController,
                           successCompletion: (() -> Void)?) {
@@ -98,7 +98,7 @@ final class ReaderModule: ReaderModuleAPI {
       drmDeviceID: deviceID) { [weak self] initialLocator in
         self?.finalizePresentation(for: publication,
                                    book: book,
-                                   serverPermissions: serverPermissions,
+                                   syncPermission: syncPermission,
                                    formatModule: formatModule,
                                    positioningAt: initialLocator,
                                    in: navigationController,
@@ -108,7 +108,7 @@ final class ReaderModule: ReaderModuleAPI {
 
   private func finalizePresentation(for publication: Publication,
                                     book: NYPLBook,
-                                    serverPermissions: NYPLReaderServerPermissions,
+                                    syncPermission: Bool,
                                     formatModule: ReaderFormatModule,
                                     positioningAt initialLocator: Locator?,
                                     in navigationController: UINavigationController,
@@ -117,7 +117,7 @@ final class ReaderModule: ReaderModuleAPI {
       let readerVC = try formatModule.makeReaderViewController(
         for: publication,
         book: book,
-        serverPermissions: serverPermissions,
+        syncPermission: syncPermission,
         initialLocation: initialLocator)
 
       let backItem = UIBarButtonItem()

--- a/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
+++ b/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
@@ -38,6 +38,7 @@ protocol ReaderModuleAPI {
   /// - Parameter navigationController: The navigation stack the book will be presented in.
   func presentPublication(_ publication: Publication,
                           book: NYPLBook,
+                          serverPermissions: NYPLReaderServerPermissions,
                           deviceID: String?,
                           in navigationController: UINavigationController,
                           successCompletion: (() -> Void)?)
@@ -78,6 +79,7 @@ final class ReaderModule: ReaderModuleAPI {
   
   func presentPublication(_ publication: Publication,
                           book: NYPLBook,
+                          serverPermissions: NYPLReaderServerPermissions,
                           deviceID: String?,
                           in navigationController: UINavigationController,
                           successCompletion: (() -> Void)?) {
@@ -90,20 +92,23 @@ final class ReaderModule: ReaderModuleAPI {
       return
     }
 
-    progressSynchronizer.sync(for: publication,
-                              book: book,
-                              drmDeviceID: deviceID) { [weak self] initialLocator in
-                                self?.finalizePresentation(for: publication,
-                                                           book: book,
-                                                           formatModule: formatModule,
-                                                           positioningAt: initialLocator,
-                                                           in: navigationController,
-                                                           successCompletion: successCompletion)
-    }
+    progressSynchronizer.sync(
+      for: publication,
+      book: book,
+      drmDeviceID: deviceID) { [weak self] initialLocator in
+        self?.finalizePresentation(for: publication,
+                                   book: book,
+                                   serverPermissions: serverPermissions,
+                                   formatModule: formatModule,
+                                   positioningAt: initialLocator,
+                                   in: navigationController,
+                                   successCompletion: successCompletion)
+      }
   }
 
   private func finalizePresentation(for publication: Publication,
                                     book: NYPLBook,
+                                    serverPermissions: NYPLReaderServerPermissions,
                                     formatModule: ReaderFormatModule,
                                     positioningAt initialLocator: Locator?,
                                     in navigationController: UINavigationController,
@@ -112,6 +117,7 @@ final class ReaderModule: ReaderModuleAPI {
       let readerVC = try formatModule.makeReaderViewController(
         for: publication,
         book: book,
+        serverPermissions: serverPermissions,
         initialLocation: initialLocator)
 
       let backItem = UIBarButtonItem()

--- a/Simplified/Reader2/ReaderPresentation/ReadingFormats/EPUBModule.swift
+++ b/Simplified/Reader2/ReaderPresentation/ReadingFormats/EPUBModule.swift
@@ -35,6 +35,7 @@ final class EPUBModule: ReaderFormatModule {
 
   func makeReaderViewController(for publication: Publication,
                                 book: NYPLBook,
+                                serverPermissions: NYPLReaderServerPermissions,
                                 initialLocation: Locator?) throws -> UIViewController {
       
     guard publication.metadata.identifier != nil else {
@@ -45,6 +46,7 @@ final class EPUBModule: ReaderFormatModule {
                                         book: book,
                                         initialLocation: initialLocation,
                                         resourcesServer: resourcesServer,
+                                        serverPermissions: serverPermissions,
                                         annotationsSynchronizer: annotationsSynchronizer)
     epubVC.moduleDelegate = delegate
     return epubVC

--- a/Simplified/Reader2/ReaderPresentation/ReadingFormats/EPUBModule.swift
+++ b/Simplified/Reader2/ReaderPresentation/ReadingFormats/EPUBModule.swift
@@ -35,7 +35,7 @@ final class EPUBModule: ReaderFormatModule {
 
   func makeReaderViewController(for publication: Publication,
                                 book: NYPLBook,
-                                serverPermissions: NYPLReaderServerPermissions,
+                                syncPermission: Bool,
                                 initialLocation: Locator?) throws -> UIViewController {
       
     guard publication.metadata.identifier != nil else {
@@ -46,7 +46,7 @@ final class EPUBModule: ReaderFormatModule {
                                         book: book,
                                         initialLocation: initialLocation,
                                         resourcesServer: resourcesServer,
-                                        serverPermissions: serverPermissions,
+                                        syncPermission: syncPermission,
                                         annotationsSynchronizer: annotationsSynchronizer)
     epubVC.moduleDelegate = delegate
     return epubVC

--- a/Simplified/Reader2/ReaderPresentation/ReadingFormats/ReaderFormatModule.swift
+++ b/Simplified/Reader2/ReaderPresentation/ReadingFormats/ReaderFormatModule.swift
@@ -27,7 +27,7 @@ protocol ReaderFormatModule {
   /// Creates the view controller to present the publication.
   func makeReaderViewController(for publication: Publication,
                                 book: NYPLBook,
-                                serverPermissions: NYPLReaderServerPermissions,
+                                syncPermission: Bool,
                                 initialLocation: Locator?) throws -> UIViewController
   
 }

--- a/Simplified/Reader2/ReaderPresentation/ReadingFormats/ReaderFormatModule.swift
+++ b/Simplified/Reader2/ReaderPresentation/ReadingFormats/ReaderFormatModule.swift
@@ -27,6 +27,7 @@ protocol ReaderFormatModule {
   /// Creates the view controller to present the publication.
   func makeReaderViewController(for publication: Publication,
                                 book: NYPLBook,
+                                serverPermissions: NYPLReaderServerPermissions,
                                 initialLocation: Locator?) throws -> UIViewController
   
 }

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -48,6 +48,7 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
   init(navigator: UIViewController & Navigator,
        publication: Publication,
        book: NYPLBook,
+       serverPermissions: NYPLReaderServerPermissions,
        annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
 
     self.navigator = navigator
@@ -64,7 +65,7 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
       r2Publication: publication,
       drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
       bookRegistryProvider: NYPLBookRegistry.shared(),
-      currentLibraryAccountProvider: AccountsManager.shared,
+      serverPermissions: serverPermissions,
       bookmarksSynchronizer: annotationsSynchronizer)
 
     bookmarksBusinessLogic.syncBookmarks { (_, _) in }

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -48,7 +48,7 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
   init(navigator: UIViewController & Navigator,
        publication: Publication,
        book: NYPLBook,
-       serverPermissions: NYPLReaderServerPermissions,
+       syncPermission: Bool,
        annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
 
     self.navigator = navigator
@@ -65,7 +65,7 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
       r2Publication: publication,
       drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
       bookRegistryProvider: NYPLBookRegistry.shared(),
-      serverPermissions: serverPermissions,
+      syncPermission: syncPermission,
       bookmarksSynchronizer: annotationsSynchronizer)
 
     bookmarksBusinessLogic.syncBookmarks { (_, _) in }

--- a/Simplified/Reader2/UI/NYPLEPUBViewController.swift
+++ b/Simplified/Reader2/UI/NYPLEPUBViewController.swift
@@ -23,6 +23,7 @@ class NYPLEPUBViewController: NYPLBaseReaderViewController {
        book: NYPLBook,
        initialLocation: Locator?,
        resourcesServer: ResourcesServer,
+       serverPermissions: NYPLReaderServerPermissions,
        annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
 
     // - hyphens = true helps with layout on small screens especially when
@@ -62,6 +63,7 @@ class NYPLEPUBViewController: NYPLBaseReaderViewController {
     super.init(navigator: navigator,
                publication: publication,
                book: book,
+               serverPermissions: serverPermissions,
                annotationsSynchronizer: annotationsSynchronizer)
 
     navigator.delegate = self

--- a/Simplified/Reader2/UI/NYPLEPUBViewController.swift
+++ b/Simplified/Reader2/UI/NYPLEPUBViewController.swift
@@ -23,7 +23,7 @@ class NYPLEPUBViewController: NYPLBaseReaderViewController {
        book: NYPLBook,
        initialLocation: Locator?,
        resourcesServer: ResourcesServer,
-       serverPermissions: NYPLReaderServerPermissions,
+       syncPermission: Bool,
        annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
 
     // - hyphens = true helps with layout on small screens especially when
@@ -63,7 +63,7 @@ class NYPLEPUBViewController: NYPLBaseReaderViewController {
     super.init(navigator: navigator,
                publication: publication,
                book: book,
-               serverPermissions: serverPermissions,
+               syncPermission: syncPermission,
                annotationsSynchronizer: annotationsSynchronizer)
 
     navigator.delegate = self

--- a/SimplifiedTests/Mocks/NYPLLibraryAccountsProviderMock.swift
+++ b/SimplifiedTests/Mocks/NYPLLibraryAccountsProviderMock.swift
@@ -89,3 +89,9 @@ class NYPLLibraryAccountMock: NSObject, NYPLLibraryAccountsProvider {
     }
   }
 }
+
+extension NYPLLibraryAccountMock: NYPLReaderServerPermissions {
+  var syncPermissionGranted: Bool {
+    return currentAccount?.details?.syncPermissionGranted ?? false
+  }
+}

--- a/SimplifiedTests/NYPLAudiobookBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLAudiobookBookmarksBusinessLogicTests.swift
@@ -58,11 +58,13 @@ class NYPLAudiobookBookmarksBusinessLogicTests: XCTestCase {
     libraryAccountMock = NYPLLibraryAccountMock()
     libraryAccountMock.currentAccount?.details?.syncPermissionGranted = true
     annotationsMock = NYPLAnnotationsMock.self
-    bookmarkBusinessLogic = NYPLAudiobookBookmarksBusinessLogic(book: fakeBook,
-                                                                drmDeviceID: deviceID,
-                                                                bookRegistryProvider: bookRegistryMock,
-                                                                currentLibraryAccountProvider: libraryAccountMock,
-                                                                annotationsSynchronizer: annotationsMock)
+    bookmarkBusinessLogic = NYPLAudiobookBookmarksBusinessLogic(
+      book: fakeBook,
+      drmDeviceID: deviceID,
+      bookRegistryProvider: bookRegistryMock,
+      syncPermission: libraryAccountMock.syncPermissionGranted,
+      annotationsSynchronizer: annotationsMock)
+    
     bookmarkCounter = 0
   }
 

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -64,7 +64,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       r2Publication: pub,
       drmDeviceID: "fakeDeviceID",
       bookRegistryProvider: bookRegistryMock,
-      serverPermissions: libraryAccountMock,
+      syncPermission: true,
       bookmarksSynchronizer: annotationsMock)
     bookmarkCounter = 0
   }

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -64,7 +64,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       r2Publication: pub,
       drmDeviceID: "fakeDeviceID",
       bookRegistryProvider: bookRegistryMock,
-      currentLibraryAccountProvider: libraryAccountMock,
+      serverPermissions: libraryAccountMock,
       bookmarksSynchronizer: annotationsMock)
     bookmarkCounter = 0
   }


### PR DESCRIPTION
**What's this do?**
Removes the dependency on the AccountManager singleton from the reader classes. It turns out all it was needed was the flag to see if we had permission to sync bookmarks. So I just passed the flag in. 

Note that this solution assumes that this flag won't change while the reader is open, which is currently the case for SimpleE/OpenE and it seems like a reasonable assumption to me. However if you think this assumption is invalid, I have also implemented it by passing a protocol in instead. This alternative is implemented by the [1st commit](https://github.com/NYPL-Simplified/Simplified-iOS/commit/3c003f5c5229918c7bcb981317a52bb6ede2a70e). The 2nd checkin replaces the protocol with the direct flag value.  

Please let me know which solution you prefer.

**Why are we doing this? (w/ JIRA link if applicable)**
[PJR-86](https://jira.nypl.org/browse/PJR-86)

**How should this be tested? / Do these changes have associated tests?**
regression will cover this. 

**Dependencies for merging? Releasing to production?**
n/a 
No breaking changes.

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore verified reading position and bookmarks are still saved and synced across devices.