### PR TITLE
PJR-87 Use NYPLAnnotations as a regular class & refactor related protocols

### DIFF
--- a/Simplified.xcodeproj/project.pbxproj
+++ b/Simplified.xcodeproj/project.pbxproj
@@ -671,6 +671,10 @@
 		7389859C264127C200088C07 /* SwiftSoup.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 732F0441263376530018A82E /* SwiftSoup.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7389859D264127C200088C07 /* ZIPFoundation.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 732F0433263374FC0018A82E /* ZIPFoundation.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7389859E264127C200088C07 /* ZXingObjC.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 732F0480263378EF0018A82E /* ZXingObjC.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		738AF9D62926CB74006217C1 /* NYPLEPUBOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738AF9D52926CB74006217C1 /* NYPLEPUBOpener.swift */; };
+		738AF9D72926CB74006217C1 /* NYPLEPUBOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738AF9D52926CB74006217C1 /* NYPLEPUBOpener.swift */; };
+		738AF9D82926CB74006217C1 /* NYPLEPUBOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738AF9D52926CB74006217C1 /* NYPLEPUBOpener.swift */; };
+		738AF9D92926CB74006217C1 /* NYPLEPUBOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738AF9D52926CB74006217C1 /* NYPLEPUBOpener.swift */; };
 		738CB2002509A61E00891F31 /* NYPLConfiguration+OE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738CB1FF2509A61E00891F31 /* NYPLConfiguration+OE.swift */; };
 		738CB2062509A87700891F31 /* NYPLConfiguration+SE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738CB2052509A87700891F31 /* NYPLConfiguration+SE.swift */; };
 		738D671A2866651500A9797D /* OECleverReauthenticatorVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738D67182866651500A9797D /* OECleverReauthenticatorVC.swift */; };
@@ -2130,6 +2134,7 @@
 		7386C1F3245225A5004C78BD /* NYPLReaderPositionsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLReaderPositionsVC.swift; sourceTree = "<group>"; };
 		7386C1F624525AFF004C78BD /* NYPLReaderTOCBusinessLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLReaderTOCBusinessLogic.swift; sourceTree = "<group>"; };
 		7386C1F9245276CA004C78BD /* NYPLReaderTOCCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLReaderTOCCell.swift; sourceTree = "<group>"; };
+		738AF9D52926CB74006217C1 /* NYPLEPUBOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLEPUBOpener.swift; sourceTree = "<group>"; };
 		738CB1FF2509A61E00891F31 /* NYPLConfiguration+OE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLConfiguration+OE.swift"; sourceTree = "<group>"; };
 		738CB2052509A87700891F31 /* NYPLConfiguration+SE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NYPLConfiguration+SE.swift"; sourceTree = "<group>"; };
 		738D67182866651500A9797D /* OECleverReauthenticatorVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OECleverReauthenticatorVC.swift; sourceTree = "<group>"; };
@@ -3206,6 +3211,7 @@
 				1120749219D20BF9008203A4 /* NYPLBookCellCollectionViewController.m */,
 				111197261986B43B0014462F /* NYPLBookCellDelegate.h */,
 				111197271986B43B0014462F /* NYPLBookCellDelegate.m */,
+				738AF9D52926CB74006217C1 /* NYPLEPUBOpener.swift */,
 				73ED9436271F95F3001E5B73 /* NYPLBookCellDelegate+Audiobooks.h */,
 				73ED9437271F95F3001E5B73 /* NYPLBookCellDelegate+Audiobooks.m */,
 				1111973D1988226F0014462F /* NYPLBookDetailDownloadFailedView.h */,
@@ -4543,6 +4549,7 @@
 				739E6085244A0D8600D00301 /* NYPLFacetBarView.swift in Sources */,
 				73A172EC27ADA6FA005E7BCF /* NYPLAxisBookDownloadMediator.swift in Sources */,
 				7342702624DCB28600A4F605 /* NYPLBook+Logging.swift in Sources */,
+				738AF9D72926CB74006217C1 /* NYPLEPUBOpener.swift in Sources */,
 				73B5510F2511751300D05B86 /* NYPLLibraryDescriptionCell.swift in Sources */,
 				73DB56C725F769FF003788EE /* NYPLLastReadPositionSynchronizer.swift in Sources */,
 				739E6086244A0D8600D00301 /* NYPLDismissibleViewController.m in Sources */,
@@ -4763,6 +4770,7 @@
 				73EB0A8325821DF4006BC997 /* NYPLAsync.m in Sources */,
 				73EB0A8425821DF4006BC997 /* NYPLReloadView.m in Sources */,
 				73D8D27625A68D3B00DF5F69 /* NYPLEPUBViewController.swift in Sources */,
+				738AF9D82926CB74006217C1 /* NYPLEPUBOpener.swift in Sources */,
 				2126FE6625C089110095C45C /* ReaderFormatModule.swift in Sources */,
 				7321485C28651E4B000DF0F0 /* NYPLSignInModalFactory.swift in Sources */,
 				73EB0A8725821DF4006BC997 /* NYPLCatalogGroupedFeedViewController.m in Sources */,
@@ -5164,6 +5172,7 @@
 				73AA8A91291C2DFB000F3F9A /* NYPLRootTabBarController+Common.swift in Sources */,
 				73FCA32F25005BA4001B0C5D /* ExtendedNavBarView.swift in Sources */,
 				219E4D9225C34A8600588588 /* DRMLibraryService.swift in Sources */,
+				738AF9D92926CB74006217C1 /* NYPLEPUBOpener.swift in Sources */,
 				73FCA33025005BA4001B0C5D /* OPDS2Link.swift in Sources */,
 				73FCA33125005BA4001B0C5D /* NYPLBookAuthor.swift in Sources */,
 				738D671A2866651500A9797D /* OECleverReauthenticatorVC.swift in Sources */,
@@ -5314,6 +5323,7 @@
 				73A172D627ADA6F9005E7BCF /* NYPLAxisBookDownloadMediator.swift in Sources */,
 				A46226271B39D4980063F549 /* NYPLOPDSGroup.m in Sources */,
 				A93F9F9721CDACF700BD3B0C /* NYPLAppReviewPrompt.swift in Sources */,
+				738AF9D62926CB74006217C1 /* NYPLEPUBOpener.swift in Sources */,
 				73DB56C625F769FF003788EE /* NYPLLastReadPositionSynchronizer.swift in Sources */,
 				8C835DD5234D0B900050A18D /* NYPLFacetBarView.swift in Sources */,
 				111197341986D7550014462F /* NYPLDismissibleViewController.m in Sources */,

--- a/Simplified/AppInfrastructure/NYPLRootTabBarController+Common.swift
+++ b/Simplified/AppInfrastructure/NYPLRootTabBarController+Common.swift
@@ -10,8 +10,8 @@ import Foundation
 
 extension NYPLRootTabBarController {
   @objc func makeR2Owner() -> NYPLR2Owner {
-    self.annotationsSync = NYPLAnnotations()
+    self.annotationsSynchronizer = NYPLAnnotations()
     return NYPLR2Owner(bookRegistry: NYPLBookRegistry.shared(),
-                       annotationsSynchronizer: annotationsSync)
+                       annotationsSynchronizer: annotationsSynchronizer)
   }
 }

--- a/Simplified/AppInfrastructure/NYPLRootTabBarController+Common.swift
+++ b/Simplified/AppInfrastructure/NYPLRootTabBarController+Common.swift
@@ -10,7 +10,8 @@ import Foundation
 
 extension NYPLRootTabBarController {
   @objc func makeR2Owner() -> NYPLR2Owner {
+    self.annotationsSync = NYPLAnnotations()
     return NYPLR2Owner(bookRegistry: NYPLBookRegistry.shared(),
-                       annotationsSynchronizer: NYPLAnnotations.self)
+                       annotationsSynchronizer: annotationsSync)
   }
 }

