### PR TITLE
iOS-584 Disable ipa upload to firebase

### DIFF
--- a/scripts/firebase-upload.sh
+++ b/scripts/firebase-upload.sh
@@ -32,12 +32,14 @@ else
   fatal "Unable to upload to firebase: missing ad-hoc export!"
 fi
 
+# Disabling the IPA upload to firebase because we encountered authentication error,
+# possibly due to `token` authentication is deprecated.
 # upload app binary
-echo "Using ipa at $IPA_PATH"
-firebase appdistribution:distribute \
-  --token "${FIREBASE_TOKEN}" \
-  --app "${FIREBASE_APP_ID}" \
-  "${IPA_PATH}"
+#echo "Using ipa at $IPA_PATH"
+#firebase appdistribution:distribute \
+#  --token "${FIREBASE_TOKEN}" \
+#  --app "${FIREBASE_APP_ID}" \
+#  "${IPA_PATH}"
 
 # upload symbols
 ./scripts/firebase-upload-symbols.sh "$APPNAME_PARAM" "$DSYMS_PATH"


### PR DESCRIPTION
**What's this do?**
Disable ipa upload to firebase due to error

**Why are we doing this? (w/ JIRA link if applicable)**
Firebase authentication is deprecated and we'll be using TestFlight instead

**How should this be tested? / Do these changes have associated tests?**
N/A

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
N/A

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
Will be tested on CI