--- a/Simplified/AppInfrastructure/NYPLRootTabBarController.h
+++ b/Simplified/AppInfrastructure/NYPLRootTabBarController.h
@@ -1,4 +1,5 @@
 @class NYPLR2Owner;
+@class NYPLAnnotations;
 @class NYPLCatalogNavigationController;
 
 @interface NYPLRootTabBarController : UITabBarController
@@ -11,6 +12,7 @@
 + (instancetype)sharedController;
 
 @property (readonly) NYPLR2Owner *r2Owner;
+@property NYPLAnnotations *annotationsSync;
 @property(nonatomic, readonly) NYPLCatalogNavigationController *catalogNavigationController;
 
 /// This method will present a view controller from the receiver, or from the

--- a/Simplified/AppInfrastructure/NYPLRootTabBarController.h
+++ b/Simplified/AppInfrastructure/NYPLRootTabBarController.h
@@ -12,7 +12,7 @@
 + (instancetype)sharedController;
 
 @property (readonly) NYPLR2Owner *r2Owner;
-@property NYPLAnnotations *annotationsSync;
+@property NYPLAnnotations *annotationsSynchronizer;
 @property(nonatomic, readonly) NYPLCatalogNavigationController *catalogNavigationController;
 
 /// This method will present a view controller from the receiver, or from the

--- a/Simplified/Audiobooks/Bookmark/NYPLAudiobookBookmarksBusinessLogic.swift
+++ b/Simplified/Audiobooks/Bookmark/NYPLAudiobookBookmarksBusinessLogic.swift
@@ -31,7 +31,7 @@ class NYPLAudiobookBookmarksBusinessLogic: NYPLAudiobookBookmarking {
   private let drmDeviceID: String?
   private let bookRegistry: NYPLAudiobookRegistryProvider
   private let syncPermission: Bool
-  private let annotationsSynchronizer: NYPLAnnotationSyncing.Type
+  private let annotationsSynchronizer: NYPLAnnotationSyncing
   
   var bookmarksCount: Int {
     return bookmarks.count
@@ -51,7 +51,7 @@ class NYPLAudiobookBookmarksBusinessLogic: NYPLAudiobookBookmarking {
        drmDeviceID: String?,
        bookRegistryProvider: NYPLAudiobookRegistryProvider,
        syncPermission: Bool,
-       annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
+       annotationsSynchronizer: NYPLAnnotationSyncing) {
     self.book = book
     self.drmDeviceID = drmDeviceID
     self.bookRegistry = bookRegistryProvider

--- a/Simplified/Book/UI/NYPLBookCellDelegate+AudiobookBookmark.swift
+++ b/Simplified/Book/UI/NYPLBookCellDelegate+AudiobookBookmark.swift
@@ -23,7 +23,7 @@ import UIKit
       drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
       bookRegistryProvider: audiobookRegistryProvider,
       syncPermission: AccountsManager.shared.syncPermissionGranted,
-      annotationsSynchronizer: NYPLAnnotations.self)
+      annotationsSynchronizer: NYPLRootTabBarController.shared().annotationsSync)
     audiobookManager.bookmarkBusinessLogic = bizLogic
   }
 }

--- a/Simplified/Book/UI/NYPLBookCellDelegate+AudiobookBookmark.swift
+++ b/Simplified/Book/UI/NYPLBookCellDelegate+AudiobookBookmark.swift
@@ -23,7 +23,7 @@ import UIKit
       drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
       bookRegistryProvider: audiobookRegistryProvider,
       syncPermission: AccountsManager.shared.syncPermissionGranted,
-      annotationsSynchronizer: NYPLRootTabBarController.shared().annotationsSync)
+      annotationsSynchronizer: NYPLRootTabBarController.shared().annotationsSynchronizer)
     audiobookManager.bookmarkBusinessLogic = bizLogic
   }
 }

--- a/Simplified/Book/UI/NYPLBookCellDelegate.m
+++ b/Simplified/Book/UI/NYPLBookCellDelegate.m
@@ -101,7 +101,7 @@
 
   switch (book.defaultBookContentType) {
     case NYPLBookContentTypeEPUB:
-      [self openEPUB:book successCompletion:successCompletion];
+      [[[NYPLEPUBOpener alloc] init] open:book successCompletion:successCompletion];
       break;
     case NYPLBookContentTypePDF:
       [self openPDF:book];
@@ -115,30 +115,6 @@
       [self presentUnsupportedItemError];
       break;
   }
-}
-
-- (void)openEPUB:(NYPLBook *)book successCompletion:(void(^)(void))successCompletion
-{
-  NSURL *const url = [[NYPLMyBooksDownloadCenter sharedDownloadCenter]
-                      fileURLForBookIndentifier:book.identifier];
-
-  AccountsManager *accountMgr = [AccountsManager sharedInstance];
-  Account *currentAccount = [accountMgr currentAccount];
-  BOOL syncPermission = currentAccount.details.syncPermissionGranted;
-
-  [[NYPLRootTabBarController sharedController] presentBook:book
-                                               fromFileURL:url
-                                            syncPermission:syncPermission
-                                         successCompletion:successCompletion];
-
-  [NYPLAnnotations
-   requestServerSyncStatusWithSettings:[NYPLSettings sharedSettings]
-   syncPermissionGranted:syncPermission
-   syncSupportedCompletion:^(BOOL enableSync, NSError *error) {
-    if (error == nil) {
-      currentAccount.details.syncPermissionGranted = enableSync;
-    }
-  }];
 }
 
 - (void)openPDF:(NYPLBook *)book {

--- a/Simplified/Book/UI/NYPLEPUBOpener.swift
+++ b/Simplified/Book/UI/NYPLEPUBOpener.swift
@@ -18,15 +18,14 @@ class NYPLEPUBOpener: NSObject {
     let currentAccountDetails = AccountsManager.shared.currentAccount?.details
     let syncPermission = currentAccountDetails?.syncPermissionGranted ?? false
     let rootTabController = NYPLRootTabBarController.shared()
-    let serverSyncRequester = rootTabController?.annotationsSync
     rootTabController?.presentBook(book,
                                    fromFileURL: url,
                                    syncPermission: syncPermission,
                                    successCompletion: successCompletion)
     
-    serverSyncRequester?
-      .requestServerSyncStatus(settings: NYPLSettings.shared,
-                               syncPermissionGranted: syncPermission) { enableSync, error in
+    rootTabController?.annotationsSynchronizer?
+      .checkServerSyncStatus(settings: NYPLSettings.shared,
+                             syncPermissionGranted: syncPermission) { enableSync, error in
         guard error == nil else {
           return
         }

--- a/Simplified/Book/UI/NYPLEPUBOpener.swift
+++ b/Simplified/Book/UI/NYPLEPUBOpener.swift
@@ -1,0 +1,37 @@
+//
+//  NYPLEPUBOpener.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 11/17/22.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+
+import Foundation
+
+class NYPLEPUBOpener: NSObject {
+  @objc
+  func open(_ book: NYPLBook, successCompletion: @escaping () -> Void) {
+
+    let url = NYPLMyBooksDownloadCenter.shared()?
+      .fileURL(forBookIndentifier: book.identifier)
+
+    let currentAccountDetails = AccountsManager.shared.currentAccount?.details
+    let syncPermission = currentAccountDetails?.syncPermissionGranted ?? false
+    let rootTabController = NYPLRootTabBarController.shared()
+    let serverSyncRequester = rootTabController?.annotationsSync
+    rootTabController?.presentBook(book,
+                                   fromFileURL: url,
+                                   syncPermission: syncPermission,
+                                   successCompletion: successCompletion)
+    
+    serverSyncRequester?
+      .requestServerSyncStatus(settings: NYPLSettings.shared,
+                               syncPermissionGranted: syncPermission) { enableSync, error in
+        guard error == nil else {
+          return
+        }
+
+        currentAccountDetails?.syncPermissionGranted = enableSync;
+      }
+  }
+}

--- a/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
+++ b/Simplified/Reader2/BusinessLogic/NYPLReaderBookmarksBusinessLogic.swift
@@ -21,14 +21,14 @@ class NYPLReaderBookmarksBusinessLogic: NSObject {
   private let bookRegistry: NYPLBookRegistryProvider
   private let syncPermission: Bool
   private let bookmarksFactory: NYPLReadiumBookmarkFactory
-  private let bookmarksSynchronizer: NYPLAnnotationSyncing.Type
+  private let bookmarksSynchronizer: NYPLAnnotationSyncing
 
   init(book: NYPLBook,
        r2Publication: Publication,
        drmDeviceID: String?,
        bookRegistryProvider: NYPLBookRegistryProvider,
        syncPermission: Bool,
-       bookmarksSynchronizer: NYPLAnnotationSyncing.Type) {
+       bookmarksSynchronizer: NYPLAnnotationSyncing) {
     self.book = book
     self.publication = r2Publication
     self.drmDeviceID = drmDeviceID

--- a/Simplified/Reader2/Networking/NYPLAnnotations.swift
+++ b/Simplified/Reader2/Networking/NYPLAnnotations.swift
@@ -5,49 +5,18 @@ import NYPLUtilities
 import NYPLAudiobookToolkit
 #endif
 
-protocol NYPLAnnotationSyncing: AnyObject {
-  // Server sync status
-  
-  static func requestServerSyncStatus(settings: NYPLAnnotationSettings,
-                                      syncPermissionGranted: Bool,
-                                      syncSupportedCompletion: @escaping (_ enableSync: Bool,
-                                                                          _ error: Error?) -> ())
-  
-  static func updateServerSyncSetting(toEnabled enabled: Bool,
-                                      completion:@escaping (Bool)->())
+@objc
+protocol NYPLServerSyncUpdating: AnyObject {
+  func updateServerSyncSetting(toEnabled enabled: Bool,
+                               completion:@escaping (Bool)->())
+}
 
-  static func syncIsPossibleAndPermitted() -> Bool
-
-  // Reading position
-  
-  static func syncReadingPosition(ofBook bookID: String?,
-                                  publication: Publication?,
-                                  toURL url: URL?,
-                                  usingNetworkExecutor executor: NYPLHTTPRequestExecutingBasic,
-                                  completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ())
-  
-  static func postReadingPosition(forBook bookID: String, selectorValue: String)
-  
-  // Bookmark
-  
-  static func getServerBookmarks<T: NYPLBookmark>(of type: T.Type,
-                                                  forBook bookID:String?,
-                                                  publication: Publication?,
-                                                  atURL annotationURL:URL?,
-                                                  completion: @escaping (_ bookmarks: [T]?) -> ())
-  
-  static func deleteBookmarks(_ bookmarks: [NYPLBookmark])
-  
-  static func deleteBookmark(annotationId: String,
-                             completionHandler: @escaping (_ success: Bool) -> ())
-  
-  static func uploadLocalBookmarks<T: NYPLBookmark>(_ bookmarks: [T],
-                                                    forBook bookID: String,
-                                                    completion: @escaping ([T], [T])->())
-  
-  static func postBookmark(_ bookmark: NYPLBookmark,
-                           forBookID bookID: String,
-                           completion: @escaping (_ serverID: String?) -> ())
+@objc
+protocol NYPLServerSyncing: NYPLServerSyncUpdating {
+  func requestServerSyncStatus(settings: NYPLAnnotationSettings,
+                               syncPermissionGranted: Bool,
+                               syncSupportedCompletion: @escaping (_ enableSync: Bool,
+                                                                   _ error: Error?) -> ())
 }
 
 @objc
@@ -55,7 +24,63 @@ protocol NYPLAnnotationSettings: AnyObject {
   var userHasSeenFirstTimeSyncMessage: Bool {get set}
 }
 
+protocol NYPLAnnotationSyncing: NYPLServerSyncing {
+
+  // Server sync status
+
+  // NYPLLastReadPositionPoster, NYPLReaderBookmarksBusinessLogic
+  func syncIsPossibleAndPermitted() -> Bool
+
+  // Reading position
+
+  // needed by NYPLLastReadPositionSynchronizer
+  func syncReadingPosition(ofBook bookID: String?,
+                           publication: Publication?,
+                           toURL url: URL?,
+                           completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ())
+
+  // NYPLLastReadPositionPoster
+  func postReadingPosition(forBook bookID: String, selectorValue: String)
+  
+  // Bookmark
+
+  // NYPLReaderBookmarksBusinessLogic
+  func getServerBookmarks<T: NYPLBookmark>(of type: T.Type,
+                                           forBook bookID:String?,
+                                           publication: Publication?,
+                                           atURL annotationURL:URL?,
+                                           completion: @escaping (_ bookmarks: [T]?) -> ())
+  // NYPLReaderBookmarksBusinessLogic
+  func deleteBookmarks(_ bookmarks: [NYPLBookmark])
+
+  // NYPLReaderBookmarksBusinessLogic
+  func deleteBookmark(annotationId: String,
+                      completionHandler: @escaping (_ success: Bool) -> ())
+
+  // NYPLReaderBookmarksBusinessLogic
+  func uploadLocalBookmarks<T: NYPLBookmark>(_ bookmarks: [T],
+                                             forBook bookID: String,
+                                             completion: @escaping ([T], [T])->())
+
+  // NYPLReaderBookmarksBusinessLogic
+  func postBookmark(_ bookmark: NYPLBookmark,
+                    forBookID bookID: String,
+                    completion: @escaping (_ serverID: String?) -> ())
+}
+
 final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
+
+  let failFastExecutor: NYPLNetworkExecutor
+
+  override init() {
+    failFastExecutor = NYPLNetworkExecutor(
+      credentialsSource: NYPLUserAccount.sharedAccount(),
+      cachingStrategy: .ephemeral,
+      waitsForConnectivity: false)
+
+    super.init()
+  }
+
   // MARK: - Sync Settings
 
   /// Shows (if needed) the opt-in flow for syncing the user bookmarks and
@@ -75,10 +100,10 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
   ///   - syncSupportedCompletion: Handler always called at the end of the
   ///   process, unless sync is not supported by the current library.
   @objc
-  class func requestServerSyncStatus(settings: NYPLAnnotationSettings,
-                                     syncPermissionGranted: Bool,
-                                     syncSupportedCompletion: @escaping (_ enableSync: Bool,
-                                                                         _ error: Error?) -> ()) {
+  func requestServerSyncStatus(settings: NYPLAnnotationSettings,
+                               syncPermissionGranted: Bool,
+                               syncSupportedCompletion: @escaping (_ enableSync: Bool,
+                                                                   _ error: Error?) -> ()) {
     guard syncIsPossible() else {
       Log.info(#function, "Account does not satisfy conditions for sync setting request.")
       return
@@ -108,11 +133,11 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
       if (!initialized && settings.userHasSeenFirstTimeSyncMessage == false) {
         Log.info(#function, "Sync has never been initialized for the patron. Showing alert flow.")
         NYPLMainThreadRun.asyncIfNeeded {
-          #if OPENEBOOKS
+#if OPENEBOOKS
           let title = "Open eBooks Sync"
-          #else
+#else
           let title = "SimplyE Sync"
-          #endif
+#endif
           let message = "Enable sync to save your reading position and bookmarks to your other devices.\n\nYou can change this any time in Settings."
           let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
           let notNowAction = UIAlertAction(title: "Not Now", style: .default) { action in
@@ -146,27 +171,27 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
   ///   - completion: if a network request is actually performed, this block
   /// is guaranteed to be called on the Main queue. Otherwise, this is called
   /// on the same thread the function was invoked on.
-  class func updateServerSyncSetting(toEnabled enabled: Bool, completion:@escaping (Bool)->()) {
+  func updateServerSyncSetting(toEnabled enabled: Bool, completion:@escaping (Bool)->()) {
     if (NYPLUserAccount.sharedAccount().hasCredentials() &&
-      AccountsManager.shared.currentAccount?.details?.supportsSimplyESync == true) {
+        AccountsManager.shared.currentAccount?.details?.supportsSimplyESync == true) {
       guard let userProfileUrl = URL(string: AccountsManager.shared.currentAccount?.details?.userProfileUrl ?? "") else {
         Log.error(#file, "Could not create user profile URL from string. Abandoning attempt to update sync setting.")
         completion(false)
         return
       }
       let parameters = ["settings": ["simplified:synchronize_annotations": enabled]] as [String : Any]
-      updateSyncSettings(at: userProfileUrl, parameters, { success in
+      NYPLAnnotations.updateSyncSettings(at: userProfileUrl, parameters, { success in
         if !success {
-          handleSyncSettingError()
+          NYPLAnnotations.handleSyncSettingError()
         }
         completion(success)
       })
     }
   }
 
-  private class func fetchSyncStatus(completion: @escaping (_ initialized: Bool,
-                                                            _ syncIsPermitted: Bool,
-                                                            _ error: Error?) -> ()) {
+  private func fetchSyncStatus(completion: @escaping (_ initialized: Bool,
+                                                      _ syncIsPermitted: Bool,
+                                                      _ error: Error?) -> ()) {
     guard let userProfileUrl = URL(string: AccountsManager.shared.currentAccount?.details?.userProfileUrl ?? "") else {
       Log.error(#file, "Failed to create user profile URL from string. Abandoning attempt to retrieve sync setting.")
       return
@@ -209,7 +234,7 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
   private class func updateSyncSettings(at url: URL,
                                         _ parameters: [String:Any],
                                         _ completion: @escaping (Bool)->()) {
-    guard let jsonData = makeSubmissionData(fromRepresentation: parameters) else {
+    guard let jsonData = NYPLAnnotations.makeSubmissionData(fromRepresentation: parameters) else {
       Log.error(#file, "Network request abandoned. Could not create JSON from given parameters.")
       completion(false)
       return
@@ -222,7 +247,7 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
         let httpStatus = (response as? HTTPURLResponse)?.statusCode ?? -1
         Log.error(#file, "Error updating sync settings, server returned: \(httpStatus)")
         if NetworkQueue.StatusCodes.contains(error.code) {
-          self.addRequestToOfflineQueue(httpMethod: .PUT,
+          NYPLAnnotations.addRequestToOfflineQueue(httpMethod: .PUT,
                                         url: url,
                                         parameters: parameters)
         }
@@ -248,11 +273,10 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
 
   /// Reads the current reading position from the server, parses the response
   /// and returns the result to the `completionHandler`.
-  class func syncReadingPosition(ofBook bookID: String?,
-                                 publication: Publication?,
-                                 toURL url:URL?,
-                                 usingNetworkExecutor executor: NYPLHTTPRequestExecutingBasic,
-                                 completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ()) {
+  func syncReadingPosition(ofBook bookID: String?,
+                           publication: Publication?,
+                           toURL url:URL?,
+                           completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ()) {
 
     guard syncIsPossibleAndPermitted() else {
       Log.info(#file, "Library account does not support sync or sync is disabled by user.")
@@ -266,20 +290,21 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
       return
     }
 
-    _ = executor.GET(url,
-                     cachePolicy: .reloadIgnoringLocalCacheData) { data, _, error in
-      let bookmarks: [NYPLReadiumBookmark]? = parseAnnotationsResponse(data,
-                                                                       of: NYPLReadiumBookmark.self,
-                                                                       error: error,
-                                                                       motivation: .readingProgress,
-                                                                       publication: publication,
-                                                                       bookID: bookID)
+    _ = failFastExecutor.GET(url,
+                             cachePolicy: .reloadIgnoringLocalCacheData) { data, _, error in
+      let bookmarks: [NYPLReadiumBookmark]? = NYPLAnnotations
+        .parseAnnotationsResponse(data,
+                                  of: NYPLReadiumBookmark.self,
+                                  error: error,
+                                  motivation: .readingProgress,
+                                  publication: publication,
+                                  bookID: bookID)
       let readPos = bookmarks?.first
       completion(readPos)
     }
   }
 
-  class func postReadingPosition(forBook bookID: String, selectorValue: String) {
+  func postReadingPosition(forBook bookID: String, selectorValue: String) {
     // Format annotation for submission to server according to spec
     let bookmark = NYPLBookmarkSpec(time: Date(),
                                     device: NYPLUserAccount.sharedAccount().deviceID ?? "",
@@ -310,11 +335,11 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
 
   // Completion handler will return a nil parameter if there are any failures with
   // the network request, deserialization, or sync permission is not allowed.
-  class func getServerBookmarks<T: NYPLBookmark>(of type: T.Type,
-                                                 forBook bookID:String?,
-                                                 publication: Publication?,
-                                                 atURL annotationURL:URL?,
-                                                 completion: @escaping (_ bookmarks: [T]?) -> ()) {
+  func getServerBookmarks<T: NYPLBookmark>(of type: T.Type,
+                                           forBook bookID:String?,
+                                           publication: Publication?,
+                                           atURL annotationURL:URL?,
+                                           completion: @escaping (_ bookmarks: [T]?) -> ()) {
 
     guard syncIsPossibleAndPermitted() else {
       Log.info(#file, "Library account does not support sync or sync is disabled by user.")
@@ -329,17 +354,18 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
     }
 
     NYPLNetworkExecutor.shared.GET(annotationURL, cachePolicy: .reloadIgnoringLocalCacheData) { data, _, error in
-      let bookmarks: [T]? = parseAnnotationsResponse(data,
-                                                     of: T.self,
-                                                     error: error,
-                                                     motivation: .bookmark,
-                                                     publication: publication,
-                                                     bookID: bookID)
+      let bookmarks: [T]? = NYPLAnnotations
+        .parseAnnotationsResponse(data,
+                                  of: T.self,
+                                  error: error,
+                                  motivation: .bookmark,
+                                  publication: publication,
+                                  bookID: bookID)
       completion(bookmarks)
     }
   }
 
-  class func deleteBookmarks(_ bookmarks: [NYPLBookmark]) {
+  func deleteBookmarks(_ bookmarks: [NYPLBookmark]) {
 
     if !syncIsPossibleAndPermitted() {
       Log.info(#file, "Library account does not support sync or sync is disabled by user.")
@@ -359,8 +385,8 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
     }
   }
 
-  class func deleteBookmark(annotationId: String,
-                            completionHandler: @escaping (_ success: Bool) -> ()) {
+  func deleteBookmark(annotationId: String,
+                      completionHandler: @escaping (_ success: Bool) -> ()) {
 
     if !syncIsPossibleAndPermitted() {
       Log.info(#file, "Library account does not support sync or sync is disabled by user.")
@@ -392,9 +418,9 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
 
   // Method is called when the SyncManager is syncing bookmarks
   // If an existing local bookmark is missing an annotationID, assume it still needs to be uploaded.
-  class func uploadLocalBookmarks<T: NYPLBookmark>(_ bookmarks: [T],
-                                  forBook bookID: String,
-                                  completion: @escaping ([T], [T])->()) {
+  func uploadLocalBookmarks<T: NYPLBookmark>(_ bookmarks: [T],
+                                             forBook bookID: String,
+                                             completion: @escaping ([T], [T])->()) {
 
     if !syncIsPossibleAndPermitted() {
       Log.info(#file, "Library account does not support sync or sync is disabled by user.")
@@ -438,9 +464,9 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
   ///   - bookmark: The bookmark to save to the server.
   ///   - bookID: The book ID the bookmark refers to.
   ///   - completion: Always called at the end of the api call.
-  class func postBookmark(_ bookmark: NYPLBookmark,
-                          forBookID bookID: String,
-                          completion: @escaping (_ serverID: String?) -> ()) {
+  func postBookmark(_ bookmark: NYPLBookmark,
+                    forBookID bookID: String,
+                    completion: @escaping (_ serverID: String?) -> ()) {
 
     let serializableBookmark = bookmark
       .serializableRepresentation(forMotivation: .bookmark,
@@ -485,20 +511,21 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
     }
 
     guard let data = data,
-      let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []),
-      let json = jsonObject as? [String: Any] else {
-        NYPLErrorLogger.logError(withCode: .serializationFail,
-                                 summary: "NYPLAnnotations::parseAnnotationsResponse error",
-                                 metadata: metadata)
-        return nil
+          let jsonObject = try? JSONSerialization.jsonObject(with: data,
+                                                             options: []),
+          let json = jsonObject as? [String: Any] else {
+      NYPLErrorLogger.logError(withCode: .serializationFail,
+                               summary: "NYPLAnnotations::parseAnnotationsResponse error",
+                               metadata: metadata)
+      return nil
     }
 
     guard let first = json["first"] as? [String: Any],
-      let items = first["items"] as? [[String: Any]] else {
-        NYPLErrorLogger.logError(withCode: .noData,
-                                 summary: "NYPLAnnotations::parseAnnotationsResponse error",
-                                 metadata: metadata)
-        return nil
+          let items = first["items"] as? [[String: Any]] else {
+      NYPLErrorLogger.logError(withCode: .noData,
+                               summary: "NYPLAnnotations::parseAnnotationsResponse error",
+                               metadata: metadata)
+      return nil
     }
 
     var bookmarks = [T]()
@@ -533,10 +560,10 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
   ///
   /// - Note: Does not log error reports to Crashlytics. That responsibility is
   /// left to the caller.
-  private class func postAnnotation(forBook bookID: String,
-                                    withParameters parameters: [String: Any],
-                                    queueOffline: Bool,
-                                    _ completion: @escaping (_ result: Result<String?, Error>) -> ()) {
+  private func postAnnotation(forBook bookID: String,
+                              withParameters parameters: [String: Any],
+                              queueOffline: Bool,
+                              _ completion: @escaping (_ result: Result<String?, Error>) -> ()) {
 
     guard let annotationsURL = NYPLAnnotations.annotationsURL else {
       let err = NSError(domain: "Error posting annotation",
@@ -546,7 +573,7 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
       return
     }
 
-    guard let jsonData = makeSubmissionData(fromRepresentation: parameters) else {
+    guard let jsonData = NYPLAnnotations.makeSubmissionData(fromRepresentation: parameters) else {
       let err = NSError(domain: "Error posting annotation",
                         code: NYPLErrorCode.serializationFail.rawValue,
                         userInfo: ["Reason": "Could not create JSON body from input params",
@@ -561,16 +588,16 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
       switch result {
       case .success(let data, _):
         Log.info(#file, "Annotation POST for bookID \(bookID): Success 200.")
-        let serverAnnotationID = annotationID(fromNetworkData: data)
+        let serverAnnotationID = NYPLAnnotations.annotationID(fromNetworkData: data)
         completion(.success(serverAnnotationID))
       case .failure(let error, _):
         let err = error as NSError
         Log.error(#file, "Annotation POST for bookID \(bookID): Error (nsCode: \(err.code) Description: \(err.localizedDescription))")
         if NetworkQueue.StatusCodes.contains(err.code) && queueOffline {
-          self.addRequestToOfflineQueue(httpMethod: .POST,
-                                        url: annotationsURL,
-                                        bookID: bookID,
-                                        parameters: parameters)
+          NYPLAnnotations.addRequestToOfflineQueue(httpMethod: .POST,
+                                                   url: annotationsURL,
+                                                   bookID: bookID,
+                                                   parameters: parameters)
         }
         completion(.failure(err))
       }
@@ -596,13 +623,13 @@ final class NYPLAnnotations: NSObject, NYPLAnnotationSyncing {
 
   /// Annotation-syncing is possible only if the current user account is signed-in
   /// and if the currently selected library supports it.
-  private class func syncIsPossible() -> Bool {
+  private func syncIsPossible() -> Bool {
     let library = AccountsManager.shared.currentAccount
     let userAccount = NYPLUserAccount.sharedAccount()
     return userAccount.hasCredentials() && library?.details?.supportsSimplyESync == true
   }
 
-  class func syncIsPossibleAndPermitted() -> Bool {
+  func syncIsPossibleAndPermitted() -> Bool {
     let library = AccountsManager.shared.currentAccount
     return syncIsPossible() && library?.details?.syncPermissionGranted == true
   }

--- a/Simplified/Reader2/Networking/NYPLLastReadPositionPoster.swift
+++ b/Simplified/Reader2/Networking/NYPLLastReadPositionPoster.swift
@@ -20,7 +20,7 @@ class NYPLLastReadPositionPoster {
 
   // external dependencies
   private let bookRegistryProvider: NYPLBookRegistryProvider
-  private let annotationsSynchronizer: NYPLAnnotationSyncing.Type
+  private let annotationsSynchronizer: NYPLAnnotationSyncing
 
   // internal state management
   private var lastReadPositionUploadDate: Date
@@ -29,7 +29,7 @@ class NYPLLastReadPositionPoster {
 
   init(book: NYPLBook,
        bookRegistryProvider: NYPLBookRegistryProvider,
-       annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
+       annotationsSynchronizer: NYPLAnnotationSyncing) {
     self.book = book
     self.bookRegistryProvider = bookRegistryProvider
     self.lastReadPositionUploadDate = Date()

--- a/Simplified/Reader2/Networking/NYPLLastReadPositionPoster.swift
+++ b/Simplified/Reader2/Networking/NYPLLastReadPositionPoster.swift
@@ -20,7 +20,7 @@ class NYPLLastReadPositionPoster {
 
   // external dependencies
   private let bookRegistryProvider: NYPLBookRegistryProvider
-  private let annotationsSynchronizer: NYPLAnnotationSyncing
+  private let synchronizer: NYPLLastReadPositionSupportAPI
 
   // internal state management
   private var lastReadPositionUploadDate: Date
@@ -29,12 +29,12 @@ class NYPLLastReadPositionPoster {
 
   init(book: NYPLBook,
        bookRegistryProvider: NYPLBookRegistryProvider,
-       annotationsSynchronizer: NYPLAnnotationSyncing) {
+       synchronizer: NYPLLastReadPositionSupportAPI) {
     self.book = book
     self.bookRegistryProvider = bookRegistryProvider
     self.lastReadPositionUploadDate = Date()
       .addingTimeInterval(-NYPLLastReadPositionPoster.throttlingInterval)
-    self.annotationsSynchronizer = annotationsSynchronizer
+    self.synchronizer = synchronizer
 
     NotificationCenter.default.addObserver(self,
                                            selector: #selector(postQueuedReadPositionInSerialQueue),
@@ -64,7 +64,7 @@ class NYPLLastReadPositionPoster {
     bookRegistryProvider.setLocation(location, forIdentifier: book.identifier)
 
     // attempt to store location on server
-    if annotationsSynchronizer.syncIsPossibleAndPermitted() {
+    if synchronizer.syncIsPossibleAndPermitted() {
       let selectorValue = NYPLReadiumBookmarkFactory
         .makeLocatorString(chapterHref: locator.href,
                            chapterProgression: Float(chapterProgress))
@@ -98,7 +98,7 @@ class NYPLLastReadPositionPoster {
   }
 
   @objc private func postQueuedReadPositionInSerialQueue() {
-    if annotationsSynchronizer.syncIsPossibleAndPermitted() {
+    if synchronizer.syncIsPossibleAndPermitted() {
       serialQueue.async { [weak self] in
         self?.postQueuedReadPosition()
       }
@@ -111,7 +111,7 @@ class NYPLLastReadPositionPoster {
       return
     }
 
-    annotationsSynchronizer.postReadingPosition(forBook: book.identifier,
+    synchronizer.postReadingPosition(forBook: book.identifier,
                                                 selectorValue: queuedReadPosition)
     self.queuedReadPosition = ""
     self.lastReadPositionUploadDate = Date()

--- a/Simplified/Reader2/Networking/NYPLLastReadPositionSynchronizer.swift
+++ b/Simplified/Reader2/Networking/NYPLLastReadPositionSynchronizer.swift
@@ -25,14 +25,14 @@ class NYPLLastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing {
     case stay, moveToServerLocator
   }
 
-  let synchronizer: NYPLAnnotationSyncing
+  let synchronizer: NYPLLastReadPositionSupportAPI
 
   /// Designated initializer.
   ///
   /// - Parameters:
   ///   - bookRegistry: The registry that stores the reading progresses.
   init(bookRegistry: NYPLBookRegistryProvider,
-       synchronizer: NYPLAnnotationSyncing) {
+       synchronizer: NYPLLastReadPositionSupportAPI) {
     self.bookRegistry = bookRegistry
     self.synchronizer = synchronizer
   }

--- a/Simplified/Reader2/Networking/NYPLLastReadPositionSynchronizer.swift
+++ b/Simplified/Reader2/Networking/NYPLLastReadPositionSynchronizer.swift
@@ -25,21 +25,16 @@ class NYPLLastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing {
     case stay, moveToServerLocator
   }
 
-  private let failFastNetworkExecutor: NYPLNetworkExecutor
-  let synchronizer: NYPLAnnotationSyncing.Type
+  let synchronizer: NYPLAnnotationSyncing
 
   /// Designated initializer.
   ///
   /// - Parameters:
   ///   - bookRegistry: The registry that stores the reading progresses.
   init(bookRegistry: NYPLBookRegistryProvider,
-       synchronizer: NYPLAnnotationSyncing.Type) {
+       synchronizer: NYPLAnnotationSyncing) {
     self.bookRegistry = bookRegistry
     self.synchronizer = synchronizer
-    failFastNetworkExecutor = NYPLNetworkExecutor(
-      credentialsSource: NYPLUserAccount.sharedAccount(),
-      cachingStrategy: .ephemeral,
-      waitsForConnectivity: false)
   }
 
   /// Fetches the read position from the server and alerts the user
@@ -113,7 +108,7 @@ class NYPLLastReadPositionSynchronizer: NYPLLastReadPositionSynchronizing {
     let localLocation = bookRegistry.location(forIdentifier: book.identifier)
 
     synchronizer
-      .syncReadingPosition(ofBook: book.identifier, publication: publication, toURL: book.annotationsURL, usingNetworkExecutor: failFastNetworkExecutor) { bookmark in
+      .syncReadingPosition(ofBook: book.identifier, publication: publication, toURL: book.annotationsURL) { bookmark in
 
         guard let bookmark = bookmark else {
           Log.info(#function, "No reading position annotation exists on the server for \(book.loggableShortString()).")

--- a/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
+++ b/Simplified/Reader2/ReaderPresentation/ReaderModule.swift
@@ -63,7 +63,7 @@ final class ReaderModule: ReaderModuleAPI {
   init(delegate: R2ModuleDelegate?,
        resourcesServer: ResourcesServer,
        bookRegistry: NYPLBookRegistryProvider,
-       annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
+       annotationsSynchronizer: NYPLAnnotationSyncing) {
     self.delegate = delegate
     self.resourcesServer = resourcesServer
     self.progressSynchronizer = NYPLLastReadPositionSynchronizer(

--- a/Simplified/Reader2/ReaderPresentation/ReadingFormats/EPUBModule.swift
+++ b/Simplified/Reader2/ReaderPresentation/ReadingFormats/EPUBModule.swift
@@ -19,11 +19,11 @@ final class EPUBModule: ReaderFormatModule {
   
   weak var delegate: R2ModuleDelegate?
   let resourcesServer: ResourcesServer
-  private let annotationsSynchronizer: NYPLAnnotationSyncing.Type
+  private let annotationsSynchronizer: NYPLAnnotationSyncing
   
   init(delegate: R2ModuleDelegate?,
        resourcesServer: ResourcesServer,
-       annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
+       annotationsSynchronizer: NYPLAnnotationSyncing) {
     self.delegate = delegate
     self.resourcesServer = resourcesServer
     self.annotationsSynchronizer = annotationsSynchronizer

--- a/Simplified/Reader2/ReaderStackConfiguration/NYPLR2Owner.swift
+++ b/Simplified/Reader2/ReaderStackConfiguration/NYPLR2Owner.swift
@@ -24,7 +24,7 @@ import R2Streamer
   var readerModule: ReaderModuleAPI! = nil
 
   init(bookRegistry: NYPLBookRegistryProvider,
-       annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
+       annotationsSynchronizer: NYPLAnnotationSyncing) {
     super.init()
     guard let server = PublicationServer() else {
       /// FIXME: we should recover properly if the publication server can't

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -49,7 +49,7 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
        publication: Publication,
        book: NYPLBook,
        syncPermission: Bool,
-       annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
+       annotationsSynchronizer: NYPLAnnotationSyncing) {
 
     self.navigator = navigator
     self.publication = publication

--- a/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
+++ b/Simplified/Reader2/UI/NYPLBaseReaderViewController.swift
@@ -57,7 +57,7 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
     lastReadPositionPoster = NYPLLastReadPositionPoster(
       book: book,
       bookRegistryProvider: NYPLBookRegistry.shared(),
-      annotationsSynchronizer: annotationsSynchronizer
+      synchronizer: annotationsSynchronizer
     )
 
     bookmarksBusinessLogic = NYPLReaderBookmarksBusinessLogic(
@@ -66,7 +66,7 @@ class NYPLBaseReaderViewController: UIViewController, Loggable {
       drmDeviceID: NYPLUserAccount.sharedAccount().deviceID,
       bookRegistryProvider: NYPLBookRegistry.shared(),
       syncPermission: syncPermission,
-      bookmarksSynchronizer: annotationsSynchronizer)
+      synchronizer: annotationsSynchronizer)
 
     bookmarksBusinessLogic.syncBookmarks { (_, _) in }
 

--- a/Simplified/Reader2/UI/NYPLEPUBViewController.swift
+++ b/Simplified/Reader2/UI/NYPLEPUBViewController.swift
@@ -24,7 +24,7 @@ class NYPLEPUBViewController: NYPLBaseReaderViewController {
        initialLocation: Locator?,
        resourcesServer: ResourcesServer,
        syncPermission: Bool,
-       annotationsSynchronizer: NYPLAnnotationSyncing.Type) {
+       annotationsSynchronizer: NYPLAnnotationSyncing) {
 
     // - hyphens = true helps with layout on small screens especially when
     // publisher's defaults are off.

--- a/Simplified/Settings/NYPLSettingsDeleteServerDataViewController.swift
+++ b/Simplified/Settings/NYPLSettingsDeleteServerDataViewController.swift
@@ -19,7 +19,7 @@ import UIKit
   private let syncSettingUpdater: NYPLServerSyncUpdating
   
   @objc init(delegate: NYPLServerDataDeleting) {
-    self.syncSettingUpdater = NYPLRootTabBarController.shared().annotationsSync
+    self.syncSettingUpdater = NYPLRootTabBarController.shared().annotationsSynchronizer
     self.delegate = delegate
     
     super.init(nibName: nil, bundle: nil)

--- a/Simplified/Settings/NYPLSettingsDeleteServerDataViewController.swift
+++ b/Simplified/Settings/NYPLSettingsDeleteServerDataViewController.swift
@@ -16,8 +16,10 @@ import UIKit
   private let tableViewFooterViewHeight: CGFloat = 15.0
   
   @objc weak var delegate: NYPLServerDataDeleting?
+  private let syncSettingUpdater: NYPLServerSyncUpdating
   
   @objc init(delegate: NYPLServerDataDeleting) {
+    self.syncSettingUpdater = NYPLRootTabBarController.shared().annotationsSync
     self.delegate = delegate
     
     super.init(nibName: nil, bundle: nil)
@@ -85,19 +87,20 @@ import UIKit
                                     comment: "Loading view message")
     let vc = NYPLActivityIndicatorMessageViewController(message: message)
     present(vc, animated: false)
-    NYPLAnnotations.updateServerSyncSetting(toEnabled: false) { [weak self] success in
-      NYPLMainThreadRun.asyncIfNeeded {
-        guard let self = self else {
-          return
-        }
-        self.dismiss(animated: false)
-        if success {
-          self.delegate?.didDeleteServerData()
-        } else {
-          self.showAlert()
+    syncSettingUpdater
+      .updateServerSyncSetting(toEnabled: false) { [weak self] success in
+        NYPLMainThreadRun.asyncIfNeeded {
+          guard let self = self else {
+            return
+          }
+          self.dismiss(animated: false)
+          if success {
+            self.delegate?.didDeleteServerData()
+          } else {
+            self.showAlert()
+          }
         }
       }
-    }
     DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
       self.dismiss(animated: false)
       self.showAlert()

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
@@ -29,7 +29,7 @@ extension NYPLSignInBusinessLogic {
                                   postServerSyncCompletion: @escaping (Bool) -> Void) {
     if granted {
       // When granting, attempt to enable on the server.
-      NYPLAnnotations.updateServerSyncSetting(toEnabled: true) { success in
+      annotationsSynchronizer.updateServerSyncSetting(toEnabled: true) { success in
         self.libraryAccount?.details?.syncPermissionGranted = success
         NYPLMainThreadRun.asyncIfNeeded {
           postServerSyncCompletion(success)
@@ -66,7 +66,7 @@ extension NYPLSignInBusinessLogic {
       preWork()
     }
 
-    NYPLAnnotations.requestServerSyncStatus(
+    annotationsSynchronizer.requestServerSyncStatus(
       settings: NYPLSettings.shared,
       syncPermissionGranted: libraryDetails.syncPermissionGranted) { enableSync, error in
         

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic+BookmarkSyncing.swift
@@ -29,7 +29,7 @@ extension NYPLSignInBusinessLogic {
                                   postServerSyncCompletion: @escaping (Bool) -> Void) {
     if granted {
       // When granting, attempt to enable on the server.
-      annotationsSynchronizer.updateServerSyncSetting(toEnabled: true) { success in
+      syncStatusSynchronizer.updateServerSyncSetting(toEnabled: true) { success in
         self.libraryAccount?.details?.syncPermissionGranted = success
         NYPLMainThreadRun.asyncIfNeeded {
           postServerSyncCompletion(success)
@@ -66,7 +66,7 @@ extension NYPLSignInBusinessLogic {
       preWork()
     }
 
-    annotationsSynchronizer.requestServerSyncStatus(
+    syncStatusSynchronizer.checkServerSyncStatus(
       settings: NYPLSettings.shared,
       syncPermissionGranted: libraryDetails.syncPermissionGranted) { enableSync, error in
         

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
@@ -89,6 +89,7 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider, NYPLCurrentL
     self.urlSettingsProvider = urlSettingsProvider
     self.bookRegistry = bookRegistry
     self.bookDownloadsRemover = bookDownloadsRemover
+    self.annotationsSynchronizer = NYPLAnnotations()
     self.userAccountProvider = userAccountProvider
     self.networker = networkExecutor
     self.drmAuthorizerAdobe = drmAuthorizerAdobe
@@ -103,6 +104,8 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider, NYPLCurrentL
 
   /// Signing out implies removing book downloads from the device.
   let bookDownloadsRemover: NYPLBookDownloadsDeleting
+
+  let annotationsSynchronizer: NYPLServerSyncing
 
   /// Provides the user account for a given library.
   private let userAccountProvider: NYPLUserAccountProvider.Type

--- a/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
+++ b/Simplified/SignInLogic/NYPLSignInBusinessLogic.swift
@@ -89,7 +89,7 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider, NYPLCurrentL
     self.urlSettingsProvider = urlSettingsProvider
     self.bookRegistry = bookRegistry
     self.bookDownloadsRemover = bookDownloadsRemover
-    self.annotationsSynchronizer = NYPLAnnotations()
+    self.syncStatusSynchronizer = NYPLAnnotations()
     self.userAccountProvider = userAccountProvider
     self.networker = networkExecutor
     self.drmAuthorizerAdobe = drmAuthorizerAdobe
@@ -105,7 +105,7 @@ class NYPLSignInBusinessLogic: NSObject, NYPLSignedInStateProvider, NYPLCurrentL
   /// Signing out implies removing book downloads from the device.
   let bookDownloadsRemover: NYPLBookDownloadsDeleting
 
-  let annotationsSynchronizer: NYPLServerSyncing
+  let syncStatusSynchronizer: NYPLServerSyncUpdating & NYPLServerSyncChecking
 
   /// Provides the user account for a given library.
   private let userAccountProvider: NYPLUserAccountProvider.Type

--- a/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
+++ b/SimplifiedTests/Mocks/NYPLAnnotationsMock.swift
@@ -12,32 +12,32 @@ import NYPLUtilities
 @testable import SimplyE
 
 class NYPLAnnotationsMock: NYPLAnnotationSyncing {
-  static var failRequest: Bool = false
-  static var serverBookmarks: [String: [NYPLBookmark]] = [String: [NYPLBookmark]]()
-  static var readingPositions: [String: NYPLBookmarkSpec] = [String: NYPLBookmarkSpec]()
+  var failRequest: Bool = false
+  var serverBookmarks: [String: [NYPLBookmark]] = [String: [NYPLBookmark]]()
+  var readingPositions: [String: NYPLBookmarkSpec] = [String: NYPLBookmarkSpec]()
   
   // For generating unique annotation id
-  static private var annotationCounter: Int = 0
+  private var annotationCounter: Int = 0
   
   // Server status
   
-  static func requestServerSyncStatus(settings: NYPLAnnotationSettings,
-                                      syncPermissionGranted: Bool,
-                                      syncSupportedCompletion: @escaping (Bool, Error?) -> ()) {
+  func checkServerSyncStatus(settings: NYPLAnnotationSettings,
+                             syncPermissionGranted: Bool,
+                             syncSupportedCompletion: @escaping (Bool, Error?) -> ()) {
     syncSupportedCompletion(true, nil)
   }
   
-  static func updateServerSyncSetting(toEnabled enabled: Bool, completion:@escaping (Bool)->()) {
+  func updateServerSyncSetting(toEnabled enabled: Bool,
+                               completion:@escaping (Bool)->()) {
     completion(false)
   }
   
   // Reading position
   
-  static func syncReadingPosition(ofBook bookID: String?,
-                                  publication: Publication?,
-                                  toURL url:URL?,
-                                  usingNetworkExecutor: NYPLHTTPRequestExecutingBasic,
-                                  completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ()) {
+  func syncReadingPosition(ofBook bookID: String?,
+                           publication: Publication?,
+                           toURL url:URL?,
+                           completion: @escaping (_ readPos: NYPLReadiumBookmark?) -> ()) {
     guard !failRequest,
           let id = bookID,
           let bookmarkSpec = readingPositions[id] else {
@@ -46,13 +46,13 @@ class NYPLAnnotationsMock: NYPLAnnotationSyncing {
     }
     let bookmarkData = bookmarkSpec.dictionaryForJSONSerialization()
     let bookmark = NYPLReadiumBookmarkFactory.make(fromServerAnnotation: bookmarkData,
-                                            annotationType: .readingProgress,
-                                            bookID: id,
-                                            publication: publication)
+                                                   annotationType: .readingProgress,
+                                                   bookID: id,
+                                                   publication: publication)
     completion(bookmark)
   }
   
-  static func postReadingPosition(forBook bookID: String, selectorValue: String) {
+  func postReadingPosition(forBook bookID: String, selectorValue: String) {
     guard !failRequest else {
       return
     }
@@ -67,11 +67,11 @@ class NYPLAnnotationsMock: NYPLAnnotationSyncing {
   
   // Bookmark
   
-  static func getServerBookmarks<T>(of type: T.Type,
-                                    forBook bookID: String?,
-                                    publication: Publication?,
-                                    atURL annotationURL: URL?,
-                                    completion: @escaping ([T]?) -> ()) where T : NYPLBookmark {
+  func getServerBookmarks<T>(of type: T.Type,
+                             forBook bookID: String?,
+                             publication: Publication?,
+                             atURL annotationURL: URL?,
+                             completion: @escaping ([T]?) -> ()) where T : NYPLBookmark {
     guard !failRequest, let id = bookID else {
       completion(nil)
       return
@@ -79,7 +79,7 @@ class NYPLAnnotationsMock: NYPLAnnotationSyncing {
     completion(serverBookmarks[id] as? [T])
   }
   
-  static func deleteBookmarks(_ bookmarks: [NYPLBookmark]) {
+  func deleteBookmarks(_ bookmarks: [NYPLBookmark]) {
     guard !failRequest else {
       return
     }
@@ -90,8 +90,8 @@ class NYPLAnnotationsMock: NYPLAnnotationSyncing {
     }
   }
 
-  static func deleteBookmark(annotationId: String,
-                             completionHandler: @escaping (_ success: Bool) -> ()) {
+  func deleteBookmark(annotationId: String,
+                      completionHandler: @escaping (_ success: Bool) -> ()) {
     let stringComponents = annotationId.components(separatedBy: "_")
     guard !failRequest,
           let bookID = stringComponents.first,
@@ -103,9 +103,9 @@ class NYPLAnnotationsMock: NYPLAnnotationSyncing {
     completionHandler(true)
   }
 
-  static func uploadLocalBookmarks<T>(_ bookmarks: [T],
-                                      forBook bookID: String,
-                                      completion: @escaping ([T], [T]) -> ()) where T : NYPLBookmark {
+  func uploadLocalBookmarks<T>(_ bookmarks: [T],
+                               forBook bookID: String,
+                               completion: @escaping ([T], [T]) -> ()) where T : NYPLBookmark {
     guard !failRequest else {
       completion([], bookmarks)
       return
@@ -126,7 +126,9 @@ class NYPLAnnotationsMock: NYPLAnnotationSyncing {
     completion(bookmarksUpdated, bookmarksFailedToUpdate)
   }
   
-  static func postBookmark(_ bookmark: NYPLBookmark, forBookID bookID: String, completion: @escaping (String?) -> ()) {
+  func postBookmark(_ bookmark: NYPLBookmark,
+                    forBookID bookID: String,
+                    completion: @escaping (String?) -> ()) {
     guard !failRequest else {
       completion(nil)
       return
@@ -149,7 +151,7 @@ class NYPLAnnotationsMock: NYPLAnnotationSyncing {
   
   // Permission
   
-  static func syncIsPossibleAndPermitted() -> Bool {
+  func syncIsPossibleAndPermitted() -> Bool {
     return true
   }
   
@@ -157,7 +159,7 @@ class NYPLAnnotationsMock: NYPLAnnotationSyncing {
   
   /// Returns an unique string in the format of "[bookID]_number"
   /// eg. BookID123_37
-  static func generateAnnotationID(_ bookID: String) -> String {
+  func generateAnnotationID(_ bookID: String) -> String {
     annotationCounter += 1
     return "\(bookID)_\(annotationCounter)"
   }

--- a/SimplifiedTests/NYPLAudiobookBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLAudiobookBookmarksBusinessLogicTests.swift
@@ -14,7 +14,7 @@ class NYPLAudiobookBookmarksBusinessLogicTests: XCTestCase {
   var bookmarkBusinessLogic: NYPLAudiobookBookmarksBusinessLogic!
   var bookRegistryMock: NYPLBookRegistryMock!
   var libraryAccountMock: NYPLLibraryAccountMock!
-  var annotationsMock: NYPLAnnotationsMock.Type!
+  var annotationsMock: NYPLAnnotationsMock!
   var bookmarkCounter: Int = 0
   let bookIdentifier = "fakeAudiobook"
   let deviceID = "fakeDeviceID"
@@ -57,7 +57,7 @@ class NYPLAudiobookBookmarksBusinessLogicTests: XCTestCase {
     bookRegistryMock.addBook(book: fakeBook, state: .DownloadSuccessful)
     libraryAccountMock = NYPLLibraryAccountMock()
     libraryAccountMock.currentAccount?.details?.syncPermissionGranted = true
-    annotationsMock = NYPLAnnotationsMock.self
+    annotationsMock = NYPLAnnotationsMock()
     bookmarkBusinessLogic = NYPLAudiobookBookmarksBusinessLogic(
       book: fakeBook,
       drmDeviceID: deviceID,

--- a/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
+++ b/SimplifiedTests/NYPLReaderBookmarksBusinessLogicTests.swift
@@ -14,13 +14,13 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
   var bookmarkBusinessLogic: NYPLReaderBookmarksBusinessLogic!
   var bookRegistryMock: NYPLBookRegistryMock!
   var libraryAccountMock: NYPLLibraryAccountMock!
-  var annotationsMock: NYPLAnnotationsMock.Type!
+  var annotationsMock: NYPLAnnotationsMock!
   var bookmarkCounter: Int = 0
   let bookIdentifier = "fakeEpub"
 
   override func setUpWithError() throws {
     try super.setUpWithError()
-    
+
     let emptyUrl = URL.init(fileURLWithPath: "")
     let fakeAcquisition = NYPLOPDSAcquisition.init(
       relation: .generic,
@@ -56,7 +56,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
     bookRegistryMock.addBook(book: fakeBook, state: .DownloadSuccessful)
     libraryAccountMock = NYPLLibraryAccountMock()
     libraryAccountMock.currentAccount?.details?.syncPermissionGranted = true
-    annotationsMock = NYPLAnnotationsMock.self
+    annotationsMock = NYPLAnnotationsMock()
     let manifest = Manifest(metadata: Metadata(title: "fakeMetadata"))
     let pub = Publication(manifest: manifest)
     bookmarkBusinessLogic = NYPLReaderBookmarksBusinessLogic(
@@ -65,7 +65,7 @@ class NYPLReaderBookmarksBusinessLogicTests: XCTestCase {
       drmDeviceID: "fakeDeviceID",
       bookRegistryProvider: bookRegistryMock,
       syncPermission: true,
-      bookmarksSynchronizer: annotationsMock)
+      synchronizer: annotationsMock)
     bookmarkCounter = 0
   }
 


### PR DESCRIPTION
**What's this do?**
- Remove NYPLNetworkExecutor dependency from NYPLAnnotations API
- Change the way NYPLAnnotations is used by making it a regular class so it can have its own related state (e.g. the `failFastExecutor` instance var)
- Split NYPLAnnotationSyncing protocol by making it more granular. This way downstream classes can refer to what they actually need. For example, NYPLLastReadPositionPoster only needs the API to update the last read position. NYPLSignInBusinessLogic only needs the api to check and update the sync toggle.

**Why are we doing this? (w/ JIRA link if applicable)**
PJR-87

**How should this be tested? / Do these changes have associated tests?**
regression should cover this

**Dependencies for merging? Releasing to production?**
no breaking changes

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
no

**Has the application documentation been updated for these changes?**
yes

**Did someone actually run this code to verify it works?**
@ettore 